### PR TITLE
Issue #25: add extraction fallback chain and golden regression gate

### DIFF
--- a/.github/workflows/extraction-golden-regression.yml
+++ b/.github/workflows/extraction-golden-regression.yml
@@ -1,0 +1,65 @@
+name: Extraction Golden Regression
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  extraction-golden-regression:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Run extraction golden corpus replay
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/golden_extract
+          PYTHONPATH=src:. python tools/replay/runner.py \
+            --corpus tests/golden/extraction_fallback_corpus.json \
+            --parser tools.golden_extract.fallback_extract_parser:parse \
+            --snapshot-out artifacts/golden_extract/current_snapshot.json
+
+      - name: Build extraction replay diff
+        run: |
+          set -euo pipefail
+          set +e
+          PYTHONPATH=src:. python tools/replay/diff_runner.py \
+            --baseline tests/golden/extraction_fallback_baseline.json \
+            --current artifacts/golden_extract/current_snapshot.json \
+            --report-out artifacts/golden_extract/diff_report.json
+          diff_exit=$?
+          set -e
+          if [ "$diff_exit" -ne 0 ] && [ "$diff_exit" -ne 2 ]; then
+            exit "$diff_exit"
+          fi
+
+      - name: Gate extraction replay drift
+        run: |
+          set -euo pipefail
+          PYTHONPATH=src:. python tools/ci_quality/replay_gate.py \
+            --diff artifacts/golden_extract/diff_report.json \
+            --max-unexpected 0 \
+            --report-out artifacts/golden_extract/replay_gate_report.json
+
+      - name: Upload extraction regression artifacts
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: extraction-golden-regression
+          path: |
+            artifacts/golden_extract/current_snapshot.json
+            artifacts/golden_extract/diff_report.json
+            artifacts/golden_extract/replay_gate_report.json
+          if-no-files-found: warn

--- a/docs/analytics/EXTRACTION_FALLBACK_CHAIN.md
+++ b/docs/analytics/EXTRACTION_FALLBACK_CHAIN.md
@@ -1,0 +1,46 @@
+# Extraction Fallback Chain and Golden Regression Harness
+
+Issue: #25
+
+## Fallback Order
+
+Configured in `src/pension_data/extract/orchestration/fallback.py`:
+
+- funded: `table_primary -> text_fallback -> full_fallback`
+- actuarial: `table_primary -> text_fallback -> full_fallback`
+- investment: `table_primary -> text_fallback -> full_fallback`
+
+## Retry + Escalation
+
+`run_fallback_chain(...)` executes parser stages in order and records structured `ParserAttempt` rows.
+
+When all stages fail required completeness checks, it emits:
+
+- `EscalationEvent`
+  - `reason = parser_fallback_exhaustion`
+  - exhausted stage count
+  - attempt-by-attempt failure details
+
+## Golden Corpus Harness
+
+The funded fallback parser used for regression snapshots lives at:
+
+- `tools/golden_extract/fallback_extract_parser.py`
+
+Golden corpus and baseline:
+
+- `tests/golden/extraction_fallback_corpus.json`
+- `tests/golden/extraction_fallback_baseline.json`
+
+## Regression Diff and CI Gate
+
+Workflow:
+
+- `.github/workflows/extraction-golden-regression.yml`
+
+Pipeline steps:
+
+1. Replay corpus into current snapshot
+2. Diff baseline vs current (field-level + confidence/evidence drift)
+3. Gate on unexpected drift (`max_unexpected = 0`)
+4. Upload snapshot + diff + gate reports as artifacts

--- a/src/pension_data/extract/orchestration/__init__.py
+++ b/src/pension_data/extract/orchestration/__init__.py
@@ -1,0 +1,17 @@
+"""Fallback orchestration helpers for extraction reliability."""
+
+from pension_data.extract.orchestration.fallback import (
+    EscalationEvent,
+    FallbackOutcome,
+    ParserAttempt,
+    ParserStage,
+    run_fallback_chain,
+)
+
+__all__ = [
+    "EscalationEvent",
+    "FallbackOutcome",
+    "ParserAttempt",
+    "ParserStage",
+    "run_fallback_chain",
+]

--- a/src/pension_data/extract/orchestration/fallback.py
+++ b/src/pension_data/extract/orchestration/fallback.py
@@ -1,0 +1,112 @@
+"""Retry/fallback orchestration for extraction parser chains."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+TResult = TypeVar("TResult")
+
+PARSER_FALLBACK_ORDER_BY_DOMAIN: dict[str, tuple[str, ...]] = {
+    "funded": ("table_primary", "text_fallback", "full_fallback"),
+    "actuarial": ("table_primary", "text_fallback", "full_fallback"),
+    "investment": ("table_primary", "text_fallback", "full_fallback"),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ParserAttempt:
+    """Structured record for one parser stage attempt."""
+
+    stage_name: str
+    parser_name: str
+    succeeded: bool
+    failure_reason: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class EscalationEvent:
+    """Escalation payload emitted when all fallback stages fail."""
+
+    domain: str
+    reason: str
+    exhausted_stage_count: int
+    attempts: tuple[ParserAttempt, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ParserStage(Generic[TResult]):
+    """One parser stage in a domain fallback chain."""
+
+    stage_name: str
+    parser_name: str
+    parse: Callable[[], TResult]
+
+
+@dataclass(frozen=True, slots=True)
+class FallbackOutcome(Generic[TResult]):
+    """Output for fallback orchestration."""
+
+    result: TResult | None
+    attempts: tuple[ParserAttempt, ...]
+    escalation: EscalationEvent | None
+
+
+def run_fallback_chain(
+    *,
+    domain: str,
+    stages: Sequence[ParserStage[TResult]],
+    is_complete: Callable[[TResult], bool],
+) -> FallbackOutcome[TResult]:
+    """Execute parser stages in order and escalate when chain exhausts."""
+    attempts: list[ParserAttempt] = []
+    for stage in stages:
+        try:
+            parsed = stage.parse()
+        except Exception as exc:  # noqa: BLE001 - needed for structured failure path
+            attempts.append(
+                ParserAttempt(
+                    stage_name=stage.stage_name,
+                    parser_name=stage.parser_name,
+                    succeeded=False,
+                    failure_reason=f"exception:{type(exc).__name__}:{exc}",
+                )
+            )
+            continue
+
+        if not is_complete(parsed):
+            attempts.append(
+                ParserAttempt(
+                    stage_name=stage.stage_name,
+                    parser_name=stage.parser_name,
+                    succeeded=False,
+                    failure_reason="incomplete-required-fields",
+                )
+            )
+            continue
+
+        attempts.append(
+            ParserAttempt(
+                stage_name=stage.stage_name,
+                parser_name=stage.parser_name,
+                succeeded=True,
+            )
+        )
+        return FallbackOutcome(
+            result=parsed,
+            attempts=tuple(attempts),
+            escalation=None,
+        )
+
+    escalation = EscalationEvent(
+        domain=domain,
+        reason="parser_fallback_exhaustion",
+        exhausted_stage_count=len(stages),
+        attempts=tuple(attempts),
+    )
+    return FallbackOutcome(
+        result=None,
+        attempts=tuple(attempts),
+        escalation=escalation,
+    )

--- a/tests/extract/orchestration/test_fallback_chain.py
+++ b/tests/extract/orchestration/test_fallback_chain.py
@@ -1,0 +1,67 @@
+"""Tests for extraction fallback orchestration and escalation control flow."""
+
+from __future__ import annotations
+
+from pension_data.extract.orchestration.fallback import (
+    PARSER_FALLBACK_ORDER_BY_DOMAIN,
+    ParserStage,
+    run_fallback_chain,
+)
+
+
+def test_domain_fallback_order_is_defined_for_all_extraction_domains() -> None:
+    assert set(PARSER_FALLBACK_ORDER_BY_DOMAIN) == {"funded", "actuarial", "investment"}
+    assert all(
+        PARSER_FALLBACK_ORDER_BY_DOMAIN[domain] for domain in PARSER_FALLBACK_ORDER_BY_DOMAIN
+    )
+
+
+def test_fallback_chain_uses_retry_order_until_result_is_complete() -> None:
+    attempts: list[str] = []
+
+    outcome = run_fallback_chain(
+        domain="funded",
+        stages=[
+            ParserStage(
+                stage_name="primary",
+                parser_name="parser-primary",
+                parse=lambda: attempts.append("primary") or {"complete": False},
+            ),
+            ParserStage(
+                stage_name="fallback",
+                parser_name="parser-fallback",
+                parse=lambda: attempts.append("fallback") or {"complete": True},
+            ),
+        ],
+        is_complete=lambda result: bool(result["complete"]),
+    )
+
+    assert attempts == ["primary", "fallback"]
+    assert outcome.result == {"complete": True}
+    assert outcome.escalation is None
+    assert [attempt.succeeded for attempt in outcome.attempts] == [False, True]
+
+
+def test_fallback_chain_emits_structured_escalation_when_exhausted() -> None:
+    outcome = run_fallback_chain(
+        domain="investment",
+        stages=[
+            ParserStage(
+                stage_name="primary",
+                parser_name="parser-primary",
+                parse=lambda: {"complete": False},
+            ),
+            ParserStage(
+                stage_name="fallback",
+                parser_name="parser-fallback",
+                parse=lambda: (_ for _ in ()).throw(RuntimeError("failed parser stage")),
+            ),
+        ],
+        is_complete=lambda result: bool(result["complete"]),
+    )
+
+    assert outcome.result is None
+    assert outcome.escalation is not None
+    assert outcome.escalation.reason == "parser_fallback_exhaustion"
+    assert outcome.escalation.exhausted_stage_count == 2
+    assert len(outcome.escalation.attempts) == 2

--- a/tests/golden/extraction_fallback_baseline.json
+++ b/tests/golden/extraction_fallback_baseline.json
@@ -1,0 +1,109 @@
+{
+  "artifact_type": "pension_replay_baseline",
+  "baseline_version": "v1",
+  "documents": [
+    {
+      "document_id": "funded-fallback-exhausted",
+      "fields": {
+        "__escalation__": {
+          "confidence": 0.0,
+          "evidence": "stages:3",
+          "value": "parser_fallback_exhaustion"
+        }
+      }
+    },
+    {
+      "document_id": "funded-table-primary",
+      "fields": {
+        "__fallback_stage__": {
+          "confidence": 1.0,
+          "evidence": "funded_table_only",
+          "value": "table_primary"
+        },
+        "aal_usd": {
+          "confidence": 0.93,
+          "evidence": "p.45",
+          "value": 600000000.0
+        },
+        "ava_usd": {
+          "confidence": 0.93,
+          "evidence": "p.45",
+          "value": 480000000.0
+        },
+        "discount_rate": {
+          "confidence": 0.93,
+          "evidence": "p.46",
+          "value": 0.0675
+        },
+        "employee_contribution_rate": {
+          "confidence": 0.93,
+          "evidence": "p.47",
+          "value": 0.075
+        },
+        "employer_contribution_rate": {
+          "confidence": 0.93,
+          "evidence": "p.47",
+          "value": 0.124
+        },
+        "funded_ratio": {
+          "confidence": 0.93,
+          "evidence": "p.45",
+          "value": 0.8
+        },
+        "participant_count": {
+          "confidence": 0.93,
+          "evidence": "p.48",
+          "value": 320000.0
+        }
+      }
+    },
+    {
+      "document_id": "funded-text-fallback",
+      "fields": {
+        "__fallback_stage__": {
+          "confidence": 1.0,
+          "evidence": "funded_text_only",
+          "value": "text_fallback"
+        },
+        "aal_usd": {
+          "confidence": 0.84,
+          "evidence": "text:2",
+          "value": 410500000.0
+        },
+        "ava_usd": {
+          "confidence": 0.84,
+          "evidence": "text:3",
+          "value": 333700000.0
+        },
+        "discount_rate": {
+          "confidence": 0.84,
+          "evidence": "text:4",
+          "value": 0.0675
+        },
+        "employee_contribution_rate": {
+          "confidence": 0.84,
+          "evidence": "text:6",
+          "value": 0.071
+        },
+        "employer_contribution_rate": {
+          "confidence": 0.84,
+          "evidence": "text:5",
+          "value": 0.111
+        },
+        "funded_ratio": {
+          "confidence": 0.84,
+          "evidence": "text:1",
+          "value": 0.812
+        },
+        "participant_count": {
+          "confidence": 0.84,
+          "evidence": "text:7",
+          "value": 112000.0
+        }
+      }
+    }
+  ],
+  "generated_at": "2026-03-03T00:00:00+00:00",
+  "parser_id": "tools.golden_extract.fallback_extract_parser:parse",
+  "schema_version": 1
+}

--- a/tests/golden/extraction_fallback_corpus.json
+++ b/tests/golden/extraction_fallback_corpus.json
@@ -1,0 +1,16 @@
+{
+  "documents": [
+    {
+      "document_id": "funded-table-primary",
+      "content": "{\"domain\": \"funded\", \"plan_id\": \"CA-PERS\", \"plan_period\": \"FY2025\", \"raw\": {\"source_document_id\": \"doc:ca:2025:funded\", \"source_url\": \"https://example.gov/ca-2025-funded.pdf\", \"effective_date\": \"2025-06-30\", \"ingestion_date\": \"2026-01-15\", \"default_money_unit_scale\": \"million_usd\", \"text_blocks\": [], \"table_rows\": [{\"label\": \"Funded Ratio\", \"value\": \"80.0%\", \"evidence_ref\": \"p.45\"}, {\"label\": \"AAL\", \"value\": \"$600 million\", \"evidence_ref\": \"p.45\"}, {\"label\": \"AVA\", \"value\": \"$480 million\", \"evidence_ref\": \"p.45\"}, {\"label\": \"Discount Rate\", \"value\": \"6.75%\", \"evidence_ref\": \"p.46\"}, {\"label\": \"Employer Contribution Rate\", \"value\": \"12.4%\", \"evidence_ref\": \"p.47\"}, {\"label\": \"Employee Contribution Rate\", \"value\": \"7.5%\", \"evidence_ref\": \"p.47\"}, {\"label\": \"Participant Count\", \"value\": \"320000\", \"evidence_ref\": \"p.48\"}]}}"
+    },
+    {
+      "document_id": "funded-text-fallback",
+      "content": "{\"domain\": \"funded\", \"plan_id\": \"TX-ERS\", \"plan_period\": \"FY2025\", \"raw\": {\"source_document_id\": \"doc:tx:2025:funded\", \"source_url\": \"https://example.gov/tx-2025-funded.pdf\", \"effective_date\": \"2025-08-31\", \"ingestion_date\": \"2026-02-02\", \"default_money_unit_scale\": \"million_usd\", \"text_blocks\": [\"Funded ratio 81.2%.\", \"Actuarial accrued liability was $410.5 million.\", \"Actuarial value of assets was $333.7 million.\", \"Discount rate remained 6.75%.\", \"Employer contribution rate was 11.1%.\", \"Employee contribution rate was 7.1%.\", \"Participant count was 112000.\"], \"table_rows\": []}}"
+    },
+    {
+      "document_id": "funded-fallback-exhausted",
+      "content": "{\"domain\": \"funded\", \"plan_id\": \"WA-SRS\", \"plan_period\": \"FY2025\", \"raw\": {\"source_document_id\": \"doc:wa:2025:funded\", \"source_url\": \"https://example.gov/wa-2025-funded.pdf\", \"effective_date\": \"2025-06-30\", \"ingestion_date\": \"2026-01-15\", \"default_money_unit_scale\": \"million_usd\", \"text_blocks\": [\"No funded metrics disclosed in this section.\"], \"table_rows\": []}}"
+    }
+  ]
+}

--- a/tests/golden/test_extraction_regression_harness.py
+++ b/tests/golden/test_extraction_regression_harness.py
@@ -1,0 +1,28 @@
+"""Golden-corpus regression harness tests for extraction fallback parser."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from tools.replay.harness import build_snapshot, diff_snapshots, load_snapshot, run_replay
+from tools.replay.runner import load_corpus, load_parser
+
+
+def test_golden_corpus_snapshot_matches_baseline_without_unexpected_drift() -> None:
+    root = Path(__file__).resolve().parents[2]
+    corpus_path = root / "tests" / "golden" / "extraction_fallback_corpus.json"
+    baseline_path = root / "tests" / "golden" / "extraction_fallback_baseline.json"
+
+    corpus = load_corpus(corpus_path)
+    parser = load_parser("tools.golden_extract.fallback_extract_parser:parse")
+    replay_results = run_replay(corpus, parser)
+    snapshot = build_snapshot(
+        replay_results,
+        parser_id="tools.golden_extract.fallback_extract_parser:parse",
+        generated_at=datetime(2026, 3, 3, 0, 0, tzinfo=UTC),
+    )
+    baseline = load_snapshot(baseline_path)
+    report = diff_snapshots(baseline=baseline, current=snapshot)
+
+    assert report["unexpected_changes"] == 0

--- a/tests/golden/test_fallback_extract_parser.py
+++ b/tests/golden/test_fallback_extract_parser.py
@@ -1,0 +1,94 @@
+"""Tests for funded extraction fallback parser used by golden corpus replay."""
+
+from __future__ import annotations
+
+import json
+
+from tools.golden_extract.fallback_extract_parser import parse
+from tools.replay.harness import CorpusDocument
+
+
+def _doc(*, document_id: str, payload: dict[str, object]) -> CorpusDocument:
+    return CorpusDocument(document_id=document_id, content=json.dumps(payload))
+
+
+def test_parser_uses_table_primary_when_required_metrics_exist_in_table() -> None:
+    payload = {
+        "domain": "funded",
+        "plan_id": "CA-PERS",
+        "plan_period": "FY2025",
+        "raw": {
+            "source_document_id": "doc:ca:2025:funded",
+            "source_url": "https://example.gov/ca-2025-funded.pdf",
+            "effective_date": "2025-06-30",
+            "ingestion_date": "2026-01-15",
+            "default_money_unit_scale": "million_usd",
+            "text_blocks": [],
+            "table_rows": [
+                {"label": "Funded Ratio", "value": "80.0%", "evidence_ref": "p.45"},
+                {"label": "AAL", "value": "$600 million", "evidence_ref": "p.45"},
+                {"label": "AVA", "value": "$480 million", "evidence_ref": "p.45"},
+                {"label": "Discount Rate", "value": "6.75%", "evidence_ref": "p.46"},
+                {"label": "Employer Contribution Rate", "value": "12.4%", "evidence_ref": "p.47"},
+                {"label": "Employee Contribution Rate", "value": "7.5%", "evidence_ref": "p.47"},
+                {"label": "Participant Count", "value": "320000", "evidence_ref": "p.48"},
+            ],
+        },
+    }
+
+    fields = parse(_doc(document_id="doc-table", payload=payload))
+    assert "__escalation__" not in fields
+    assert fields["__fallback_stage__"].value == "table_primary"
+    assert fields["funded_ratio"].evidence == "p.45"
+
+
+def test_parser_falls_back_to_text_stage_when_table_stage_is_incomplete() -> None:
+    payload = {
+        "domain": "funded",
+        "plan_id": "TX-ERS",
+        "plan_period": "FY2025",
+        "raw": {
+            "source_document_id": "doc:tx:2025:funded",
+            "source_url": "https://example.gov/tx-2025-funded.pdf",
+            "effective_date": "2025-08-31",
+            "ingestion_date": "2026-02-02",
+            "default_money_unit_scale": "million_usd",
+            "text_blocks": [
+                "Funded ratio 81.2%.",
+                "Actuarial accrued liability was $410.5 million.",
+                "Actuarial value of assets was $333.7 million.",
+                "Discount rate remained 6.75%.",
+                "Employer contribution rate was 11.1%.",
+                "Employee contribution rate was 7.1%.",
+                "Participant count was 112000.",
+            ],
+            "table_rows": [],
+        },
+    }
+
+    fields = parse(_doc(document_id="doc-text-fallback", payload=payload))
+    assert "__escalation__" not in fields
+    assert fields["__fallback_stage__"].value == "text_fallback"
+    assert fields["funded_ratio"].evidence == "text:1"
+
+
+def test_parser_emits_escalation_when_all_stages_exhausted() -> None:
+    payload = {
+        "domain": "funded",
+        "plan_id": "WA-SRS",
+        "plan_period": "FY2025",
+        "raw": {
+            "source_document_id": "doc:wa:2025:funded",
+            "source_url": "https://example.gov/wa-2025-funded.pdf",
+            "effective_date": "2025-06-30",
+            "ingestion_date": "2026-01-15",
+            "default_money_unit_scale": "million_usd",
+            "text_blocks": ["No funded metrics disclosed in this section."],
+            "table_rows": [],
+        },
+    }
+
+    fields = parse(_doc(document_id="doc-escalate", payload=payload))
+    escalation = fields["__escalation__"]
+    assert escalation.value == "parser_fallback_exhaustion"
+    assert escalation.evidence == "stages:3"

--- a/tools/golden_extract/__init__.py
+++ b/tools/golden_extract/__init__.py
@@ -1,0 +1,1 @@
+"""Extraction golden-corpus parser entrypoints."""

--- a/tools/golden_extract/fallback_extract_parser.py
+++ b/tools/golden_extract/fallback_extract_parser.py
@@ -1,0 +1,180 @@
+"""Golden-corpus parser callable that exercises extraction fallback orchestration."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import cast
+
+from pension_data.db.models.funded_actuarial import FUNDED_ACTUARIAL_REQUIRED_METRICS
+from pension_data.extract.actuarial.metrics import (
+    RawFundedActuarialInput,
+    extract_funded_and_actuarial_metrics,
+)
+from pension_data.extract.orchestration.fallback import (
+    PARSER_FALLBACK_ORDER_BY_DOMAIN,
+    ParserStage,
+    run_fallback_chain,
+)
+from pension_data.normalize.financial_units import UnitScale
+from tools.replay.harness import CorpusDocument, FieldExtraction
+
+
+@dataclass(frozen=True, slots=True)
+class _FundedStageResult:
+    fields: dict[str, FieldExtraction]
+    missing_metrics: tuple[str, ...]
+
+
+def _parse_payload(document: CorpusDocument) -> dict[str, object]:
+    payload = json.loads(document.content)
+    if not isinstance(payload, dict):
+        raise ValueError("document.content must decode to a JSON object")
+    return payload
+
+
+def _require_string(payload: Mapping[str, object], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"payload missing required string field '{key}'")
+    return value
+
+
+def _as_raw_funded(payload: Mapping[str, object]) -> RawFundedActuarialInput:
+    raw = payload.get("raw")
+    if not isinstance(raw, Mapping):
+        raise ValueError("payload.raw must be an object")
+    text_blocks = raw.get("text_blocks")
+    table_rows = raw.get("table_rows")
+    if not isinstance(text_blocks, list) or not all(isinstance(item, str) for item in text_blocks):
+        raise ValueError("payload.raw.text_blocks must be a list[str]")
+    if not isinstance(table_rows, list) or not all(
+        isinstance(item, Mapping) for item in table_rows
+    ):
+        raise ValueError("payload.raw.table_rows must be a list[object]")
+    return RawFundedActuarialInput(
+        source_document_id=_require_string(raw, "source_document_id"),
+        source_url=_require_string(raw, "source_url"),
+        effective_date=_require_string(raw, "effective_date"),
+        ingestion_date=_require_string(raw, "ingestion_date"),
+        default_money_unit_scale=cast(UnitScale, _require_string(raw, "default_money_unit_scale")),
+        text_blocks=tuple(text_blocks),
+        table_rows=tuple(dict(item) for item in table_rows),
+    )
+
+
+def _run_funded_stage(
+    *,
+    plan_id: str,
+    plan_period: str,
+    raw: RawFundedActuarialInput,
+    use_text_blocks: bool,
+    use_table_rows: bool,
+) -> _FundedStageResult:
+    stage_raw = RawFundedActuarialInput(
+        source_document_id=raw.source_document_id,
+        source_url=raw.source_url,
+        effective_date=raw.effective_date,
+        ingestion_date=raw.ingestion_date,
+        default_money_unit_scale=raw.default_money_unit_scale,
+        text_blocks=raw.text_blocks if use_text_blocks else (),
+        table_rows=raw.table_rows if use_table_rows else (),
+    )
+    facts, _ = extract_funded_and_actuarial_metrics(
+        plan_id=plan_id,
+        plan_period=plan_period,
+        raw=stage_raw,
+    )
+    fields = {
+        str(fact.metric_name): FieldExtraction(
+            value=fact.normalized_value,
+            confidence=fact.confidence,
+            evidence=fact.evidence_refs[0] if fact.evidence_refs else None,
+        )
+        for fact in facts
+    }
+    missing_metrics = tuple(
+        metric_name
+        for metric_name in FUNDED_ACTUARIAL_REQUIRED_METRICS
+        if metric_name not in fields
+    )
+    return _FundedStageResult(
+        fields=fields,
+        missing_metrics=missing_metrics,
+    )
+
+
+def parse(document: CorpusDocument) -> Mapping[str, FieldExtraction]:
+    """Replay parser callable used by golden-corpus extraction checks."""
+    payload = _parse_payload(document)
+    domain = _require_string(payload, "domain")
+    if domain != "funded":
+        raise ValueError(f"unsupported domain '{domain}' in golden corpus")
+
+    plan_id = _require_string(payload, "plan_id")
+    plan_period = _require_string(payload, "plan_period")
+    raw = _as_raw_funded(payload)
+    order = PARSER_FALLBACK_ORDER_BY_DOMAIN["funded"]
+    stage_builders: dict[str, ParserStage[_FundedStageResult]] = {
+        "table_primary": ParserStage(
+            stage_name="table_primary",
+            parser_name="funded_table_only",
+            parse=lambda: _run_funded_stage(
+                plan_id=plan_id,
+                plan_period=plan_period,
+                raw=raw,
+                use_text_blocks=False,
+                use_table_rows=True,
+            ),
+        ),
+        "text_fallback": ParserStage(
+            stage_name="text_fallback",
+            parser_name="funded_text_only",
+            parse=lambda: _run_funded_stage(
+                plan_id=plan_id,
+                plan_period=plan_period,
+                raw=raw,
+                use_text_blocks=True,
+                use_table_rows=False,
+            ),
+        ),
+        "full_fallback": ParserStage(
+            stage_name="full_fallback",
+            parser_name="funded_full",
+            parse=lambda: _run_funded_stage(
+                plan_id=plan_id,
+                plan_period=plan_period,
+                raw=raw,
+                use_text_blocks=True,
+                use_table_rows=True,
+            ),
+        ),
+    }
+
+    outcome = run_fallback_chain(
+        domain=domain,
+        stages=[stage_builders[name] for name in order],
+        is_complete=lambda result: not result.missing_metrics,
+    )
+    if outcome.result is None or outcome.escalation is not None:
+        return {
+            "__escalation__": FieldExtraction(
+                value=outcome.escalation.reason if outcome.escalation is not None else "unknown",
+                confidence=0.0,
+                evidence=f"stages:{len(outcome.attempts)}",
+            )
+        }
+
+    selected_stage = next(
+        attempt.stage_name for attempt in reversed(outcome.attempts) if attempt.succeeded
+    )
+    with_stage = dict(outcome.result.fields)
+    with_stage["__fallback_stage__"] = FieldExtraction(
+        value=selected_stage,
+        confidence=1.0,
+        evidence=next(
+            attempt.parser_name for attempt in reversed(outcome.attempts) if attempt.succeeded
+        ),
+    )
+    return with_stage


### PR DESCRIPTION
Closes #25

## Summary
- add a domain fallback-chain orchestrator with configured stage order, structured attempt records, and escalation events when all stages are exhausted
- add a funded-domain golden parser callable that exercises table-primary -> text-fallback -> full-fallback control flow and emits structured escalation markers
- add a deterministic golden corpus + baseline snapshot for fallback behavior regression detection
- add extraction regression harness tests plus fallback chain/parser tests
- add a dedicated CI workflow that replays the extraction corpus, diffs against baseline, and fails on unexpected drift with uploaded artifacts
- document the fallback chain, escalation semantics, and golden-regression workflow

## Validation
- black --check src/pension_data/extract/orchestration/fallback.py src/pension_data/extract/orchestration/__init__.py tools/golden_extract/fallback_extract_parser.py tools/golden_extract/__init__.py tests/extract/orchestration/test_fallback_chain.py tests/golden/test_fallback_extract_parser.py tests/golden/test_extraction_regression_harness.py
- ruff check src/pension_data/extract/orchestration/fallback.py src/pension_data/extract/orchestration/__init__.py tools/golden_extract/fallback_extract_parser.py tools/golden_extract/__init__.py tests/extract/orchestration/test_fallback_chain.py tests/golden/test_fallback_extract_parser.py tests/golden/test_extraction_regression_harness.py
- mypy src/pension_data/extract/orchestration/fallback.py tools/golden_extract/fallback_extract_parser.py
- PYTHONPATH=src:. pytest --no-cov tests/extract/orchestration/test_fallback_chain.py tests/golden/test_fallback_extract_parser.py tests/golden/test_extraction_regression_harness.py
- PYTHONPATH=src:. python tools/replay/runner.py --corpus tests/golden/extraction_fallback_corpus.json --parser tools.golden_extract.fallback_extract_parser:parse --snapshot-out artifacts/golden_extract/current_snapshot.json --overwrite --baseline-update-ticket issue-25-local
- PYTHONPATH=src:. python tools/replay/diff_runner.py --baseline tests/golden/extraction_fallback_baseline.json --current artifacts/golden_extract/current_snapshot.json --report-out artifacts/golden_extract/diff_report.json
- PYTHONPATH=src:. python tools/ci_quality/replay_gate.py --diff artifacts/golden_extract/diff_report.json --max-unexpected 0 --report-out artifacts/golden_extract/replay_gate_report.json

<!-- pr-preamble:start -->
> **Source:** Issue #25

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Extraction reliability depends on graceful fallback behavior when primary parsing fails. The system must retry with alternate extractors before escalating to human review, and regressions must be caught against a golden corpus.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#19](https://github.com/stranske/Pension-Data/issues/19)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Define parser fallback order per extraction domain (funded, actuarial, investment)
- [ ] Implement retry/orchestration layer with structured failure reason capture
- [ ] Implement escalation trigger when fallback chain exhausts
- [ ] Build golden-corpus harness with expected output baselines
- [ ] Add diff tooling for extraction regressions (field-level and confidence-level)
- [ ] Add CI gate for golden-corpus regression checks

#### Acceptance criteria
- [ ] Failed primary extraction attempts trigger configured fallback parsers
- [ ] Exhausted fallback paths produce structured escalation events
- [ ] Golden-corpus harness detects extraction regressions deterministically
- [ ] CI fails with actionable diffs when regressions are introduced

**Head SHA:** 0124e7ebaa6b9c5d7415fb4d48feaff0d9a897df
**Latest Runs:** ⏳ queued — Gate
**Required:** gate: ⏳ queued

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| .github/workflows/autofix.yml | ❌ failure | [View run](https://github.com/stranske/Pension-Data/actions/runs/22604455440) |
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Pension-Data/actions/runs/22604461459) |
| Agents PR Meta | ⏭️ skipped | [View run](https://github.com/stranske/Pension-Data/actions/runs/22604461491) |
| CI | ❔ in progress | [View run](https://github.com/stranske/Pension-Data/actions/runs/22604461456) |
| Copilot code review | ❔ in progress | [View run](https://github.com/stranske/Pension-Data/actions/runs/22604464966) |
| Dependabot Auto-merge | ⏭️ skipped | [View run](https://github.com/stranske/Pension-Data/actions/runs/22604461465) |
| Entity Regression Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/22604461408) |
| Extraction Golden Regression | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/22604461423) |
| Foundation Fixture E2E | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/22604461422) |
| Gate | ⏳ queued | [View run](https://github.com/stranske/Pension-Data/actions/runs/22604461476) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/22604461413) |
| Quality Replay Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/22604461402) |
| Quality SLA Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/22604461400) |
<!-- auto-status-summary:end -->