### PR TITLE
Stabilize Claude review runtime and output length

### DIFF
--- a/.github/workflows/maint-76-claude-code-review.yml
+++ b/.github/workflows/maint-76-claude-code-review.yml
@@ -87,10 +87,13 @@ jobs:
       - name: Run Claude Code Review
         id: claude
         continue-on-error: true
-        uses: anthropics/claude-code-action@v1
+        # Pin to a known-good revision to avoid runtime/output drift from moving tags.
+        uses: anthropics/claude-code-action@220272d38887a1caed373da96a9ffdb0919c26cc
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: '*'
+          claude_args: |
+            --max-turns 8
           plugin_marketplaces: https://github.com/anthropics/claude-code.git
           plugins: code-review@claude-code-plugins
           prompt: >-


### PR DESCRIPTION
## Summary
- pin `anthropics/claude-code-action` to commit `220272d38887a1caed373da96a9ffdb0919c26cc` (pre-drift `@v1` target)
- add `claude_args: --max-turns 8` to cap long-running review sessions
- keep existing code-review plugin wiring unchanged

## Why
`@v1` moved during March 2, 2026 and introduced runtime drift across runs. Pinning removes moving-target behavior, and max-turns keeps runtime/output closer to prior check lengths.

## Validation
- workflow YAML updated and committed
- no behavior changes outside `.github/workflows/maint-76-claude-code-review.yml`
