### PR TITLE
style: apply black to test_chain_to_artifact_pipeline.py (follow-up #429)

### DIFF
--- a/tests/langchain/test_chain_to_artifact_pipeline.py
+++ b/tests/langchain/test_chain_to_artifact_pipeline.py
@@ -231,9 +231,9 @@ def test_contract_doc_documents_chain_output_vs_published_artifact() -> None:
 
     audit_report_path = "docs/reports/reviewable-findings-contract-audit.md"
     occurrences = contract.count(audit_report_path)
-    assert occurrences == 1, (
-        f"audit report path must be cross-referenced exactly once, found {occurrences}"
-    )
+    assert (
+        occurrences == 1
+    ), f"audit report path must be cross-referenced exactly once, found {occurrences}"
 
     section_start = contract.index("### Chain Output vs Published Artifact")
     next_section_marker = "\n## "
@@ -241,6 +241,6 @@ def test_contract_doc_documents_chain_output_vs_published_artifact() -> None:
     if section_end_idx == -1:
         section_end_idx = len(contract)
     layering_section = contract[section_start:section_end_idx]
-    assert audit_report_path in layering_section, (
-        "audit report cross-reference must live inside the layering subsection"
-    )
+    assert (
+        audit_report_path in layering_section
+    ), "audit report cross-reference must live inside the layering subsection"


### PR DESCRIPTION
Bounded follow-up to merged PR #430 / issue #429.

## Why

CI run [25849320616](https://github.com/stranske/Pension-Data/actions/runs/25849468919) flagged a black format violation on the merged head \`f71f5edeaeb358a2f981f3185110b63568df763b\`:

\`\`\`
would reformat tests/langchain/test_chain_to_artifact_pipeline.py
1 file would be reformatted, 317 files would be left unchanged.
\`\`\`

\`Gate / gate\` was green so the merge proceeded, but main now has a format-check failure for this file. The anthropic verifier comparison report also flagged this (PR #430 verifier comment at 08:28:58Z).

## Change

Apply repo-pinned black (\`pyproject.toml\` — line-length=100, py312) to the test file. The reformat converts two \`assert ..., (\\n  f\"...\"\\n)\` blocks into the older \`assert (\\n  ...\\n), f\"...\"\` parenthesized-assert style that the configured black emits.

No functional change — same assertions, same messages, same test outcomes.

## Validation

\`\`\`
$ black --check tests/langchain/test_chain_to_artifact_pipeline.py
All done! ✨ 🍰 ✨
1 file would be left unchanged.

$ pytest tests/langchain/test_chain_to_artifact_pipeline.py -q --no-cov
3 passed in 0.32s
\`\`\`

Closes the lint-format CI gap for #429. No \`verify:*\` label needed — this is a style/formatting follow-up; once it merges and CI is clean, source issue #429 can be closed.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- pr-preamble:start -->
<!-- meta:issue:429 -->
> **Source:** Issue #429

Closes #429

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The reviewable-findings contract audit (PR #428, `docs/reports/reviewable-findings-contract-audit.md`) classifies the `artifact_path` LangChain output field as `implemented-and-tested`. PR #428's Copilot review thread (https://github.com/stranske/Pension-Data/pull/428#pullrequestreview-9c4f43a4-... `PRRT_kwDORbgH9M6B83QN`) pushed back: the chain step itself never populates `artifact_path` — `findings_explain.py:78` and `findings_compare.py:80` both initialize `artifact_path=None` in metadata; `tests/langchain/test_findings_chains.py:236` asserts the route-level `artifact_path is None`. `eval_harness.py:273-285,293-305` enforces non-empty `artifact_path` only against the live-runner or recorded mock output.

The audit's disposition is defensible because the contract is satisfied at the **export persistence layer** (`findings_export.py`) and at the **recorded-output canary** (`tests/langchain/test_review_artifact_contract.py:74-93`) which asserts `artifact_path` is a non-empty string in `tests/langchain/recorded_outputs/findings_*.json`. The chain step intentionally leaves `artifact_path=None` because the export step owns the published artifact path.

But the chain → export → eval-harness pipeline is not exercised end-to-end in tests. If the live-runner script (`eval_harness._load_live_output` -> `live_command`) skips the export persistence step, the eval-harness schema check fails with `schema invalid: findings_(explain|compare) output requires non-empty string field 'artifact_path'`. There is no current smoke test that proves the live-runner emits the post-export payload.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [stranske/Pension-Data#428](https://github.com/stranske/Pension-Data/issues/428)
- [#428](https://github.com/stranske/Pension-Data/issues/428)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] `docs/contracts/reviewable-findings-artifact-contract.md` should add a "layering" note distinguishing chain-step metadata (transient, `artifact_path` optional) from the published artifact (mandatory non-empty `artifact_path`).
- [ ] `docs/reports/reviewable-findings-contract-audit.md` (already merged from #428) should be cross-linked when the contract doc is updated.
- [ ] Add an end-to-end smoke test that drives the chain step → export step → eval-harness schema check using one synthetic case, proving the live-runner output always satisfies the schema canary. Acceptable locations: `tests/langchain/test_eval_harness.py` or a new `tests/langchain/test_chain_to_artifact_pipeline.py`.

#### Acceptance criteria
- [ ] Contract doc has a "Chain output vs published artifact" subsection explaining the two-layer model: chain metadata may carry `artifact_path=None`, the published artifact must include a non-empty `artifact_path`, and the export step is the persistence bridge.
- [ ] One pytest case (mock-mode is fine) reproduces the chain → export → eval-harness path and asserts the eval-harness schema validation reports zero `artifact_path` defects.
- [ ] The audit report `docs/reports/reviewable-findings-contract-audit.md` is cross-referenced once from the contract doc's new subsection.

<!-- auto-status-summary:end -->