### PR TITLE
Fix CI formatting and PostgreSQL migration

### DIFF
--- a/src/pension_data/api/routes/saved_views.py
+++ b/src/pension_data/api/routes/saved_views.py
@@ -36,9 +36,7 @@ def run_saved_view_endpoint(
     api_key_header: str | None,
     key_store: APIKeyStore,
     view_name: str,
-    view_inputs: (
-        list[FundingTrendInput] | list[AllocationPeerInput] | list[HoldingsOverlapInput]
-    ),
+    view_inputs: list[FundingTrendInput] | list[AllocationPeerInput] | list[HoldingsOverlapInput],
     subject_plan_id: str | None = None,
     plan_period: str | None = None,
     event: Mapping[str, Any] | None = None,

--- a/src/pension_data/db/migrations/20260303_101_pg_core_fact_staging.sql
+++ b/src/pension_data/db/migrations/20260303_101_pg_core_fact_staging.sql
@@ -74,6 +74,22 @@ CREATE TABLE IF NOT EXISTS staging_manager_fund_vehicle_relationships (
   source_document_id TEXT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS staging_consultant_engagements (
+  engagement_id TEXT PRIMARY KEY,
+  plan_id TEXT NOT NULL,
+  plan_period TEXT NOT NULL,
+  consultant_name TEXT NOT NULL,
+  role_description TEXT NOT NULL,
+  recommendation_topic TEXT,
+  recommendation_text TEXT,
+  attribution_outcome TEXT,
+  relationship_completeness TEXT NOT NULL,
+  effective_date TIMESTAMPTZ NOT NULL,
+  ingestion_date TIMESTAMPTZ NOT NULL,
+  benchmark_version TEXT NOT NULL,
+  source_document_id TEXT NOT NULL
+);
+
 CREATE OR REPLACE VIEW curated_metric_facts AS
 SELECT
   plan_id,

--- a/tests/db/test_database_strategy.py
+++ b/tests/db/test_database_strategy.py
@@ -139,6 +139,4 @@ def test_extended_migration_creates_all_domain_tables() -> None:
         "entity_review_queue",
         "discovered_inventory",
     }
-    assert expected_tables.issubset(table_names), (
-        f"Missing tables: {expected_tables - table_names}"
-    )
+    assert expected_tables.issubset(table_names), f"Missing tables: {expected_tables - table_names}"

--- a/tests/entities/test_matching_algorithm.py
+++ b/tests/entities/test_matching_algorithm.py
@@ -26,27 +26,21 @@ def _entity(
 class TestExactMatch:
     def test_exact_match_full_confidence(self) -> None:
         entities = [_entity("e1", "BlackRock")]
-        results = generate_alias_match_candidates(
-            source_name="BlackRock", entities=entities
-        )
+        results = generate_alias_match_candidates(source_name="BlackRock", entities=entities)
         assert len(results) == 1
         assert results[0].strategy == "exact"
         assert results[0].confidence == 1.0
 
     def test_exact_match_case_insensitive(self) -> None:
         entities = [_entity("e1", "BlackRock")]
-        results = generate_alias_match_candidates(
-            source_name="blackrock", entities=entities
-        )
+        results = generate_alias_match_candidates(source_name="blackrock", entities=entities)
         assert len(results) == 1
         assert results[0].strategy == "exact"
         assert results[0].confidence == 1.0
 
     def test_exact_match_via_alias(self) -> None:
         entities = [_entity("e1", "BlackRock Inc.", aliases=("BlackRock",))]
-        results = generate_alias_match_candidates(
-            source_name="blackrock", entities=entities
-        )
+        results = generate_alias_match_candidates(source_name="blackrock", entities=entities)
         assert len(results) == 1
         assert results[0].strategy == "exact"
 
@@ -117,9 +111,7 @@ class TestDeduplication:
         entities = [
             _entity("e1", "BlackRock", aliases=("BLK", "BlackRock Fund")),
         ]
-        results = generate_alias_match_candidates(
-            source_name="BlackRock", entities=entities
-        )
+        results = generate_alias_match_candidates(source_name="BlackRock", entities=entities)
         assert len(results) == 1
         # Exact match (1.0) should win over any fuzzy match
         assert results[0].confidence == 1.0
@@ -129,9 +121,7 @@ class TestDeduplication:
             _entity("e1", "BlackRock"),
             _entity("e2", "Blackstone"),
         ]
-        results = generate_alias_match_candidates(
-            source_name="BlackRock", entities=entities
-        )
+        results = generate_alias_match_candidates(source_name="BlackRock", entities=entities)
         stable_ids = {r.stable_id for r in results}
         assert "e1" in stable_ids
 
@@ -156,9 +146,7 @@ class TestSorting:
             _entity("e2", "Same Name"),
             _entity("e1", "Same Name"),
         ]
-        results = generate_alias_match_candidates(
-            source_name="Same Name", entities=entities
-        )
+        results = generate_alias_match_candidates(source_name="Same Name", entities=entities)
         assert len(results) == 2
         # Both are exact matches; should sort by stable_id ascending
         assert results[0].stable_id == "e1"
@@ -171,27 +159,19 @@ class TestSorting:
 class TestEdgeCases:
     def test_empty_source_name_returns_empty(self) -> None:
         entities = [_entity("e1", "BlackRock")]
-        results = generate_alias_match_candidates(
-            source_name="", entities=entities
-        )
+        results = generate_alias_match_candidates(source_name="", entities=entities)
         assert results == []
 
     def test_whitespace_source_name_returns_empty(self) -> None:
         entities = [_entity("e1", "BlackRock")]
-        results = generate_alias_match_candidates(
-            source_name="   ", entities=entities
-        )
+        results = generate_alias_match_candidates(source_name="   ", entities=entities)
         assert results == []
 
     def test_empty_entities_returns_empty(self) -> None:
-        results = generate_alias_match_candidates(
-            source_name="BlackRock", entities=[]
-        )
+        results = generate_alias_match_candidates(source_name="BlackRock", entities=[])
         assert results == []
 
     def test_entity_with_empty_name_skipped(self) -> None:
         entities = [_entity("e1", "")]
-        results = generate_alias_match_candidates(
-            source_name="BlackRock", entities=entities
-        )
+        results = generate_alias_match_candidates(source_name="BlackRock", entities=entities)
         assert results == []

--- a/tests/normalize/test_financial_units.py
+++ b/tests/normalize/test_financial_units.py
@@ -28,23 +28,47 @@ class TestNormalizeMoneyToUsd:
 
 class TestNormalizeFlowSign:
     def test_inflow_is_positive(self) -> None:
-        assert normalize_flow_sign(100.0, direction="inflow", outflows_reported_as_negative=False) == 100.0
+        assert (
+            normalize_flow_sign(100.0, direction="inflow", outflows_reported_as_negative=False)
+            == 100.0
+        )
 
     def test_inflow_negative_input_becomes_positive(self) -> None:
-        assert normalize_flow_sign(-100.0, direction="inflow", outflows_reported_as_negative=False) == 100.0
+        assert (
+            normalize_flow_sign(-100.0, direction="inflow", outflows_reported_as_negative=False)
+            == 100.0
+        )
 
     def test_outflow_is_negative(self) -> None:
-        assert normalize_flow_sign(100.0, direction="outflow", outflows_reported_as_negative=False) == -100.0
+        assert (
+            normalize_flow_sign(100.0, direction="outflow", outflows_reported_as_negative=False)
+            == -100.0
+        )
 
     def test_outflow_already_negative_when_reported_as_negative(self) -> None:
-        assert normalize_flow_sign(-100.0, direction="outflow", outflows_reported_as_negative=True) == -100.0
+        assert (
+            normalize_flow_sign(-100.0, direction="outflow", outflows_reported_as_negative=True)
+            == -100.0
+        )
 
     def test_outflow_positive_when_reported_as_negative_gets_negated(self) -> None:
-        assert normalize_flow_sign(100.0, direction="outflow", outflows_reported_as_negative=True) == -100.0
+        assert (
+            normalize_flow_sign(100.0, direction="outflow", outflows_reported_as_negative=True)
+            == -100.0
+        )
 
     def test_balance_keeps_raw_sign(self) -> None:
-        assert normalize_flow_sign(-50.0, direction="balance", outflows_reported_as_negative=False) == -50.0
-        assert normalize_flow_sign(50.0, direction="balance", outflows_reported_as_negative=False) == 50.0
+        assert (
+            normalize_flow_sign(-50.0, direction="balance", outflows_reported_as_negative=False)
+            == -50.0
+        )
+        assert (
+            normalize_flow_sign(50.0, direction="balance", outflows_reported_as_negative=False)
+            == 50.0
+        )
 
     def test_none_amount_returns_none(self) -> None:
-        assert normalize_flow_sign(None, direction="inflow", outflows_reported_as_negative=False) is None
+        assert (
+            normalize_flow_sign(None, direction="inflow", outflows_reported_as_negative=False)
+            is None
+        )

--- a/tests/query/test_sql_safety.py
+++ b/tests/query/test_sql_safety.py
@@ -99,9 +99,7 @@ class TestValidateReadOnlySql:
 
     def test_rejects_multiple_statements(self) -> None:
         with pytest.raises(SQLSafetyValidationError, match="multiple"):
-            validate_read_only_sql(
-                "SELECT 1; SELECT 2"
-            )
+            validate_read_only_sql("SELECT 1; SELECT 2")
 
     def test_allows_trailing_semicolon(self) -> None:
         result = validate_read_only_sql("SELECT plan_id FROM curated_metric_facts;")
@@ -205,9 +203,7 @@ class TestExtractSelectedColumns:
         assert cols == ("plan_id", "metric_name")
 
     def test_distinct_stripped(self) -> None:
-        cols = extract_selected_columns(
-            "SELECT DISTINCT plan_id FROM curated_metric_facts"
-        )
+        cols = extract_selected_columns("SELECT DISTINCT plan_id FROM curated_metric_facts")
         assert cols == ("plan_id",)
 
     def test_star_rejected(self) -> None:
@@ -215,9 +211,7 @@ class TestExtractSelectedColumns:
             extract_selected_columns("SELECT * FROM curated_metric_facts")
 
     def test_table_qualified_column(self) -> None:
-        cols = extract_selected_columns(
-            "SELECT c.plan_id FROM curated_metric_facts c"
-        )
+        cols = extract_selected_columns("SELECT c.plan_id FROM curated_metric_facts c")
         assert cols == ("plan_id",)
 
 

--- a/tests/review_queue/test_extraction_state_transitions.py
+++ b/tests/review_queue/test_extraction_state_transitions.py
@@ -76,21 +76,25 @@ class TestBuildExtractionReviewQueue:
 
     def test_inconsistent_routing_raises(self) -> None:
         with pytest.raises(ValueError, match="inconsistent"):
-            build_extraction_review_queue([
-                _decision(
-                    routing_outcome="publish_with_warning",
-                    review_priority="high",
-                )
-            ])
+            build_extraction_review_queue(
+                [
+                    _decision(
+                        routing_outcome="publish_with_warning",
+                        review_priority="high",
+                    )
+                ]
+            )
 
     def test_inconsistent_high_priority_raises(self) -> None:
         with pytest.raises(ValueError, match="inconsistent"):
-            build_extraction_review_queue([
-                _decision(
-                    routing_outcome="high_priority_review",
-                    review_priority="medium",
-                )
-            ])
+            build_extraction_review_queue(
+                [
+                    _decision(
+                        routing_outcome="high_priority_review",
+                        review_priority="medium",
+                    )
+                ]
+            )
 
     def test_audit_trail_populated(self) -> None:
         rows = build_extraction_review_queue([_decision()])
@@ -147,9 +151,7 @@ class TestTransitionState:
     @pytest.fixture()
     def _base_rows(self) -> list[ExtractionReviewQueueRecord]:
         ts = datetime(2024, 1, 1, tzinfo=UTC)
-        return build_extraction_review_queue(
-            [_decision()], queued_at=ts
-        )
+        return build_extraction_review_queue([_decision()], queued_at=ts)
 
     def test_new_to_in_review(self, _base_rows: list[ExtractionReviewQueueRecord]) -> None:
         result = transition_extraction_review_state(
@@ -200,9 +202,7 @@ class TestTransitionState:
                 reason="reopen",
             )
 
-    def test_deferred_to_in_review(
-        self, _base_rows: list[ExtractionReviewQueueRecord]
-    ) -> None:
+    def test_deferred_to_in_review(self, _base_rows: list[ExtractionReviewQueueRecord]) -> None:
         deferred = transition_extraction_review_state(
             _base_rows,
             queue_id=_base_rows[0].queue_id,
@@ -219,9 +219,7 @@ class TestTransitionState:
         )
         assert result[0].state == "in_review"
 
-    def test_audit_trail_grows(
-        self, _base_rows: list[ExtractionReviewQueueRecord]
-    ) -> None:
+    def test_audit_trail_grows(self, _base_rows: list[ExtractionReviewQueueRecord]) -> None:
         result = transition_extraction_review_state(
             _base_rows,
             queue_id=_base_rows[0].queue_id,
@@ -236,9 +234,7 @@ class TestTransitionState:
         assert latest.next_state == "in_review"
         assert latest.actor == "reviewer"
 
-    def test_unknown_queue_id_raises(
-        self, _base_rows: list[ExtractionReviewQueueRecord]
-    ) -> None:
+    def test_unknown_queue_id_raises(self, _base_rows: list[ExtractionReviewQueueRecord]) -> None:
         with pytest.raises(ValueError, match="not found"):
             transition_extraction_review_state(
                 _base_rows,
@@ -260,9 +256,7 @@ class TestTransitionState:
         )
         assert result[0].audit_trail[-1].actor == "unknown"
 
-    def test_empty_reason_defaults(
-        self, _base_rows: list[ExtractionReviewQueueRecord]
-    ) -> None:
+    def test_empty_reason_defaults(self, _base_rows: list[ExtractionReviewQueueRecord]) -> None:
         result = transition_extraction_review_state(
             _base_rows,
             queue_id=_base_rows[0].queue_id,

--- a/tests/sources/test_source_validation_helpers.py
+++ b/tests/sources/test_source_validation_helpers.py
@@ -193,63 +193,79 @@ class TestValidateSourceMapEntries:
         assert findings == []
 
     def test_invalid_url_detected(self) -> None:
-        findings = validate_source_map_entries([
-            _valid_entry(seed_url="not-a-url"),
-        ])
+        findings = validate_source_map_entries(
+            [
+                _valid_entry(seed_url="not-a-url"),
+            ]
+        )
         codes = [f.code for f in findings]
         assert "invalid_url" in codes
 
     def test_missing_allowed_domains_detected(self) -> None:
-        findings = validate_source_map_entries([
-            _valid_entry(allowed_domains=()),
-        ])
+        findings = validate_source_map_entries(
+            [
+                _valid_entry(allowed_domains=()),
+            ]
+        )
         codes = [f.code for f in findings]
         assert "missing_allowed_domains" in codes
 
     def test_invalid_domain_detected(self) -> None:
-        findings = validate_source_map_entries([
-            _valid_entry(allowed_domains=("nodot",)),
-        ])
+        findings = validate_source_map_entries(
+            [
+                _valid_entry(allowed_domains=("nodot",)),
+            ]
+        )
         codes = [f.code for f in findings]
         assert "invalid_allowed_domain" in codes
 
     def test_invalid_authority_tier_detected(self) -> None:
-        findings = validate_source_map_entries([
-            _valid_entry(source_authority_tier="bogus"),
-        ])
+        findings = validate_source_map_entries(
+            [
+                _valid_entry(source_authority_tier="bogus"),
+            ]
+        )
         codes = [f.code for f in findings]
         assert "invalid_authority_tier" in codes
 
     def test_annual_report_requires_authority_tier(self) -> None:
-        findings = validate_source_map_entries([
-            _valid_entry(
-                doc_type_hints=("annual_report",),
-                source_authority_tier="",
-            ),
-        ])
+        findings = validate_source_map_entries(
+            [
+                _valid_entry(
+                    doc_type_hints=("annual_report",),
+                    source_authority_tier="",
+                ),
+            ]
+        )
         codes = [f.code for f in findings]
         assert "missing_authority_tier" in codes
 
     def test_invalid_doc_type_hint(self) -> None:
-        findings = validate_source_map_entries([
-            _valid_entry(doc_type_hints=("unknown_type",)),
-        ])
+        findings = validate_source_map_entries(
+            [
+                _valid_entry(doc_type_hints=("unknown_type",)),
+            ]
+        )
         codes = [f.code for f in findings]
         assert "invalid_doc_type_hint" in codes
 
     def test_invalid_pagination_hint(self) -> None:
-        findings = validate_source_map_entries([
-            _valid_entry(pagination_hints=("unknown_pagination",)),
-        ])
+        findings = validate_source_map_entries(
+            [
+                _valid_entry(pagination_hints=("unknown_pagination",)),
+            ]
+        )
         codes = [f.code for f in findings]
         assert "invalid_pagination_hint" in codes
 
     def test_invalid_crawl_constraints(self) -> None:
-        findings = validate_source_map_entries([
-            _valid_entry(
-                crawl_constraints=CrawlConstraints(max_pages=0, max_depth=2),
-            ),
-        ])
+        findings = validate_source_map_entries(
+            [
+                _valid_entry(
+                    crawl_constraints=CrawlConstraints(max_pages=0, max_depth=2),
+                ),
+            ]
+        )
         codes = [f.code for f in findings]
         assert "invalid_crawl_constraints" in codes
 
@@ -274,29 +290,37 @@ class TestValidateSourceMapEntries:
         assert "duplicate_seed_url" in codes
 
     def test_invalid_override_key_detected(self) -> None:
-        findings = validate_source_map_entries([
-            _valid_entry(overrides=(("bad_key", "value"),)),
-        ])
+        findings = validate_source_map_entries(
+            [
+                _valid_entry(overrides=(("bad_key", "value"),)),
+            ]
+        )
         codes = [f.code for f in findings]
         assert "invalid_override_key" in codes
 
     def test_invalid_override_pagination_mode(self) -> None:
-        findings = validate_source_map_entries([
-            _valid_entry(overrides=(("pagination_mode", "bad_mode"),)),
-        ])
+        findings = validate_source_map_entries(
+            [
+                _valid_entry(overrides=(("pagination_mode", "bad_mode"),)),
+            ]
+        )
         codes = [f.code for f in findings]
         assert "invalid_override_value" in codes
 
     def test_invalid_override_requires_js(self) -> None:
-        findings = validate_source_map_entries([
-            _valid_entry(overrides=(("requires_js", "maybe"),)),
-        ])
+        findings = validate_source_map_entries(
+            [
+                _valid_entry(overrides=(("requires_js", "maybe"),)),
+            ]
+        )
         codes = [f.code for f in findings]
         assert "invalid_override_value" in codes
 
     def test_invalid_override_force_render_wait_ms(self) -> None:
-        findings = validate_source_map_entries([
-            _valid_entry(overrides=(("force_render_wait_ms", "not_a_number"),)),
-        ])
+        findings = validate_source_map_entries(
+            [
+                _valid_entry(overrides=(("force_render_wait_ms", "not_a_number"),)),
+            ]
+        )
         codes = [f.code for f in findings]
         assert "invalid_override_value" in codes


### PR DESCRIPTION
## Summary
- apply Black formatting to files currently failing CI format checks
- add the missing PostgreSQL `staging_consultant_engagements` table before extended migrations index it

## Tests
- python -m black --check .
- python -m pytest -q --no-cov tests/db/test_database_strategy.py

Follow-up for sync PR #338 CI blockers.

<!-- pr-preamble:start -->
<!-- meta:issue:338 -->
> **Source:** Issue #338

Closes #338

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
## Sync Summary

### Files Updated

#### Tasks
- [ ] aggregate_agent_metrics.py: Aggregates downloaded weekly agent metrics - required by agents-weekly-metrics.yml
- [ ] source_context.js: Classifies PR workflow source context for issue, local, automation, sync, Dependabot, review follow-up, and direct GitHub work
- [ ] agents_pr_meta_update_body.js: Updates PR body with agent metadata

#### Acceptance criteria
- [ ] pr-00-gate.yml: File exists and sync_mode is create_only
- [ ] ci.yml: File exists and sync_mode is create_only
- [ ] dependabot.yml: File exists and sync_mode is create_only
- [ ] llm_slots.json: None

**Head SHA:** ebb52e5e2276dbf77a9d524c114e9924588579bb
**Latest Runs:** ⏹️ cancelled — Gate
**Required:** gate: ⏹️ cancelled

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| .github/workflows/autofix.yml | ❌ failure | [View run](https://github.com/stranske/Pension-Data/actions/runs/24977024782) |
| Agents Auto-Pilot | ⏭️ skipped | [View run](https://github.com/stranske/Pension-Data/actions/runs/24977037506) |
| Agents Bot Comment Handler | ⏹️ cancelled | [View run](https://github.com/stranske/Pension-Data/actions/runs/24977037516) |
| Agents Gate Followups | ⏹️ cancelled | [View run](https://github.com/stranske/Pension-Data/actions/runs/24977037528) |
| Agents Keepalive Loop | ⏭️ skipped | [View run](https://github.com/stranske/Pension-Data/actions/runs/24977037519) |
| Agents PR Event Hub | ⏹️ cancelled | [View run](https://github.com/stranske/Pension-Data/actions/runs/24977037638) |
| Agents PR Meta | ⏭️ skipped | [View run](https://github.com/stranske/Pension-Data/actions/runs/24977030309) |
| Agents Verifier | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/24977037613) |
| CI | ❔ in progress | [View run](https://github.com/stranske/Pension-Data/actions/runs/24977030279) |
| Claude Code Review (Opt-in) | ⏳ queued | [View run](https://github.com/stranske/Pension-Data/actions/runs/24977037484) |
| Copilot code review | ❔ in progress | [View run](https://github.com/stranske/Pension-Data/actions/runs/24977031033) |
| Create Issue from Verification (DEPRECATED) | ⏭️ skipped | [View run](https://github.com/stranske/Pension-Data/actions/runs/24977037492) |
| Create Issue from Verification (Enhanced) | ⏭️ skipped | [View run](https://github.com/stranske/Pension-Data/actions/runs/24977037486) |
| Create New PR from Verification | ⏭️ skipped | [View run](https://github.com/stranske/Pension-Data/actions/runs/24977037621) |
| Dependabot Auto-merge | ⏭️ skipped | [View run](https://github.com/stranske/Pension-Data/actions/runs/24977030212) |
| Entity Regression Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/24977030226) |
| Extraction Golden Regression | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/24977030230) |
| Foundation Fixture E2E | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/24977030235) |
| Gate | ⏹️ cancelled | [View run](https://github.com/stranske/Pension-Data/actions/runs/24977037504) |
| Health 45 Agents Guard | ⏹️ cancelled | [View run](https://github.com/stranske/Pension-Data/actions/runs/24977037491) |
| PostgreSQL Integration | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/24977030262) |
| Quality Replay Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/24977030222) |
| Quality SLA Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/24977030215) |
<!-- auto-status-summary:end -->