### PR TITLE
Issue #429: document chain-vs-published artifact_path layering

### DIFF
--- a/docs/contracts/reviewable-findings-artifact-contract.md
+++ b/docs/contracts/reviewable-findings-artifact-contract.md
@@ -66,7 +66,7 @@ different invariants:
 | Layer | Surface | `artifact_path` invariant |
 | --- | --- | --- |
 | Chain step | `ExplainResponse.metadata` / `CompareResponse.metadata` (`findings_explain.py`, `findings_compare.py`) | Initialized to `None`. The chain does not know the persistence path it will be written to; it returns transient request output. |
-| Export step | `FindingsExportArtifact` built by `build_findings_export_artifact` in `findings_export.py` | The persistence bridge: takes the chain's `request_id`, `summary`, and `citations`, attaches a non-empty `artifact_path`, and stamps `generated_at`. |
+| Export step | `FindingsExportArtifact` built by `build_findings_export_artifact` in `findings_export.py` | The persistence bridge: takes the chain's `request_id`, `summary`, and `citations`, stamps `generated_at`, and attaches an `artifact_path` (the helper accepts `artifact_path=None`, so the non-empty invariant only applies when the export step is invoked with a concrete publication path; intermediate `FindingsExportArtifact` instances without a publication target legitimately carry `artifact_path=None`). |
 | Published payload | The JSON written to the export path (and the recorded-output canaries in `tests/langchain/recorded_outputs/`) | `artifact_path` must be a non-empty string. The eval-harness schema check (`eval_harness.py`) and `tests/langchain/test_review_artifact_contract.py` both enforce this against the published payload, never against chain metadata. |
 
 This split is intentional. The chain step is callable from request paths that do not persist
@@ -76,8 +76,11 @@ the export persistence step runs.
 
 If a live-runner script (`eval_harness._load_live_output` -> `live_command`) emits raw chain
 metadata without first going through `build_findings_export_artifact`, the eval-harness schema
-check will fail with `schema invalid: findings_(explain|compare) output requires non-empty
-string field 'artifact_path'`. The end-to-end smoke test in
+check fails with one of the literal messages
+`schema invalid: findings_explain output requires non-empty string field 'artifact_path'` or
+`schema invalid: findings_compare output requires non-empty string field 'artifact_path'`
+(the harness emits a separate per-action message; see `eval_harness.py` checks for
+`findings_explain` and `findings_compare`). The end-to-end smoke test in
 `tests/langchain/test_chain_to_artifact_pipeline.py` exercises the chain → export →
 eval-harness path against this contract.
 

--- a/docs/contracts/reviewable-findings-artifact-contract.md
+++ b/docs/contracts/reviewable-findings-artifact-contract.md
@@ -57,6 +57,33 @@ The artifact advertises two asynchronous actions:
 
 Outputs must include `request_id`, `generated_at`, `summary`, `citations`, and `artifact_path`.
 
+### Chain Output vs Published Artifact
+
+The five required output fields are enforced at the **published-artifact** layer, not on the
+in-process chain step's response metadata. There are two layers in the pipeline and they hold
+different invariants:
+
+| Layer | Surface | `artifact_path` invariant |
+| --- | --- | --- |
+| Chain step | `ExplainResponse.metadata` / `CompareResponse.metadata` (`findings_explain.py`, `findings_compare.py`) | Initialized to `None`. The chain does not know the persistence path it will be written to; it returns transient request output. |
+| Export step | `FindingsExportArtifact` built by `build_findings_export_artifact` in `findings_export.py` | The persistence bridge: takes the chain's `request_id`, `summary`, and `citations`, attaches a non-empty `artifact_path`, and stamps `generated_at`. |
+| Published payload | The JSON written to the export path (and the recorded-output canaries in `tests/langchain/recorded_outputs/`) | `artifact_path` must be a non-empty string. The eval-harness schema check (`eval_harness.py`) and `tests/langchain/test_review_artifact_contract.py` both enforce this against the published payload, never against chain metadata. |
+
+This split is intentional. The chain step is callable from request paths that do not persist
+their output (e.g. unit-tested route adapters; `tests/langchain/test_findings_chains.py` asserts
+the route-level `artifact_path` is `None`). The published-artifact contract only attaches once
+the export persistence step runs.
+
+If a live-runner script (`eval_harness._load_live_output` -> `live_command`) emits raw chain
+metadata without first going through `build_findings_export_artifact`, the eval-harness schema
+check will fail with `schema invalid: findings_(explain|compare) output requires non-empty
+string field 'artifact_path'`. The end-to-end smoke test in
+`tests/langchain/test_chain_to_artifact_pipeline.py` exercises the chain → export →
+eval-harness path against this contract.
+
+See `docs/reports/reviewable-findings-contract-audit.md` for the audit that first surfaced this
+two-layer model.
+
 ## Generation Plan
 
 The first generator should read extraction persistence outputs and source-readiness artifacts, then

--- a/tests/langchain/test_chain_to_artifact_pipeline.py
+++ b/tests/langchain/test_chain_to_artifact_pipeline.py
@@ -221,9 +221,9 @@ def test_eval_harness_flags_artifact_path_when_export_step_is_skipped(
 def test_contract_doc_documents_chain_output_vs_published_artifact() -> None:
     """The contract doc must carry the layering subsection this test backs up."""
     repo_root = Path(__file__).resolve().parents[2]
-    contract = (
-        repo_root / "docs/contracts/reviewable-findings-artifact-contract.md"
-    ).read_text(encoding="utf-8")
+    contract = (repo_root / "docs/contracts/reviewable-findings-artifact-contract.md").read_text(
+        encoding="utf-8"
+    )
 
     assert "Chain Output vs Published Artifact" in contract
     assert "build_findings_export_artifact" in contract

--- a/tests/langchain/test_chain_to_artifact_pipeline.py
+++ b/tests/langchain/test_chain_to_artifact_pipeline.py
@@ -1,0 +1,231 @@
+"""End-to-end smoke test: chain step -> export step -> eval-harness schema check.
+
+This exercises the layering documented in
+`docs/contracts/reviewable-findings-artifact-contract.md` (Chain Output vs Published
+Artifact): the chain step intentionally leaves `metadata.artifact_path=None`, the export
+step is the persistence bridge that attaches a non-empty `artifact_path`, and the
+eval-harness schema check enforces non-empty `artifact_path` against the published payload.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from pension_data.langchain.eval_harness import evaluate_dataset, load_eval_dataset
+from pension_data.langchain.findings_common import FindingSlice
+from pension_data.langchain.findings_explain import ExplainRequest, run_findings_explain_chain
+from pension_data.langchain.findings_export import build_findings_export_artifact
+
+
+class _StaticChain:
+    def __init__(self, output: Mapping[str, Any]) -> None:
+        self.output = output
+
+    def invoke(self, values: Mapping[str, Any]) -> Mapping[str, Any]:
+        del values
+        return self.output
+
+
+def _published_payload_from_chain(
+    *,
+    chain_output: Mapping[str, Any],
+    artifact_path: str,
+) -> dict[str, Any]:
+    """Drive chain -> export -> serializable published payload.
+
+    Mirrors the production pipeline: the chain returns transient metadata, the export
+    step attaches the persistence path, and the published payload is what the
+    eval-harness schema check sees.
+    """
+    finding_slice = FindingSlice(
+        slice_id="slice:pipeline-smoke",
+        plan_id="CA-PERS",
+        plan_period="FY2024",
+        metrics={"funded_ratio": 0.81},
+        citations=("doc:funded#p.52",),
+    )
+    response = run_findings_explain_chain(
+        request=ExplainRequest(
+            question="Why did the funded ratio improve in FY2024?",
+            finding_slice=finding_slice,
+        ),
+        chain=_StaticChain(chain_output),
+        request_id="fx:pipeline-smoke",
+    )
+
+    # Layer-1 invariant: chain metadata never carries an artifact_path.
+    assert response.status == "ok"
+    assert response.result is not None
+    assert response.metadata.artifact_path is None
+
+    export = build_findings_export_artifact(
+        artifact_type="explain",
+        request_id=response.metadata.request_id,
+        payload={
+            "summary": response.result.summary,
+            "key_drivers": list(response.result.key_drivers),
+            "caveats": list(response.result.caveats),
+        },
+        citations=response.result.citations,
+        artifact_path=artifact_path,
+    )
+
+    # Layer-2 invariant: export step attaches a non-empty artifact_path.
+    assert export.artifact_path == artifact_path
+
+    return {
+        "request_id": export.request_id,
+        "generated_at": export.generated_at,
+        "artifact_path": export.artifact_path,
+        "summary": export.payload["summary"],
+        "key_drivers": list(export.payload["key_drivers"]),
+        "caveats": list(export.payload["caveats"]),
+        "citations": list(export.citations),
+    }
+
+
+def _write_dataset_for_recorded_output(
+    tmp_path: Path,
+    *,
+    recorded_filename: str,
+    payload: Mapping[str, Any],
+    expected_citations: tuple[str, ...],
+) -> Path:
+    recorded_path = tmp_path / recorded_filename
+    recorded_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    dataset = {
+        "version": 1,
+        "thresholds": {
+            "min_schema_validity_rate": 1.0,
+            "min_citation_coverage_rate": 1.0,
+            "min_no_hallucination_rate": 1.0,
+            "min_safety_pass_rate": 1.0,
+        },
+        "cases": [
+            {
+                "id": "pipeline-smoke-explain",
+                "domain": "funded_ratio",
+                "feature": "findings_explain",
+                "question": "Why did the funded ratio improve in FY2024?",
+                "recorded_output": recorded_filename,
+                "expected_citations": list(expected_citations),
+            }
+        ],
+    }
+    dataset_path = tmp_path / "pipeline-smoke-dataset.json"
+    dataset_path.write_text(json.dumps(dataset), encoding="utf-8")
+    return dataset_path
+
+
+def test_chain_export_eval_pipeline_passes_when_export_step_attaches_artifact_path(
+    tmp_path: Path,
+) -> None:
+    """Full chain -> export -> eval-harness path produces zero artifact_path defects."""
+    published = _published_payload_from_chain(
+        chain_output={
+            "summary": "Funded ratio improved as assets outpaced liabilities.",
+            "key_drivers": ["Actuarial assets rose faster than liabilities"],
+            "caveats": ["Single period; review with contribution notes"],
+            "citations": ["doc:funded#p.52"],
+        },
+        artifact_path="artifacts/langchain/findings-pipeline-smoke.json",
+    )
+    dataset_path = _write_dataset_for_recorded_output(
+        tmp_path,
+        recorded_filename="findings_pipeline_smoke_explain.json",
+        payload=published,
+        expected_citations=("doc:funded#p.52",),
+    )
+
+    dataset = load_eval_dataset(dataset_path)
+    report = evaluate_dataset(dataset, mode="mock")
+
+    assert report.status == "pass", report.failures
+    assert len(report.case_results) == 1
+    case = report.case_results[0]
+    assert case.schema_valid, case.details
+    assert case.pass_status, case.details
+    # No detail should ever mention an artifact_path defect on the published payload.
+    assert not any("artifact_path" in detail for detail in case.details), case.details
+
+
+def test_eval_harness_flags_artifact_path_when_export_step_is_skipped(
+    tmp_path: Path,
+) -> None:
+    """Skipping the export persistence step surfaces the documented schema defect.
+
+    This is the negative side of the chain-vs-published contract: emitting raw chain
+    metadata (no `artifact_path`) without first going through `build_findings_export_artifact`
+    must trip the eval-harness `'artifact_path'` schema check.
+    """
+    finding_slice = FindingSlice(
+        slice_id="slice:pipeline-smoke",
+        plan_id="CA-PERS",
+        plan_period="FY2024",
+        metrics={"funded_ratio": 0.81},
+        citations=("doc:funded#p.52",),
+    )
+    response = run_findings_explain_chain(
+        request=ExplainRequest(
+            question="Why did the funded ratio improve in FY2024?",
+            finding_slice=finding_slice,
+        ),
+        chain=_StaticChain(
+            {
+                "summary": "Funded ratio improved as assets outpaced liabilities.",
+                "key_drivers": ["Actuarial assets rose faster than liabilities"],
+                "caveats": ["Single period; review with contribution notes"],
+                "citations": ["doc:funded#p.52"],
+            }
+        ),
+        request_id="fx:pipeline-smoke-negative",
+    )
+    assert response.result is not None
+    assert response.metadata.artifact_path is None
+
+    # Publish chain metadata directly, bypassing the export step. This is the failure
+    # mode the contract subsection warns about.
+    raw_chain_payload = {
+        "request_id": response.metadata.request_id,
+        "generated_at": response.metadata.generated_at,
+        "summary": response.result.summary,
+        "key_drivers": list(response.result.key_drivers),
+        "caveats": list(response.result.caveats),
+        "citations": list(response.result.citations),
+        "artifact_path": response.metadata.artifact_path,
+    }
+    dataset_path = _write_dataset_for_recorded_output(
+        tmp_path,
+        recorded_filename="findings_pipeline_smoke_explain_no_export.json",
+        payload=raw_chain_payload,
+        expected_citations=("doc:funded#p.52",),
+    )
+
+    dataset = load_eval_dataset(dataset_path)
+    report = evaluate_dataset(dataset, mode="mock")
+
+    assert report.status == "fail"
+    assert len(report.case_results) == 1
+    case = report.case_results[0]
+    assert not case.schema_valid
+    assert any(
+        "findings_explain output requires non-empty string field 'artifact_path'" in detail
+        for detail in case.details
+    ), case.details
+
+
+def test_contract_doc_documents_chain_output_vs_published_artifact() -> None:
+    """The contract doc must carry the layering subsection this test backs up."""
+    repo_root = Path(__file__).resolve().parents[2]
+    contract = (
+        repo_root / "docs/contracts/reviewable-findings-artifact-contract.md"
+    ).read_text(encoding="utf-8")
+
+    assert "Chain Output vs Published Artifact" in contract
+    assert "build_findings_export_artifact" in contract
+    assert "tests/langchain/test_chain_to_artifact_pipeline.py" in contract
+    assert "docs/reports/reviewable-findings-contract-audit.md" in contract

--- a/tests/langchain/test_chain_to_artifact_pipeline.py
+++ b/tests/langchain/test_chain_to_artifact_pipeline.py
@@ -228,4 +228,19 @@ def test_contract_doc_documents_chain_output_vs_published_artifact() -> None:
     assert "Chain Output vs Published Artifact" in contract
     assert "build_findings_export_artifact" in contract
     assert "tests/langchain/test_chain_to_artifact_pipeline.py" in contract
-    assert "docs/reports/reviewable-findings-contract-audit.md" in contract
+
+    audit_report_path = "docs/reports/reviewable-findings-contract-audit.md"
+    occurrences = contract.count(audit_report_path)
+    assert occurrences == 1, (
+        f"audit report path must be cross-referenced exactly once, found {occurrences}"
+    )
+
+    section_start = contract.index("### Chain Output vs Published Artifact")
+    next_section_marker = "\n## "
+    section_end_idx = contract.find(next_section_marker, section_start)
+    if section_end_idx == -1:
+        section_end_idx = len(contract)
+    layering_section = contract[section_start:section_end_idx]
+    assert audit_report_path in layering_section, (
+        "audit report cross-reference must live inside the layering subsection"
+    )


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:429 -->
> **Source:** Issue #429

Closes #429

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The reviewable-findings contract audit (PR #428, `docs/reports/reviewable-findings-contract-audit.md`) classifies the `artifact_path` LangChain output field as `implemented-and-tested`. PR #428's Copilot review thread (https://github.com/stranske/Pension-Data/pull/428#pullrequestreview-9c4f43a4-... `PRRT_kwDORbgH9M6B83QN`) pushed back: the chain step itself never populates `artifact_path` — `findings_explain.py:78` and `findings_compare.py:80` both initialize `artifact_path=None` in metadata; `tests/langchain/test_findings_chains.py:236` asserts the route-level `artifact_path is None`. `eval_harness.py:273-285,293-305` enforces non-empty `artifact_path` only against the live-runner or recorded mock output.

The audit's disposition is defensible because the contract is satisfied at the **export persistence layer** (`findings_export.py`) and at the **recorded-output canary** (`tests/langchain/test_review_artifact_contract.py:74-93`) which asserts `artifact_path` is a non-empty string in `tests/langchain/recorded_outputs/findings_*.json`. The chain step intentionally leaves `artifact_path=None` because the export step owns the published artifact path.

But the chain → export → eval-harness pipeline is not exercised end-to-end in tests. If the live-runner script (`eval_harness._load_live_output` -> `live_command`) skips the export persistence step, the eval-harness schema check fails with `schema invalid: findings_(explain|compare) output requires non-empty string field 'artifact_path'`. There is no current smoke test that proves the live-runner emits the post-export payload.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [stranske/Pension-Data#428](https://github.com/stranske/Pension-Data/issues/428)
- [#428](https://github.com/stranske/Pension-Data/issues/428)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] `docs/contracts/reviewable-findings-artifact-contract.md` should add a "layering" note distinguishing chain-step metadata (transient, `artifact_path` optional) from the published artifact (mandatory non-empty `artifact_path`).
- [ ] `docs/reports/reviewable-findings-contract-audit.md` (already merged from #428) should be cross-linked when the contract doc is updated.
- [ ] Add an end-to-end smoke test that drives the chain step → export step → eval-harness schema check using one synthetic case, proving the live-runner output always satisfies the schema canary. Acceptable locations: `tests/langchain/test_eval_harness.py` or a new `tests/langchain/test_chain_to_artifact_pipeline.py`.

#### Acceptance criteria
- [ ] Contract doc has a "Chain output vs published artifact" subsection explaining the two-layer model: chain metadata may carry `artifact_path=None`, the published artifact must include a non-empty `artifact_path`, and the export step is the persistence bridge.
- [ ] One pytest case (mock-mode is fine) reproduces the chain → export → eval-harness path and asserts the eval-harness schema validation reports zero `artifact_path` defects.
- [ ] The audit report `docs/reports/reviewable-findings-contract-audit.md` is cross-referenced once from the contract doc's new subsection.

<!-- auto-status-summary:end -->