### PR TITLE
Fix missing dep causing 'This isn't working' on PRs

### DIFF
--- a/.github/workflows/agents-81-gate-followups.yml
+++ b/.github/workflows/agents-81-gate-followups.yml
@@ -631,6 +631,7 @@ jobs:
           sparse-checkout: |
             .github/actions/setup-api-client
             .github/scripts/prompt_injection_guard.js
+            .github/scripts/github-rate-limited-wrapper.js
             .github/scripts/github-api-with-retry.js
             .github/scripts/token_load_balancer.js
             .github/scripts/agent_registry.js


### PR DESCRIPTION
## Summary
- `prompt_injection_guard.js` requires `github-rate-limited-wrapper.js` (line 14)
- This file was missing from the sparse-checkout in the Gate Followups workflow
- Every PR showed "This isn't working right now. You can try again later." because the "Prepare autofix context" job failed with `Cannot find module './github-rate-limited-wrapper.js'`

## Fix
Added `github-rate-limited-wrapper.js` to the sparse-checkout list.

## Test plan
- [ ] Verify "Prepare autofix context" passes on this PR
- [ ] Verify the warning disappears from PR pages after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)