### PR TITLE
chore: sync workflow templates

### DIFF
--- a/scripts/langchain/task_validator.py
+++ b/scripts/langchain/task_validator.py
@@ -242,7 +242,9 @@ def triage_tasks(tasks: list[str]) -> dict[str, list[Any]]:
         tasks: List of task strings to triage
 
     Returns:
-        Dictionary with "clean" (list[str]) and "flagged" (list[dict]) keys
+        Dictionary with "clean" (list[str]), "clean_items" (list[dict] with
+        task/index pairs), and "flagged" (list[dict] with task, warnings, and
+        index) keys
     """
     clean: list[str] = []
     clean_items: list[dict[str, Any]] = []

--- a/scripts/langchain/trace_utils.py
+++ b/scripts/langchain/trace_utils.py
@@ -82,11 +82,34 @@ def _invoke_accepts_config(invoke: Any) -> bool:
 
 
 def _is_unsupported_config_error(exc: TypeError) -> bool:
-    message = str(exc)
-    return "config" in message and (
-        "unexpected keyword argument" in message
-        or "got an unexpected keyword" in message
-        or "positional-only" in message
+    message = str(exc).lower()
+    no_keyword_support = (
+        "takes no keyword argument" in message
+        or "takes no keyword arguments" in message
+        or "does not take keyword argument" in message
+        or "does not take keyword arguments" in message
+        or "doesn't take keyword argument" in message
+        or "doesn't take keyword arguments" in message
+    )
+    unsupported_config_message = no_keyword_support or (
+        "config" in message
+        and (
+            "unexpected keyword argument" in message
+            or "got an unexpected keyword" in message
+            or "positional-only" in message
+        )
+    )
+    return unsupported_config_message and _is_direct_call_type_error(exc)
+
+
+def _is_direct_call_type_error(exc: TypeError) -> bool:
+    """Return true when Python rejected the call before entering invoke()."""
+
+    tb = exc.__traceback__
+    # TypeErrors raised by the runnable include an inner traceback frame.
+    # Direct argument-binding failures from builtins/C shims stop at this call site.
+    return (
+        tb is not None and tb.tb_frame.f_code is invoke_with_trace.__code__ and tb.tb_next is None
     )
 
 


### PR DESCRIPTION
## Sync Summary

### Files Updated
- trace_utils.py: Shared LangSmith trace metadata helpers for LangChain workflows
- task_validator.py: Task validator - refines generated issue tasks for actionability

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `27b0dea60b315953cab9a593a9ec50e230e3d826`
**Template hash:** `fdf56e1872bf`
**Sync branch:** `sync/workflows-fdf56e1872bf`
**Consumer repo:** `stranske/Pension-Data`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Pension-Data","source_repository":"stranske/Workflows","source_sha":"27b0dea60b315953cab9a593a9ec50e230e3d826","template_hash":"fdf56e1872bf","sync_branch":"sync/workflows-fdf56e1872bf","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"25934434310","run_attempt":"1","changes_count":2} -->