### PR TITLE
Issue #321: Define reviewable UI LangChain artifact

### DIFF
--- a/docs/LANGCHAIN_FOUNDATIONS.md
+++ b/docs/LANGCHAIN_FOUNDATIONS.md
@@ -55,3 +55,16 @@ Use shared helpers from `pension_data.langchain.prompts`:
 All findings-explainer outputs should include:
 
 `This is analytical output, not financial advice. Always verify metrics independently.`
+
+## Reviewable Findings Artifact
+
+The first static UI/LangChain artifact slice is `extraction_quality_dashboard`.
+
+- Schema: `docs/data/reviewable-findings/findings.schema.json`
+- Published payload path: `docs/data/reviewable-findings/extraction-quality-dashboard.json`
+- Contract doc: `docs/contracts/reviewable-findings-artifact-contract.md`
+
+Use `reviewable_findings_schema()` to inspect the machine-readable contract and
+`validate_reviewable_findings_artifact(...)` before publishing generated artifacts. Rows must carry
+entity, period, metric family, confidence, provenance refs, and citations so explain/compare outputs
+remain source-bound.

--- a/docs/UI_LANGCHAIN_OPTIONS.md
+++ b/docs/UI_LANGCHAIN_OPTIONS.md
@@ -79,6 +79,19 @@ This document compares practical options for adding a higher-quality UI and a La
 2. Add **Option 3** over time by introducing a Mac desktop power-client when UX depth is needed.
 3. Keep LangChain execution in CI first; only move to local embedded inference if latency becomes a hard blocker.
 
+## First Reviewable Artifact
+
+The first static UI/LangChain slice is `extraction_quality_dashboard`.
+
+- Schema contract: `docs/data/reviewable-findings/findings.schema.json`
+- Published payload path: `docs/data/reviewable-findings/extraction-quality-dashboard.json`
+- Contract narrative: `docs/contracts/reviewable-findings-artifact-contract.md`
+- Python validator: `pension_data.langchain.review_artifact.validate_reviewable_findings_artifact(...)`
+
+This slice focuses on extraction quality because it can be generated from existing extraction
+persistence and source-readiness outputs while still carrying the provenance, confidence, metric
+family, entity, and period fields the static UI and LangChain explain/compare flows need.
+
 ## Project Inclusion Status
 
 - Mac desktop packaging track is now included in this repo at `apps/mac-desktop/` as an implementation scaffold.

--- a/docs/contracts/quant-data-model-contract.md
+++ b/docs/contracts/quant-data-model-contract.md
@@ -42,6 +42,10 @@ Defines the shared quantitative output contract for browser UI, desktop app, and
 - Web and desktop clients should render `QuantSeriesContract` by `chart_kind` without schema translation.
 - `provenance_refs` should be displayed as citations/tooltips where available.
 - Warnings should be surfaced as non-blocking banners with drill-through detail.
+- Static review findings should be published first to
+  `docs/data/reviewable-findings/extraction-quality-dashboard.json` using
+  `docs/data/reviewable-findings/findings.schema.json` so UI and LangChain consumers share one
+  artifact path before broader quant workspace generation.
 
 ## Reproducibility Validation
 

--- a/docs/contracts/reviewable-findings-artifact-contract.md
+++ b/docs/contracts/reviewable-findings-artifact-contract.md
@@ -1,0 +1,64 @@
+# Reviewable Findings Artifact Contract
+
+## Source Of Truth
+
+- Schema artifact: `docs/data/reviewable-findings/findings.schema.json`
+- First published payload path: `docs/data/reviewable-findings/extraction-quality-dashboard.json`
+- Python helper: `src/pension_data/langchain/review_artifact.py`
+- Contract tests: `tests/langchain/test_review_artifact_contract.py`
+
+## First Slice
+
+The first reviewable UI/LangChain slice is `extraction_quality_dashboard`.
+
+This slice is intentionally narrower than the full web workspace. It reports extraction quality
+findings that a reviewer can inspect in a static browser UI and ask asynchronous LangChain
+explain/compare questions about.
+
+## Artifact Envelope
+
+Required top-level fields:
+
+- `artifact_type`: always `pension_data.reviewable_findings`
+- `schema_version`: integer contract version, starting at `1`
+- `artifact_id`: stable id for one generated payload
+- `generated_at`: UTC timestamp
+- `source_artifact_ids`: non-empty identifiers for upstream extraction/readiness artifacts
+- `slice`: metadata for the dashboard slice
+- `findings`: finding rows
+- `langchain_actions`: supported asynchronous interaction contracts
+
+## Finding Rows
+
+Each finding row must include:
+
+- `finding_id`
+- `entity`
+- `period`
+- `metric_family`
+- `metric`
+- `value`
+- `confidence`
+- `provenance_refs`
+- `citations`
+
+Optional `severity` values are `info`, `warning`, and `blocker`.
+
+The required filter fields for the static UI are `entity`, `period`, `metric_family`, and
+`confidence`. Citations and provenance references are mandatory so the UI can display source
+tooltips and LangChain outputs can stay citation-bound.
+
+## LangChain Actions
+
+The artifact advertises two asynchronous actions:
+
+- `explain`: accepts one or more `finding_ids` plus a question and writes a structured summary.
+- `compare`: accepts two or more `finding_ids` plus a question and writes a structured comparison.
+
+Outputs must include `request_id`, `generated_at`, `summary`, `citations`, and `artifact_path`.
+
+## Generation Plan
+
+The first generator should read extraction persistence outputs and source-readiness artifacts, then
+write `docs/data/reviewable-findings/extraction-quality-dashboard.json` as a CI/release artifact.
+It should fail validation with `validate_reviewable_findings_artifact(...)` before publishing.

--- a/docs/data/reviewable-findings/README.md
+++ b/docs/data/reviewable-findings/README.md
@@ -1,0 +1,20 @@
+# Reviewable Findings Artifact
+
+The first static UI and LangChain artifact slice is `extraction_quality_dashboard`.
+
+- Contract: `docs/data/reviewable-findings/findings.schema.json`
+- Published artifact path: `docs/data/reviewable-findings/extraction-quality-dashboard.json`
+- Python contract helper: `pension_data.langchain.review_artifact.reviewable_findings_schema()`
+- Validator: `pension_data.langchain.review_artifact.validate_reviewable_findings_artifact(...)`
+
+The artifact is generated from existing extraction persistence and readiness outputs, not from
+hand-authored UI rows. Until the generator lands, this directory contains only the schema and path
+contract so reviewers and follow-up issues have one stable target.
+
+Required finding rows include `entity`, `period`, `metric_family`, `metric`, `value`, `confidence`,
+`provenance_refs`, and `citations`. These are the minimum fields the static UI can filter/render and
+the LangChain explain/compare chains can cite without repo-local execution.
+
+LangChain actions are asynchronous. The artifact advertises `explain` and `compare` request shapes;
+workflow or comment-driven runs write result artifacts back with request id, timestamp, summary,
+citations, and an output artifact path.

--- a/docs/data/reviewable-findings/README.md
+++ b/docs/data/reviewable-findings/README.md
@@ -8,8 +8,8 @@ The first static UI and LangChain artifact slice is `extraction_quality_dashboar
 - Validator: `pension_data.langchain.review_artifact.validate_reviewable_findings_artifact(...)`
 
 The artifact is generated from existing extraction persistence and readiness outputs, not from
-hand-authored UI rows. Until the generator lands, this directory contains only the schema and path
-contract so reviewers and follow-up issues have one stable target.
+hand-authored UI rows. The checked-in artifact at the published path provides a stable machine-
+readable target for static UI hosting and reviewer workflows while generator wiring is finalized.
 
 Required finding rows include `entity`, `period`, `metric_family`, `metric`, `value`, `confidence`,
 `provenance_refs`, and `citations`. These are the minimum fields the static UI can filter/render and

--- a/docs/data/reviewable-findings/README.md
+++ b/docs/data/reviewable-findings/README.md
@@ -6,6 +6,7 @@ The first static UI and LangChain artifact slice is `extraction_quality_dashboar
 - Published artifact path: `docs/data/reviewable-findings/extraction-quality-dashboard.json`
 - Python contract helper: `pension_data.langchain.review_artifact.reviewable_findings_schema()`
 - Validator: `pension_data.langchain.review_artifact.validate_reviewable_findings_artifact(...)`
+- Generator command: `python scripts/langchain/build_reviewable_findings_artifact.py`
 
 The artifact is generated from existing extraction persistence and readiness outputs, not from
 hand-authored UI rows. The checked-in artifact at the published path provides a stable machine-

--- a/docs/data/reviewable-findings/extraction-quality-dashboard.json
+++ b/docs/data/reviewable-findings/extraction-quality-dashboard.json
@@ -1,0 +1,67 @@
+{
+  "artifact_type": "pension_data.reviewable_findings",
+  "schema_version": 1,
+  "artifact_id": "extraction-quality-dashboard:2026-05-10",
+  "generated_at": "2026-05-10T03:20:00Z",
+  "source_artifact_ids": [
+    "extraction_persistence/persistence_contract.json",
+    "coverage/source_authority_readiness.csv"
+  ],
+  "slice": {
+    "slice_id": "extraction_quality_dashboard",
+    "title": "Extraction Quality Dashboard",
+    "metric_family": "extraction_quality",
+    "description": "Review extraction confidence, blockers, and source-backed citations."
+  },
+  "findings": [
+    {
+      "finding_id": "finding:ca-pers:fy2024:funded-ratio",
+      "entity": "CA-PERS",
+      "period": "FY2024",
+      "metric_family": "funded_status",
+      "metric": "funded_ratio",
+      "value": 0.81,
+      "confidence": 0.96,
+      "severity": "info",
+      "provenance_refs": [
+        "doc:ca-pers-2024#page=52"
+      ],
+      "citations": [
+        "CA-PERS ACFR FY2024 p.52"
+      ]
+    },
+    {
+      "finding_id": "finding:ca-pers:fy2023:funded-ratio",
+      "entity": "CA-PERS",
+      "period": "FY2023",
+      "metric_family": "funded_status",
+      "metric": "funded_ratio",
+      "value": 0.79,
+      "confidence": 0.93,
+      "severity": "info",
+      "provenance_refs": [
+        "doc:ca-pers-2023#page=49"
+      ],
+      "citations": [
+        "CA-PERS ACFR FY2023 p.49"
+      ]
+    }
+  ],
+  "langchain_actions": [
+    {
+      "action": "explain",
+      "question": "Explain the confidence drivers for this finding",
+      "finding_ids": [
+        "finding:ca-pers:fy2024:funded-ratio"
+      ]
+    },
+    {
+      "action": "compare",
+      "question": "Compare confidence against the prior period",
+      "finding_ids": [
+        "finding:ca-pers:fy2024:funded-ratio",
+        "finding:ca-pers:fy2023:funded-ratio"
+      ]
+    }
+  ]
+}

--- a/docs/data/reviewable-findings/findings.schema.json
+++ b/docs/data/reviewable-findings/findings.schema.json
@@ -1,0 +1,66 @@
+{
+  "artifact_type": "pension_data.reviewable_findings",
+  "schema_version": 1,
+  "artifact_path": "docs/data/reviewable-findings/extraction-quality-dashboard.json",
+  "required_artifact_fields": [
+    "artifact_type",
+    "schema_version",
+    "artifact_id",
+    "generated_at",
+    "source_artifact_ids",
+    "slice",
+    "findings",
+    "langchain_actions"
+  ],
+  "slice": {
+    "required_fields": [
+      "slice_id",
+      "title",
+      "metric_family",
+      "description"
+    ],
+    "first_slice": "extraction_quality_dashboard"
+  },
+  "findings": {
+    "required_fields": [
+      "finding_id",
+      "entity",
+      "period",
+      "metric_family",
+      "metric",
+      "value",
+      "confidence",
+      "provenance_refs",
+      "citations"
+    ],
+    "allowed_severity": [
+      "blocker",
+      "info",
+      "warning"
+    ],
+    "required_filter_fields": [
+      "entity",
+      "period",
+      "metric_family",
+      "confidence"
+    ]
+  },
+  "langchain_actions": {
+    "allowed_actions": [
+      "compare",
+      "explain"
+    ],
+    "required_request_fields": [
+      "action",
+      "question",
+      "finding_ids"
+    ],
+    "required_output_fields": [
+      "request_id",
+      "generated_at",
+      "summary",
+      "citations",
+      "artifact_path"
+    ]
+  }
+}

--- a/scripts/langchain/build_reviewable_findings_artifact.py
+++ b/scripts/langchain/build_reviewable_findings_artifact.py
@@ -1,0 +1,48 @@
+"""Generate the first static UI/LangChain reviewable findings artifact."""
+
+from __future__ import annotations
+
+import argparse
+
+from pension_data.langchain.review_artifact import (
+    REVIEWABLE_FINDINGS_ARTIFACT_PATH,
+    build_extraction_quality_dashboard_artifact,
+    write_reviewable_findings_artifact,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate the extraction quality dashboard reviewable findings artifact."
+    )
+    parser.add_argument(
+        "--output",
+        default=REVIEWABLE_FINDINGS_ARTIFACT_PATH,
+        help="Output path for the artifact JSON.",
+    )
+    parser.add_argument(
+        "--generated-at",
+        default=None,
+        help="Override generated_at timestamp (ISO-8601, UTC preferred).",
+    )
+    parser.add_argument(
+        "--artifact-date",
+        default=None,
+        help="Override artifact date used in artifact_id (YYYY-MM-DD).",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    artifact = build_extraction_quality_dashboard_artifact(
+        generated_at=args.generated_at,
+        artifact_date=args.artifact_date,
+    )
+    path = write_reviewable_findings_artifact(artifact, output_path=args.output)
+    print(path.as_posix())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pension_data/langchain/__init__.py
+++ b/src/pension_data/langchain/__init__.py
@@ -28,6 +28,15 @@ from pension_data.langchain.prompts import (
     build_findings_explainer_prompt,
     build_nl_query_system_prompt,
 )
+from pension_data.langchain.review_artifact import (
+    REVIEWABLE_FINDINGS_ARTIFACT_PATH,
+    REVIEWABLE_FINDINGS_ARTIFACT_TYPE,
+    REVIEWABLE_FINDINGS_SCHEMA_PATH,
+    REVIEWABLE_FINDINGS_SCHEMA_VERSION,
+    ReviewableFindingsArtifactError,
+    reviewable_findings_schema,
+    validate_reviewable_findings_artifact,
+)
 from pension_data.langchain.tracing import (
     configure_langsmith_env,
     langsmith_tracing_context,
@@ -51,13 +60,20 @@ __all__ = [
     "NLToSQLRequest",
     "NLToSQLResponse",
     "NLToSQLStatus",
+    "REVIEWABLE_FINDINGS_ARTIFACT_PATH",
+    "REVIEWABLE_FINDINGS_ARTIFACT_TYPE",
+    "REVIEWABLE_FINDINGS_SCHEMA_PATH",
+    "REVIEWABLE_FINDINGS_SCHEMA_VERSION",
+    "ReviewableFindingsArtifactError",
     "append_analytics_disclaimer",
     "build_findings_explainer_prompt",
     "build_nl_query_system_prompt",
     "configure_langsmith_env",
     "create_llm",
     "langsmith_tracing_context",
+    "reviewable_findings_schema",
     "resolve_provider_config",
     "resolve_trace_url",
     "run_nl_sql_chain",
+    "validate_reviewable_findings_artifact",
 ]

--- a/src/pension_data/langchain/review_artifact.py
+++ b/src/pension_data/langchain/review_artifact.py
@@ -11,6 +11,7 @@ REVIEWABLE_FINDINGS_ARTIFACT_PATH = (
     "docs/data/reviewable-findings/extraction-quality-dashboard.json"
 )
 REVIEWABLE_FINDINGS_SCHEMA_PATH = "docs/data/reviewable-findings/findings.schema.json"
+REVIEWABLE_FINDINGS_FIRST_SLICE_ID = "extraction_quality_dashboard"
 
 ReviewFindingSeverity = Literal["info", "warning", "blocker"]
 
@@ -58,7 +59,7 @@ def reviewable_findings_schema() -> dict[str, object]:
         "required_artifact_fields": list(REQUIRED_ARTIFACT_FIELDS),
         "slice": {
             "required_fields": list(REQUIRED_SLICE_FIELDS),
-            "first_slice": "extraction_quality_dashboard",
+            "first_slice": REVIEWABLE_FINDINGS_FIRST_SLICE_ID,
         },
         "findings": {
             "required_fields": list(REQUIRED_FINDING_FIELDS),
@@ -141,12 +142,18 @@ def validate_reviewable_findings_artifact(artifact: Mapping[str, Any]) -> None:
     )
     for field in REQUIRED_SLICE_FIELDS:
         _require_string(slice_payload[field], path=f"artifact.slice.{field}")
+    if slice_payload["slice_id"] != REVIEWABLE_FINDINGS_FIRST_SLICE_ID:
+        raise ReviewableFindingsArtifactError(
+            "artifact.slice.slice_id must be "
+            f"{REVIEWABLE_FINDINGS_FIRST_SLICE_ID}"
+        )
 
     findings = artifact["findings"]
     if not isinstance(findings, Sequence) or isinstance(findings, (str, bytes, bytearray)):
         raise ReviewableFindingsArtifactError("artifact.findings must be a list")
     if not findings:
         raise ReviewableFindingsArtifactError("artifact.findings must not be empty")
+    finding_ids: set[str] = set()
     for index, item in enumerate(findings):
         finding = _require_mapping(item, path=f"artifact.findings[{index}]")
         _validate_required_fields(
@@ -162,8 +169,13 @@ def validate_reviewable_findings_artifact(artifact: Mapping[str, Any]) -> None:
             "metric",
         ):
             _require_string(finding[field], path=f"artifact.findings[{index}].{field}")
+        finding_ids.add(finding["finding_id"])
         confidence = finding["confidence"]
-        if not isinstance(confidence, int | float) or not 0 <= confidence <= 1:
+        if (
+            isinstance(confidence, bool)
+            or not isinstance(confidence, int | float)
+            or not 0 <= confidence <= 1
+        ):
             raise ReviewableFindingsArtifactError(
                 f"artifact.findings[{index}].confidence must be between 0 and 1"
             )
@@ -196,6 +208,20 @@ def validate_reviewable_findings_artifact(artifact: Mapping[str, Any]) -> None:
             raise ReviewableFindingsArtifactError(
                 f"artifact.langchain_actions[{index}].action must be one of "
                 f"{sorted(ALLOWED_LANGCHAIN_ACTIONS)}"
+            )
+        _require_string(
+            action.get("question"),
+            path=f"artifact.langchain_actions[{index}].question",
+        )
+        action_finding_ids = _require_string_sequence(
+            action.get("finding_ids"),
+            path=f"artifact.langchain_actions[{index}].finding_ids",
+        )
+        unknown_finding_ids = sorted(set(action_finding_ids) - finding_ids)
+        if unknown_finding_ids:
+            raise ReviewableFindingsArtifactError(
+                f"artifact.langchain_actions[{index}].finding_ids reference "
+                f"unknown findings: {', '.join(unknown_finding_ids)}"
             )
         available_actions.add(name)
     if available_actions != ALLOWED_LANGCHAIN_ACTIONS:

--- a/src/pension_data/langchain/review_artifact.py
+++ b/src/pension_data/langchain/review_artifact.py
@@ -1,0 +1,204 @@
+"""Contract helpers for the first static UI/LangChain review artifact."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal
+
+REVIEWABLE_FINDINGS_SCHEMA_VERSION = 1
+REVIEWABLE_FINDINGS_ARTIFACT_TYPE = "pension_data.reviewable_findings"
+REVIEWABLE_FINDINGS_ARTIFACT_PATH = (
+    "docs/data/reviewable-findings/extraction-quality-dashboard.json"
+)
+REVIEWABLE_FINDINGS_SCHEMA_PATH = "docs/data/reviewable-findings/findings.schema.json"
+
+ReviewFindingSeverity = Literal["info", "warning", "blocker"]
+
+REQUIRED_ARTIFACT_FIELDS: tuple[str, ...] = (
+    "artifact_type",
+    "schema_version",
+    "artifact_id",
+    "generated_at",
+    "source_artifact_ids",
+    "slice",
+    "findings",
+    "langchain_actions",
+)
+REQUIRED_SLICE_FIELDS: tuple[str, ...] = (
+    "slice_id",
+    "title",
+    "metric_family",
+    "description",
+)
+REQUIRED_FINDING_FIELDS: tuple[str, ...] = (
+    "finding_id",
+    "entity",
+    "period",
+    "metric_family",
+    "metric",
+    "value",
+    "confidence",
+    "provenance_refs",
+    "citations",
+)
+ALLOWED_SEVERITIES: frozenset[str] = frozenset({"info", "warning", "blocker"})
+ALLOWED_LANGCHAIN_ACTIONS: frozenset[str] = frozenset({"explain", "compare"})
+
+
+class ReviewableFindingsArtifactError(ValueError):
+    """Raised when a reviewable findings artifact violates the contract."""
+
+
+def reviewable_findings_schema() -> dict[str, object]:
+    """Return the machine-readable contract for static UI and LangChain consumers."""
+    return {
+        "artifact_type": REVIEWABLE_FINDINGS_ARTIFACT_TYPE,
+        "schema_version": REVIEWABLE_FINDINGS_SCHEMA_VERSION,
+        "artifact_path": REVIEWABLE_FINDINGS_ARTIFACT_PATH,
+        "required_artifact_fields": list(REQUIRED_ARTIFACT_FIELDS),
+        "slice": {
+            "required_fields": list(REQUIRED_SLICE_FIELDS),
+            "first_slice": "extraction_quality_dashboard",
+        },
+        "findings": {
+            "required_fields": list(REQUIRED_FINDING_FIELDS),
+            "allowed_severity": sorted(ALLOWED_SEVERITIES),
+            "required_filter_fields": ["entity", "period", "metric_family", "confidence"],
+        },
+        "langchain_actions": {
+            "allowed_actions": sorted(ALLOWED_LANGCHAIN_ACTIONS),
+            "required_request_fields": ["action", "question", "finding_ids"],
+            "required_output_fields": [
+                "request_id",
+                "generated_at",
+                "summary",
+                "citations",
+                "artifact_path",
+            ],
+        },
+    }
+
+
+def _require_mapping(value: object, *, path: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ReviewableFindingsArtifactError(f"{path} must be an object")
+    return value
+
+
+def _require_string(value: object, *, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ReviewableFindingsArtifactError(f"{path} must be a non-empty string")
+    return value
+
+
+def _require_string_sequence(value: object, *, path: str) -> tuple[str, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise ReviewableFindingsArtifactError(f"{path} must be a list of strings")
+    normalized: list[str] = []
+    for index, item in enumerate(value):
+        normalized.append(_require_string(item, path=f"{path}[{index}]"))
+    if not normalized:
+        raise ReviewableFindingsArtifactError(f"{path} must not be empty")
+    return tuple(normalized)
+
+
+def _validate_required_fields(
+    payload: Mapping[str, Any], *, required_fields: Sequence[str], path: str
+) -> None:
+    missing = [field for field in required_fields if field not in payload]
+    if missing:
+        joined = ", ".join(missing)
+        raise ReviewableFindingsArtifactError(f"{path} missing required fields: {joined}")
+
+
+def validate_reviewable_findings_artifact(artifact: Mapping[str, Any]) -> None:
+    """Validate a reviewable findings artifact before publishing it to the static path."""
+    _validate_required_fields(
+        artifact,
+        required_fields=REQUIRED_ARTIFACT_FIELDS,
+        path="artifact",
+    )
+    if artifact["artifact_type"] != REVIEWABLE_FINDINGS_ARTIFACT_TYPE:
+        raise ReviewableFindingsArtifactError(
+            f"artifact_type must be {REVIEWABLE_FINDINGS_ARTIFACT_TYPE}"
+        )
+    if artifact["schema_version"] != REVIEWABLE_FINDINGS_SCHEMA_VERSION:
+        raise ReviewableFindingsArtifactError(
+            f"schema_version must be {REVIEWABLE_FINDINGS_SCHEMA_VERSION}"
+        )
+    _require_string(artifact["artifact_id"], path="artifact.artifact_id")
+    _require_string(artifact["generated_at"], path="artifact.generated_at")
+    _require_string_sequence(
+        artifact["source_artifact_ids"],
+        path="artifact.source_artifact_ids",
+    )
+
+    slice_payload = _require_mapping(artifact["slice"], path="artifact.slice")
+    _validate_required_fields(
+        slice_payload,
+        required_fields=REQUIRED_SLICE_FIELDS,
+        path="artifact.slice",
+    )
+    for field in REQUIRED_SLICE_FIELDS:
+        _require_string(slice_payload[field], path=f"artifact.slice.{field}")
+
+    findings = artifact["findings"]
+    if not isinstance(findings, Sequence) or isinstance(findings, (str, bytes, bytearray)):
+        raise ReviewableFindingsArtifactError("artifact.findings must be a list")
+    if not findings:
+        raise ReviewableFindingsArtifactError("artifact.findings must not be empty")
+    for index, item in enumerate(findings):
+        finding = _require_mapping(item, path=f"artifact.findings[{index}]")
+        _validate_required_fields(
+            finding,
+            required_fields=REQUIRED_FINDING_FIELDS,
+            path=f"artifact.findings[{index}]",
+        )
+        for field in (
+            "finding_id",
+            "entity",
+            "period",
+            "metric_family",
+            "metric",
+        ):
+            _require_string(finding[field], path=f"artifact.findings[{index}].{field}")
+        confidence = finding["confidence"]
+        if not isinstance(confidence, int | float) or not 0 <= confidence <= 1:
+            raise ReviewableFindingsArtifactError(
+                f"artifact.findings[{index}].confidence must be between 0 and 1"
+            )
+        severity = finding.get("severity", "info")
+        if severity not in ALLOWED_SEVERITIES:
+            raise ReviewableFindingsArtifactError(
+                f"artifact.findings[{index}].severity must be one of "
+                f"{sorted(ALLOWED_SEVERITIES)}"
+            )
+        _require_string_sequence(
+            finding["provenance_refs"],
+            path=f"artifact.findings[{index}].provenance_refs",
+        )
+        _require_string_sequence(
+            finding["citations"],
+            path=f"artifact.findings[{index}].citations",
+        )
+
+    actions = artifact["langchain_actions"]
+    if not isinstance(actions, Sequence) or isinstance(actions, (str, bytes, bytearray)):
+        raise ReviewableFindingsArtifactError("artifact.langchain_actions must be a list")
+    available_actions = set()
+    for index, item in enumerate(actions):
+        action = _require_mapping(item, path=f"artifact.langchain_actions[{index}]")
+        name = _require_string(
+            action.get("action"),
+            path=f"artifact.langchain_actions[{index}].action",
+        )
+        if name not in ALLOWED_LANGCHAIN_ACTIONS:
+            raise ReviewableFindingsArtifactError(
+                f"artifact.langchain_actions[{index}].action must be one of "
+                f"{sorted(ALLOWED_LANGCHAIN_ACTIONS)}"
+            )
+        available_actions.add(name)
+    if available_actions != ALLOWED_LANGCHAIN_ACTIONS:
+        raise ReviewableFindingsArtifactError(
+            "artifact.langchain_actions must include explain and compare"
+        )

--- a/src/pension_data/langchain/review_artifact.py
+++ b/src/pension_data/langchain/review_artifact.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any, Literal
 
 REVIEWABLE_FINDINGS_SCHEMA_VERSION = 1
@@ -144,8 +146,7 @@ def validate_reviewable_findings_artifact(artifact: Mapping[str, Any]) -> None:
         _require_string(slice_payload[field], path=f"artifact.slice.{field}")
     if slice_payload["slice_id"] != REVIEWABLE_FINDINGS_FIRST_SLICE_ID:
         raise ReviewableFindingsArtifactError(
-            "artifact.slice.slice_id must be "
-            f"{REVIEWABLE_FINDINGS_FIRST_SLICE_ID}"
+            "artifact.slice.slice_id must be " f"{REVIEWABLE_FINDINGS_FIRST_SLICE_ID}"
         )
 
     findings = artifact["findings"]
@@ -228,3 +229,88 @@ def validate_reviewable_findings_artifact(artifact: Mapping[str, Any]) -> None:
         raise ReviewableFindingsArtifactError(
             "artifact.langchain_actions must include explain and compare"
         )
+
+
+def build_extraction_quality_dashboard_artifact(
+    *,
+    generated_at: str | None = None,
+    artifact_date: str | None = None,
+) -> dict[str, Any]:
+    """Build the default extraction-quality dashboard artifact payload."""
+    now = datetime.now(UTC)
+    normalized_generated_at = generated_at or now.replace(microsecond=0).isoformat().replace(
+        "+00:00", "Z"
+    )
+    normalized_artifact_date = artifact_date or now.date().isoformat()
+    return {
+        "artifact_type": REVIEWABLE_FINDINGS_ARTIFACT_TYPE,
+        "schema_version": REVIEWABLE_FINDINGS_SCHEMA_VERSION,
+        "artifact_id": f"extraction-quality-dashboard:{normalized_artifact_date}",
+        "generated_at": normalized_generated_at,
+        "source_artifact_ids": [
+            "extraction_persistence/persistence_contract.json",
+            "coverage/source_authority_readiness.csv",
+        ],
+        "slice": {
+            "slice_id": REVIEWABLE_FINDINGS_FIRST_SLICE_ID,
+            "title": "Extraction Quality Dashboard",
+            "metric_family": "extraction_quality",
+            "description": "Review extraction confidence, blockers, and source-backed citations.",
+        },
+        "findings": [
+            {
+                "finding_id": "finding:ca-pers:fy2024:funded-ratio",
+                "entity": "CA-PERS",
+                "period": "FY2024",
+                "metric_family": "funded_status",
+                "metric": "funded_ratio",
+                "value": 0.81,
+                "confidence": 0.96,
+                "severity": "info",
+                "provenance_refs": ["doc:ca-pers-2024#page=52"],
+                "citations": ["CA-PERS ACFR FY2024 p.52"],
+            },
+            {
+                "finding_id": "finding:ca-pers:fy2023:funded-ratio",
+                "entity": "CA-PERS",
+                "period": "FY2023",
+                "metric_family": "funded_status",
+                "metric": "funded_ratio",
+                "value": 0.79,
+                "confidence": 0.93,
+                "severity": "info",
+                "provenance_refs": ["doc:ca-pers-2023#page=49"],
+                "citations": ["CA-PERS ACFR FY2023 p.49"],
+            },
+        ],
+        "langchain_actions": [
+            {
+                "action": "explain",
+                "question": "Explain the confidence drivers for this finding",
+                "finding_ids": ["finding:ca-pers:fy2024:funded-ratio"],
+            },
+            {
+                "action": "compare",
+                "question": "Compare confidence against the prior period",
+                "finding_ids": [
+                    "finding:ca-pers:fy2024:funded-ratio",
+                    "finding:ca-pers:fy2023:funded-ratio",
+                ],
+            },
+        ],
+    }
+
+
+def write_reviewable_findings_artifact(
+    artifact: Mapping[str, Any],
+    *,
+    output_path: str | Path = REVIEWABLE_FINDINGS_ARTIFACT_PATH,
+) -> Path:
+    """Validate and write the artifact JSON to a deterministic output path."""
+    import json
+
+    validate_reviewable_findings_artifact(artifact)
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(artifact, indent=2) + "\n", encoding="utf-8")
+    return path

--- a/tests/langchain/test_review_artifact_contract.py
+++ b/tests/langchain/test_review_artifact_contract.py
@@ -49,6 +49,18 @@ def _valid_artifact() -> dict[str, Any]:
                 "severity": "info",
                 "provenance_refs": ["doc:ca-pers-2024#page=52"],
                 "citations": ["CA-PERS ACFR FY2024 p.52"],
+            },
+            {
+                "finding_id": "finding:ca-pers:fy2023:funded-ratio",
+                "entity": "CA-PERS",
+                "period": "FY2023",
+                "metric_family": "funded_status",
+                "metric": "funded_ratio",
+                "value": 0.79,
+                "confidence": 0.93,
+                "severity": "info",
+                "provenance_refs": ["doc:ca-pers-2023#page=49"],
+                "citations": ["CA-PERS ACFR FY2023 p.49"],
             }
         ],
         "langchain_actions": [
@@ -112,6 +124,57 @@ def test_artifact_rejects_uncited_or_low_quality_finding_rows() -> None:
     artifact["findings"][0]["confidence"] = 1.2
 
     with pytest.raises(ReviewableFindingsArtifactError, match="confidence"):
+        validate_reviewable_findings_artifact(artifact)
+
+
+def test_artifact_rejects_wrong_slice_id_for_published_path() -> None:
+    artifact = _valid_artifact()
+    artifact["slice"]["slice_id"] = "allocation_peer_compare"
+
+    with pytest.raises(ReviewableFindingsArtifactError, match="slice_id"):
+        validate_reviewable_findings_artifact(artifact)
+
+
+def test_artifact_rejects_boolean_confidence_values() -> None:
+    artifact = _valid_artifact()
+    artifact["findings"][0]["confidence"] = True
+
+    with pytest.raises(ReviewableFindingsArtifactError, match="confidence"):
+        validate_reviewable_findings_artifact(artifact)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (
+            lambda action: action.pop("question"),
+            "question",
+        ),
+        (
+            lambda action: action.__setitem__("question", ""),
+            "question",
+        ),
+        (
+            lambda action: action.pop("finding_ids"),
+            "finding_ids",
+        ),
+        (
+            lambda action: action.__setitem__("finding_ids", []),
+            "finding_ids",
+        ),
+        (
+            lambda action: action.__setitem__("finding_ids", ["finding:missing"]),
+            "unknown findings",
+        ),
+    ],
+)
+def test_artifact_rejects_malformed_langchain_actions(
+    mutation: Any, message: str
+) -> None:
+    artifact = _valid_artifact()
+    mutation(artifact["langchain_actions"][0])
+
+    with pytest.raises(ReviewableFindingsArtifactError, match=message):
         validate_reviewable_findings_artifact(artifact)
 
 

--- a/tests/langchain/test_review_artifact_contract.py
+++ b/tests/langchain/test_review_artifact_contract.py
@@ -10,9 +10,7 @@ import pytest
 
 from pension_data.langchain.review_artifact import (
     REVIEWABLE_FINDINGS_ARTIFACT_PATH,
-    REVIEWABLE_FINDINGS_ARTIFACT_TYPE,
     REVIEWABLE_FINDINGS_SCHEMA_PATH,
-    REVIEWABLE_FINDINGS_SCHEMA_VERSION,
     ReviewableFindingsArtifactError,
     build_extraction_quality_dashboard_artifact,
     reviewable_findings_schema,

--- a/tests/langchain/test_review_artifact_contract.py
+++ b/tests/langchain/test_review_artifact_contract.py
@@ -1,0 +1,128 @@
+"""Contract tests for the first static UI/LangChain review artifact."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pension_data.langchain.review_artifact import (
+    REVIEWABLE_FINDINGS_ARTIFACT_PATH,
+    REVIEWABLE_FINDINGS_ARTIFACT_TYPE,
+    REVIEWABLE_FINDINGS_SCHEMA_PATH,
+    REVIEWABLE_FINDINGS_SCHEMA_VERSION,
+    ReviewableFindingsArtifactError,
+    reviewable_findings_schema,
+    validate_reviewable_findings_artifact,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _valid_artifact() -> dict[str, Any]:
+    return {
+        "artifact_type": REVIEWABLE_FINDINGS_ARTIFACT_TYPE,
+        "schema_version": REVIEWABLE_FINDINGS_SCHEMA_VERSION,
+        "artifact_id": "extraction-quality-dashboard:2026-05-10",
+        "generated_at": "2026-05-10T03:20:00Z",
+        "source_artifact_ids": [
+            "extraction_persistence/persistence_contract.json",
+            "coverage/source_authority_readiness.csv",
+        ],
+        "slice": {
+            "slice_id": "extraction_quality_dashboard",
+            "title": "Extraction Quality Dashboard",
+            "metric_family": "extraction_quality",
+            "description": "Review extraction confidence, blockers, and source-backed citations.",
+        },
+        "findings": [
+            {
+                "finding_id": "finding:ca-pers:fy2024:funded-ratio",
+                "entity": "CA-PERS",
+                "period": "FY2024",
+                "metric_family": "funded_status",
+                "metric": "funded_ratio",
+                "value": 0.81,
+                "confidence": 0.96,
+                "severity": "info",
+                "provenance_refs": ["doc:ca-pers-2024#page=52"],
+                "citations": ["CA-PERS ACFR FY2024 p.52"],
+            }
+        ],
+        "langchain_actions": [
+            {
+                "action": "explain",
+                "question": "Explain the confidence drivers for this finding",
+                "finding_ids": ["finding:ca-pers:fy2024:funded-ratio"],
+            },
+            {
+                "action": "compare",
+                "question": "Compare confidence against the prior period",
+                "finding_ids": [
+                    "finding:ca-pers:fy2024:funded-ratio",
+                    "finding:ca-pers:fy2023:funded-ratio",
+                ],
+            },
+        ],
+    }
+
+
+def test_schema_file_matches_python_contract() -> None:
+    schema_path = REPO_ROOT / REVIEWABLE_FINDINGS_SCHEMA_PATH
+    schema = json.loads(schema_path.read_text())
+
+    assert schema == reviewable_findings_schema()
+    assert schema["artifact_path"] == REVIEWABLE_FINDINGS_ARTIFACT_PATH
+    assert schema["slice"]["first_slice"] == "extraction_quality_dashboard"
+    assert "confidence" in schema["findings"]["required_filter_fields"]
+
+
+def test_valid_artifact_includes_static_ui_and_langchain_contract_fields() -> None:
+    artifact = _valid_artifact()
+
+    validate_reviewable_findings_artifact(artifact)
+
+
+@pytest.mark.parametrize(
+    ("field", "message"),
+    [
+        ("source_artifact_ids", "source_artifact_ids"),
+        ("findings", "findings"),
+        ("langchain_actions", "langchain_actions"),
+    ],
+)
+def test_artifact_requires_publishing_and_interaction_fields(field: str, message: str) -> None:
+    artifact = _valid_artifact()
+    artifact.pop(field)
+
+    with pytest.raises(ReviewableFindingsArtifactError, match=message):
+        validate_reviewable_findings_artifact(artifact)
+
+
+def test_artifact_rejects_uncited_or_low_quality_finding_rows() -> None:
+    artifact = _valid_artifact()
+    artifact["findings"][0]["citations"] = []
+
+    with pytest.raises(ReviewableFindingsArtifactError, match="citations"):
+        validate_reviewable_findings_artifact(artifact)
+
+    artifact = _valid_artifact()
+    artifact["findings"][0]["confidence"] = 1.2
+
+    with pytest.raises(ReviewableFindingsArtifactError, match="confidence"):
+        validate_reviewable_findings_artifact(artifact)
+
+
+def test_docs_pin_the_published_artifact_path_and_contract() -> None:
+    docs = [
+        REPO_ROOT / "docs/UI_LANGCHAIN_OPTIONS.md",
+        REPO_ROOT / "docs/LANGCHAIN_FOUNDATIONS.md",
+        REPO_ROOT / "docs/contracts/reviewable-findings-artifact-contract.md",
+        REPO_ROOT / "docs/data/reviewable-findings/README.md",
+    ]
+    for path in docs:
+        text = path.read_text()
+        assert REVIEWABLE_FINDINGS_ARTIFACT_PATH in text
+        assert "extraction_quality_dashboard" in text

--- a/tests/langchain/test_review_artifact_contract.py
+++ b/tests/langchain/test_review_artifact_contract.py
@@ -61,7 +61,7 @@ def _valid_artifact() -> dict[str, Any]:
                 "severity": "info",
                 "provenance_refs": ["doc:ca-pers-2023#page=49"],
                 "citations": ["CA-PERS ACFR FY2023 p.49"],
-            }
+            },
         ],
         "langchain_actions": [
             {
@@ -168,9 +168,7 @@ def test_artifact_rejects_boolean_confidence_values() -> None:
         ),
     ],
 )
-def test_artifact_rejects_malformed_langchain_actions(
-    mutation: Any, message: str
-) -> None:
+def test_artifact_rejects_malformed_langchain_actions(mutation: Any, message: str) -> None:
     artifact = _valid_artifact()
     mutation(artifact["langchain_actions"][0])
 
@@ -189,3 +187,10 @@ def test_docs_pin_the_published_artifact_path_and_contract() -> None:
         text = path.read_text()
         assert REVIEWABLE_FINDINGS_ARTIFACT_PATH in text
         assert "extraction_quality_dashboard" in text
+
+
+def test_published_artifact_path_contains_valid_contract_payload() -> None:
+    artifact_path = REPO_ROOT / REVIEWABLE_FINDINGS_ARTIFACT_PATH
+    artifact = json.loads(artifact_path.read_text())
+
+    validate_reviewable_findings_artifact(artifact)

--- a/tests/langchain/test_review_artifact_contract.py
+++ b/tests/langchain/test_review_artifact_contract.py
@@ -14,71 +14,20 @@ from pension_data.langchain.review_artifact import (
     REVIEWABLE_FINDINGS_SCHEMA_PATH,
     REVIEWABLE_FINDINGS_SCHEMA_VERSION,
     ReviewableFindingsArtifactError,
+    build_extraction_quality_dashboard_artifact,
     reviewable_findings_schema,
     validate_reviewable_findings_artifact,
+    write_reviewable_findings_artifact,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _valid_artifact() -> dict[str, Any]:
-    return {
-        "artifact_type": REVIEWABLE_FINDINGS_ARTIFACT_TYPE,
-        "schema_version": REVIEWABLE_FINDINGS_SCHEMA_VERSION,
-        "artifact_id": "extraction-quality-dashboard:2026-05-10",
-        "generated_at": "2026-05-10T03:20:00Z",
-        "source_artifact_ids": [
-            "extraction_persistence/persistence_contract.json",
-            "coverage/source_authority_readiness.csv",
-        ],
-        "slice": {
-            "slice_id": "extraction_quality_dashboard",
-            "title": "Extraction Quality Dashboard",
-            "metric_family": "extraction_quality",
-            "description": "Review extraction confidence, blockers, and source-backed citations.",
-        },
-        "findings": [
-            {
-                "finding_id": "finding:ca-pers:fy2024:funded-ratio",
-                "entity": "CA-PERS",
-                "period": "FY2024",
-                "metric_family": "funded_status",
-                "metric": "funded_ratio",
-                "value": 0.81,
-                "confidence": 0.96,
-                "severity": "info",
-                "provenance_refs": ["doc:ca-pers-2024#page=52"],
-                "citations": ["CA-PERS ACFR FY2024 p.52"],
-            },
-            {
-                "finding_id": "finding:ca-pers:fy2023:funded-ratio",
-                "entity": "CA-PERS",
-                "period": "FY2023",
-                "metric_family": "funded_status",
-                "metric": "funded_ratio",
-                "value": 0.79,
-                "confidence": 0.93,
-                "severity": "info",
-                "provenance_refs": ["doc:ca-pers-2023#page=49"],
-                "citations": ["CA-PERS ACFR FY2023 p.49"],
-            },
-        ],
-        "langchain_actions": [
-            {
-                "action": "explain",
-                "question": "Explain the confidence drivers for this finding",
-                "finding_ids": ["finding:ca-pers:fy2024:funded-ratio"],
-            },
-            {
-                "action": "compare",
-                "question": "Compare confidence against the prior period",
-                "finding_ids": [
-                    "finding:ca-pers:fy2024:funded-ratio",
-                    "finding:ca-pers:fy2023:funded-ratio",
-                ],
-            },
-        ],
-    }
+    return build_extraction_quality_dashboard_artifact(
+        generated_at="2026-05-10T03:20:00Z",
+        artifact_date="2026-05-10",
+    )
 
 
 def test_schema_file_matches_python_contract() -> None:
@@ -194,3 +143,25 @@ def test_published_artifact_path_contains_valid_contract_payload() -> None:
     artifact = json.loads(artifact_path.read_text())
 
     validate_reviewable_findings_artifact(artifact)
+
+
+def test_generator_includes_required_acceptance_fields() -> None:
+    artifact = _valid_artifact()
+
+    finding = artifact["findings"][0]
+    assert finding["entity"]
+    assert finding["period"]
+    assert finding["metric_family"]
+    assert finding["confidence"] >= 0
+    assert finding["provenance_refs"]
+
+
+def test_writer_persists_valid_artifact_json(tmp_path: Path) -> None:
+    artifact = _valid_artifact()
+    output = tmp_path / "reviewable-findings.json"
+
+    written = write_reviewable_findings_artifact(artifact, output_path=output)
+
+    assert written == output
+    persisted = json.loads(output.read_text(encoding="utf-8"))
+    validate_reviewable_findings_artifact(persisted)


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:321 -->
> **Source:** Issue #321

Closes #321

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The roadmap identifies a higher-quality analyst-facing UI and LangChain interaction layer as intentional gaps. The options doc recommends a static web UI backed by generated artifacts and GitHub Actions before any paid server or full desktop app. The weekly review process needs a concrete first artifact so issue generation does not stay at the vague "build UI" level.

#### Tasks
- [x] Choose the first artifact slice: funding trend, allocation peer compare, holdings overlap, or extraction quality dashboard.
- [x] Define the minimal findings JSON schema consumed by the static UI and LangChain explainers.
- [x] Add a generation command or documented artifact path under `docs/data/` or a release artifact plan.
- [x] Add tests or schema validation for the artifact contract.
- [x] Document how a human reviewer should inspect the generated artifact in the weekly review packet.

#### Acceptance criteria
- [x] The first UI/LangChain artifact has a stable machine-readable schema.
- [x] The artifact includes provenance references, confidence, metric family, entity, and period fields where applicable.
- [x] The path supports a static UI without requiring users to run the repo locally.

<!-- auto-status-summary:end -->