### PR TITLE
Follow-up #445: complete LangSmith verifier trace gaps

### DIFF
--- a/docs/runbooks/langsmith-fleet.md
+++ b/docs/runbooks/langsmith-fleet.md
@@ -30,8 +30,12 @@ fields (validated against the v1 schema):
 
 Records also carry `stage` (matches the operation name), `latency_ms`,
 `max_rows`, `trace_event_count`, and — when present — `trace_id`, `trace_url`,
-`provider`, `model`, and `github_pr`. Raw prompts, generated SQL, member
-data, and result rows are never written to the artifact.
+`provider`, `model`, and `github_pr`. The live LangSmith sink emits the
+sanitized lifecycle stages `nl.prompt.received`, `nl.sql.generated`,
+`nl.sql.validated`, `nl.sql.executed`, and `nl.sql.error` as applicable; the
+route copies the latest sink trace ID/URL into the fleet artifact and audit
+event when callers do not pass explicit trace values. Raw prompts, generated
+SQL, member data, and result rows are never written to the artifact.
 
 ## Status semantics
 
@@ -74,6 +78,22 @@ production wiring point. Callers may also pass `fleet_trace_id`,
 PR context through. Bench/replay scripts can call
 `pension_data.observability.langsmith_fleet.build_fleet_records_from_response`
 directly and use `write_fleet_records` for one-off artifact writes.
+
+## Verifier checklist
+
+For issue `#445` completion, the dashboard contract is satisfied when:
+
+1. Successful NL requests produce `sql-generation`, `validation`, and
+   `execution` fleet records with `status="success"` when `LANGSMITH_API_KEY`
+   is set, or `status="no_secret"` without the key.
+2. Validation failures set the `validation` operation to `error`, skip later
+   operations, and include `sql_validation_status` plus `read_only_status` in
+   the domain payload.
+3. Replay/evaluation callers provide `replay_dataset_id`, `replay_run_id`, or
+   `replay_match_status`; otherwise the replay operation is intentionally
+   `skipped`.
+4. Trace correlation is visible in both the artifact and audit payload through
+   `trace_id`/`trace_url` or `langsmith_trace_id`/`langsmith_trace_url`.
 
 ## Disabling emission
 

--- a/src/pension_data/api/routes/nl.py
+++ b/src/pension_data/api/routes/nl.py
@@ -76,6 +76,12 @@ def run_nl_query_endpoint(
         trace_sink=active_trace_sink,
         policy=policy,
     )
+    resolved_fleet_trace_id = fleet_trace_id or _trace_sink_attr(
+        active_trace_sink, "latest_trace_id"
+    )
+    resolved_fleet_trace_url = fleet_trace_url or _trace_sink_attr(
+        active_trace_sink, "latest_trace_url"
+    )
     entry = build_nl_operation_log_entry(
         request=request,
         response=response,
@@ -102,8 +108,8 @@ def run_nl_query_endpoint(
                 query_category=normalized_category or "unspecified",
                 provider=provider if provider != "unknown" else None,
                 model=model if model != "unknown" else None,
-                trace_id=fleet_trace_id,
-                trace_url=fleet_trace_url,
+                trace_id=resolved_fleet_trace_id,
+                trace_url=resolved_fleet_trace_url,
                 github_pr=fleet_github_pr,
             ),
             response=response,
@@ -126,8 +132,8 @@ def run_nl_query_endpoint(
             "error_code": response.error.code if response.error is not None else None,
             "provider": entry.provider,
             "model": entry.model,
-            "langsmith_trace_id": fleet_trace_id,
-            "langsmith_trace_url": fleet_trace_url,
+            "langsmith_trace_id": resolved_fleet_trace_id,
+            "langsmith_trace_url": resolved_fleet_trace_url,
             "langsmith_query_category": (
                 query_category.strip() if query_category and query_category.strip() else None
             ),
@@ -141,3 +147,8 @@ def run_nl_query_endpoint(
             event=event_payload,
         ),
     )
+
+
+def _trace_sink_attr(trace_sink: LangSmithTraceSink | None, name: str) -> str | None:
+    value = getattr(trace_sink, name, None)
+    return value.strip() if isinstance(value, str) and value.strip() else None

--- a/src/pension_data/api/routes/nl.py
+++ b/src/pension_data/api/routes/nl.py
@@ -106,6 +106,7 @@ def run_nl_query_endpoint(
             context=FleetRunContext(
                 run_id=response.metadata.request_id,
                 query_category=normalized_category or "unspecified",
+                session_id=entry.correlation_id,
                 provider=provider if provider != "unknown" else None,
                 model=model if model != "unknown" else None,
                 trace_id=resolved_fleet_trace_id,

--- a/src/pension_data/langchain/nl_sql_chain.py
+++ b/src/pension_data/langchain/nl_sql_chain.py
@@ -37,18 +37,33 @@ NL_TO_SQL_TRACE_STAGES_SUCCESS: tuple[str, ...] = (
     "nl.sql.executed",
 )
 NL_TO_SQL_TRACE_STAGE_ERROR: str = "nl.sql.error"
-NL_TO_SQL_TRACE_ERROR_STAGES: tuple[str, ...] = ("validation", "execution")
+NL_TO_SQL_TRACE_ERROR_STAGES: tuple[str, ...] = ("request", "validation", "execution")
 
 
 def nl_to_sql_trace_stages(
-    *, status: NLToSQLStatus, error_stage: Literal["validation", "execution"] = "execution"
+    *,
+    status: NLToSQLStatus,
+    error_stage: Literal["request", "validation", "execution"] = "execution",
 ) -> tuple[str, ...]:
-    """Return ordered lifecycle stages that should be traced for a run status."""
+    """Return ordered lifecycle stages that should be traced for a run status.
+
+    The ``error_stage`` argument names the point in the lifecycle where the
+    error originated and therefore which prior stages were already emitted:
+
+    - ``request``: pre-SQL failure (request bounds, ambiguous prompt). Only
+      ``nl.prompt.received`` was emitted before ``nl.sql.error``.
+    - ``validation``: SQL was generated but rejected by the read-only safety
+      policy. ``nl.prompt.received`` and ``nl.sql.generated`` were emitted.
+    - ``execution``: SQL was generated and validated but failed during query
+      execution. All three pre-execution stages were emitted.
+    """
 
     if status == "ok":
         return NL_TO_SQL_TRACE_STAGES_SUCCESS
-    if error_stage == "validation":
+    if error_stage == "request":
         return (NL_TO_SQL_TRACE_STAGES_SUCCESS[0], NL_TO_SQL_TRACE_STAGE_ERROR)
+    if error_stage == "validation":
+        return (*NL_TO_SQL_TRACE_STAGES_SUCCESS[:2], NL_TO_SQL_TRACE_STAGE_ERROR)
     return (*NL_TO_SQL_TRACE_STAGES_SUCCESS[:3], NL_TO_SQL_TRACE_STAGE_ERROR)
 
 
@@ -331,6 +346,12 @@ def run_nl_sql_chain(
     ):
         sql: str | None = None
         active_policy = policy or default_nl_query_policy()
+        _emit_trace(
+            trace_sink,
+            emitted_events,
+            stage="nl.prompt.received",
+            payload={"request_id": request_id, "question": request.question},
+        )
         try:
             if request.max_rows < 1:
                 raise NLRequestValidationError("max_rows must be >= 1")
@@ -346,27 +367,22 @@ def run_nl_sql_chain(
                 )
             params = _normalize_params(request.params)
             question = validate_nl_prompt(request.question)
-            _emit_trace(
-                trace_sink,
-                emitted_events,
-                stage="nl.prompt.received",
-                payload={"request_id": request_id, "question": question},
-            )
 
             generated = chain.invoke({"question": question, "dialect": "sqlite"})
-            sql = validate_sql_policy(_extract_sql(generated), policy=active_policy)
-            if active_policy.require_source_document_id:
-                selected_columns = extract_selected_columns(sql)
-                if "source_document_id" not in set(selected_columns):
-                    raise SQLSafetyValidationError(
-                        "generated SQL must include source_document_id in SELECT for provenance metadata"
-                    )
+            sql = _extract_sql(generated)
             _emit_trace(
                 trace_sink,
                 emitted_events,
                 stage="nl.sql.generated",
                 payload={"request_id": request_id, "sql": sql},
             )
+            sql = validate_sql_policy(sql, policy=active_policy)
+            if active_policy.require_source_document_id:
+                selected_columns = extract_selected_columns(sql)
+                if "source_document_id" not in set(selected_columns):
+                    raise SQLSafetyValidationError(
+                        "generated SQL must include source_document_id in SELECT for provenance metadata"
+                    )
             _emit_trace(
                 trace_sink,
                 emitted_events,

--- a/src/pension_data/langchain/nl_sql_chain.py
+++ b/src/pension_data/langchain/nl_sql_chain.py
@@ -10,6 +10,7 @@ from time import perf_counter
 from typing import Any, Literal, Protocol
 from uuid import uuid4
 
+from pension_data.langchain.tracing import langsmith_tracing_context
 from pension_data.query.sql_safety import (
     AmbiguousPromptError,
     SQLSafetyPolicy,
@@ -317,112 +318,123 @@ def run_nl_sql_chain(
             error=error,
         )
 
-    sql: str | None = None
-    active_policy = policy or default_nl_query_policy()
-    try:
-        if request.max_rows < 1:
-            raise NLRequestValidationError("max_rows must be >= 1")
-        if request.timeout_ms < 1:
-            raise NLRequestValidationError("timeout_ms must be >= 1")
-        if request.max_rows > active_policy.max_rows:
-            raise NLRequestValidationError(
-                f"max_rows must be <= policy max_rows ({active_policy.max_rows})"
-            )
-        if request.timeout_ms > active_policy.max_timeout_ms:
-            raise NLRequestValidationError(
-                "timeout_ms exceeds policy max_timeout_ms " f"({active_policy.max_timeout_ms})"
-            )
-        params = _normalize_params(request.params)
-        question = validate_nl_prompt(request.question)
-        _emit_trace(
-            trace_sink,
-            emitted_events,
-            stage="nl.prompt.received",
-            payload={"request_id": request_id, "question": question},
-        )
-
-        generated = chain.invoke({"question": question, "dialect": "sqlite"})
-        sql = validate_sql_policy(_extract_sql(generated), policy=active_policy)
-        if active_policy.require_source_document_id:
-            selected_columns = extract_selected_columns(sql)
-            if "source_document_id" not in set(selected_columns):
-                raise SQLSafetyValidationError(
-                    "generated SQL must include source_document_id in SELECT for provenance metadata"
+    with langsmith_tracing_context(
+        name="nl_to_sql.query",
+        run_type="chain",
+        inputs={"request_id": request_id, "question": request.question},
+        metadata={
+            "surface": "nl-to-sql",
+            "entrypoint": "pension_data.langchain.nl_sql_chain.run_nl_sql_chain",
+            "max_rows": request.max_rows,
+            "timeout_ms": request.timeout_ms,
+        },
+    ):
+        sql: str | None = None
+        active_policy = policy or default_nl_query_policy()
+        try:
+            if request.max_rows < 1:
+                raise NLRequestValidationError("max_rows must be >= 1")
+            if request.timeout_ms < 1:
+                raise NLRequestValidationError("timeout_ms must be >= 1")
+            if request.max_rows > active_policy.max_rows:
+                raise NLRequestValidationError(
+                    f"max_rows must be <= policy max_rows ({active_policy.max_rows})"
                 )
-        _emit_trace(
-            trace_sink,
-            emitted_events,
-            stage="nl.sql.generated",
-            payload={"request_id": request_id, "sql": sql},
-        )
-        _emit_trace(
-            trace_sink,
-            emitted_events,
-            stage="nl.sql.validated",
-            payload={
-                "request_id": request_id,
-                "status": "ok",
-                "sql_validation_status": "pass",
-                "read_only_status": "read_only",
-            },
-        )
+            if request.timeout_ms > active_policy.max_timeout_ms:
+                raise NLRequestValidationError(
+                    "timeout_ms exceeds policy max_timeout_ms " f"({active_policy.max_timeout_ms})"
+                )
+            params = _normalize_params(request.params)
+            question = validate_nl_prompt(request.question)
+            _emit_trace(
+                trace_sink,
+                emitted_events,
+                stage="nl.prompt.received",
+                payload={"request_id": request_id, "question": question},
+            )
 
-        deadline = perf_counter() + (request.timeout_ms / 1000.0)
-        _set_timeout_handler(connection, deadline_s=deadline)
-        cursor = connection.execute(sql, params)
-        columns = tuple(column[0] for column in (cursor.description or ()))
-        validate_result_columns(columns, policy=active_policy)
-        fetched = tuple(tuple(row) for row in cursor.fetchmany(request.max_rows + 1))
-        if len(fetched) > request.max_rows:
-            raise MaxRowsExceededError(
-                f"generated SQL exceeded max_rows limit ({request.max_rows})"
+            generated = chain.invoke({"question": question, "dialect": "sqlite"})
+            sql = validate_sql_policy(_extract_sql(generated), policy=active_policy)
+            if active_policy.require_source_document_id:
+                selected_columns = extract_selected_columns(sql)
+                if "source_document_id" not in set(selected_columns):
+                    raise SQLSafetyValidationError(
+                        "generated SQL must include source_document_id in SELECT for provenance metadata"
+                    )
+            _emit_trace(
+                trace_sink,
+                emitted_events,
+                stage="nl.sql.generated",
+                payload={"request_id": request_id, "sql": sql},
             )
-        provenance = _build_provenance(columns=columns, rows=fetched)
-        if "source_document_id" in {column.lower() for column in columns} and any(
-            row.source_document_id is None for row in provenance
-        ):
-            raise SQLSafetyValidationError(
-                "source_document_id must be populated for provenance-tracked rows"
+            _emit_trace(
+                trace_sink,
+                emitted_events,
+                stage="nl.sql.validated",
+                payload={
+                    "request_id": request_id,
+                    "status": "ok",
+                    "sql_validation_status": "pass",
+                    "read_only_status": "read_only",
+                },
             )
-        _emit_trace(
-            trace_sink,
-            emitted_events,
-            stage="nl.sql.executed",
-            payload={
-                "request_id": request_id,
-                "status": "ok",
-                "row_count": len(fetched),
-            },
-        )
-        return _finalize(
-            status="ok",
-            sql=sql,
-            columns=columns,
-            rows=fetched,
-            provenance=provenance,
-            error=None,
-        )
-    except Exception as exc:  # noqa: BLE001
-        if isinstance(exc, sqlite3.OperationalError) and "interrupted" in str(exc).lower():
-            exc = TimeoutError("query timed out before completion")
-        _emit_trace(
-            trace_sink,
-            emitted_events,
-            stage="nl.sql.error",
-            payload={
-                "request_id": request_id,
-                "status": "error",
-                "error_code": _error_code(exc),
-                "message": str(exc),
-            },
-        )
-        return _finalize(
-            status="error",
-            sql=sql,
-            columns=(),
-            rows=(),
-            provenance=(),
-            error=NLToSQLError(code=_error_code(exc), message=str(exc)),
-        )
-    finally:
-        _clear_timeout_handler(connection)
+
+            deadline = perf_counter() + (request.timeout_ms / 1000.0)
+            _set_timeout_handler(connection, deadline_s=deadline)
+            cursor = connection.execute(sql, params)
+            columns = tuple(column[0] for column in (cursor.description or ()))
+            validate_result_columns(columns, policy=active_policy)
+            fetched = tuple(tuple(row) for row in cursor.fetchmany(request.max_rows + 1))
+            if len(fetched) > request.max_rows:
+                raise MaxRowsExceededError(
+                    f"generated SQL exceeded max_rows limit ({request.max_rows})"
+                )
+            provenance = _build_provenance(columns=columns, rows=fetched)
+            if "source_document_id" in {column.lower() for column in columns} and any(
+                row.source_document_id is None for row in provenance
+            ):
+                raise SQLSafetyValidationError(
+                    "source_document_id must be populated for provenance-tracked rows"
+                )
+            _emit_trace(
+                trace_sink,
+                emitted_events,
+                stage="nl.sql.executed",
+                payload={
+                    "request_id": request_id,
+                    "status": "ok",
+                    "row_count": len(fetched),
+                },
+            )
+            return _finalize(
+                status="ok",
+                sql=sql,
+                columns=columns,
+                rows=fetched,
+                provenance=provenance,
+                error=None,
+            )
+        except Exception as exc:  # noqa: BLE001
+            if isinstance(exc, sqlite3.OperationalError) and "interrupted" in str(exc).lower():
+                exc = TimeoutError("query timed out before completion")
+            _emit_trace(
+                trace_sink,
+                emitted_events,
+                stage="nl.sql.error",
+                payload={
+                    "request_id": request_id,
+                    "status": "error",
+                    "error_code": _error_code(exc),
+                    "message": str(exc),
+                },
+            )
+            return _finalize(
+                status="error",
+                sql=sql,
+                columns=(),
+                rows=(),
+                provenance=(),
+                error=NLToSQLError(code=_error_code(exc), message=str(exc)),
+            )
+        finally:
+            _clear_timeout_handler(connection)

--- a/src/pension_data/langchain/nl_sql_chain.py
+++ b/src/pension_data/langchain/nl_sql_chain.py
@@ -32,6 +32,7 @@ NL_TO_SQL_TRACE_ENTRYPOINTS: tuple[str, ...] = (
 NL_TO_SQL_TRACE_STAGES_SUCCESS: tuple[str, ...] = (
     "nl.prompt.received",
     "nl.sql.generated",
+    "nl.sql.validated",
     "nl.sql.executed",
 )
 NL_TO_SQL_TRACE_STAGE_ERROR: str = "nl.sql.error"
@@ -47,7 +48,7 @@ def nl_to_sql_trace_stages(
         return NL_TO_SQL_TRACE_STAGES_SUCCESS
     if error_stage == "validation":
         return (NL_TO_SQL_TRACE_STAGES_SUCCESS[0], NL_TO_SQL_TRACE_STAGE_ERROR)
-    return (*NL_TO_SQL_TRACE_STAGES_SUCCESS[:2], NL_TO_SQL_TRACE_STAGE_ERROR)
+    return (*NL_TO_SQL_TRACE_STAGES_SUCCESS[:3], NL_TO_SQL_TRACE_STAGE_ERROR)
 
 
 @dataclass(frozen=True, slots=True)
@@ -353,6 +354,17 @@ def run_nl_sql_chain(
             emitted_events,
             stage="nl.sql.generated",
             payload={"request_id": request_id, "sql": sql},
+        )
+        _emit_trace(
+            trace_sink,
+            emitted_events,
+            stage="nl.sql.validated",
+            payload={
+                "request_id": request_id,
+                "status": "ok",
+                "sql_validation_status": "pass",
+                "read_only_status": "read_only",
+            },
         )
 
         deadline = perf_counter() + (request.timeout_ms / 1000.0)

--- a/src/pension_data/observability/langsmith_fleet.py
+++ b/src/pension_data/observability/langsmith_fleet.py
@@ -154,11 +154,13 @@ def build_fleet_records(
     row_count: int,
     max_rows: int | None = None,
     trace_event_count: int | None = None,
+    evidence_available: bool | None = None,
     error_code: str | None = None,
     error_stage: str | None = None,
     replay_dataset_id: str | None = None,
     replay_run_id: str | None = None,
     replay_match_status: str | None = None,
+    golden_corpus_outcome: str | None = None,
     artifact_ref: str | None = None,
 ) -> list[dict[str, Any]]:
     """Return Workflows-compatible fleet records for one NL-to-SQL run.
@@ -182,11 +184,17 @@ def build_fleet_records(
     )
 
     shared_domain: dict[str, Any] = {
+        "query_intent": context.query_category,
         "query_category": context.query_category,
+        "query_category_or_intent": context.query_category,
         "sql_validation_status": sql_validation_status,
+        "sql_validation": sql_validation_status,
         "read_only_status": read_only_status,
+        "read_only_safety_status": read_only_status,
         "row_count": sanitized_row_count,
     }
+    if evidence_available is not None:
+        shared_domain["evidence_available"] = bool(evidence_available)
     if sanitized_max_rows is not None:
         shared_domain["max_rows"] = sanitized_max_rows
     if context.latency_ms is not None:
@@ -261,6 +269,9 @@ def build_fleet_records(
         replay_domain["replay_run_id"] = replay_run_id
     if replay_match_status:
         replay_domain["replay_match_status"] = replay_match_status
+    normalized_golden_outcome = (golden_corpus_outcome or replay_match_status or "").strip()
+    if normalized_golden_outcome:
+        replay_domain["golden_corpus_outcome"] = normalized_golden_outcome
     records.append(
         _record(
             context=context,
@@ -300,6 +311,7 @@ def build_fleet_records_from_response(
     sql_validation_status = _derive_sql_validation_status(error_code, response)
     read_only_status = _derive_read_only_status(error_code, response)
     row_count = _response_row_count(response)
+    evidence_available = _response_evidence_available(response)
     max_rows = _request_max_rows(request)
     trace_event_count = _response_trace_event_count(response)
     error_stage = _error_stage_for(error_code)
@@ -330,6 +342,8 @@ def build_fleet_records_from_response(
         replay_dataset_id=replay_dataset_id,
         replay_run_id=replay_run_id,
         replay_match_status=replay_match_status,
+        evidence_available=evidence_available,
+        golden_corpus_outcome=replay_match_status,
         artifact_ref=artifact_ref,
     )
 
@@ -583,6 +597,23 @@ def _response_trace_event_count(response: Any) -> int | None:
         return max(0, int(count))
     except (TypeError, ValueError):
         return None
+
+
+def _response_evidence_available(response: Any) -> bool | None:
+    provenance = getattr(response, "provenance", None)
+    if provenance is None:
+        return None
+    if not isinstance(provenance, tuple | list):
+        return None
+    if not provenance:
+        return False
+    for row in provenance:
+        refs = getattr(row, "evidence_refs", None)
+        if isinstance(refs, tuple | list) and any(
+            isinstance(ref, str) and ref.strip() for ref in refs
+        ):
+            return True
+    return False
 
 
 def _response_latency_ms(response: Any) -> int | None:

--- a/src/pension_data/observability/langsmith_fleet.py
+++ b/src/pension_data/observability/langsmith_fleet.py
@@ -110,9 +110,8 @@ class LangSmithClientTraceSink:
         )
         trace_id = _resolve_run_attr(run, "id", "run_id", "trace_id")
         trace_url = _resolve_run_attr(run, "url", "trace_url")
-        if trace_id:
+        if trace_id or trace_url:
             self.latest_trace_id = trace_id
-        if trace_url:
             self.latest_trace_url = trace_url
 
 

--- a/src/pension_data/observability/langsmith_fleet.py
+++ b/src/pension_data/observability/langsmith_fleet.py
@@ -57,6 +57,7 @@ class FleetRunContext:
 
     run_id: str
     query_category: str
+    session_id: str | None = None
     provider: str | None = None
     model: str | None = None
     trace_id: str | None = None
@@ -306,6 +307,7 @@ def build_fleet_records_from_response(
     if context.latency_ms is None and latency_ms is not None:
         context = FleetRunContext(
             run_id=context.run_id,
+            session_id=context.session_id,
             query_category=context.query_category,
             provider=context.provider,
             model=context.model,
@@ -422,11 +424,14 @@ def _record(
         "surface": SURFACE,
         "operation": operation,
         "run_id": context.run_id,
+        "request_id": context.run_id,
         "status": status,
         "github_issue": GITHUB_ISSUE,
         "recorded_at": recorded_at,
         "domain": dict(domain),
     }
+    if context.session_id:
+        record["session_id"] = context.session_id
     if context.github_pr:
         record["github_pr"] = context.github_pr
     if context.provider:

--- a/src/pension_data/observability/langsmith_fleet.py
+++ b/src/pension_data/observability/langsmith_fleet.py
@@ -76,6 +76,8 @@ class LangSmithClientTraceSink:
             client = Client()
         self._client = client
         self._project_name = project_name
+        self.latest_trace_id: str | None = None
+        self.latest_trace_url: str | None = None
 
     def emit(self, event: Any) -> None:
         """Create one ended LangSmith run for a sanitized lifecycle event."""
@@ -84,7 +86,7 @@ class LangSmithClientTraceSink:
         payload = _safe_trace_payload(getattr(event, "payload", {}))
         request_id = str(payload.get("request_id", ""))
         timestamp = datetime.now(UTC)
-        self._client.create_run(
+        run = self._client.create_run(
             name=f"{SURFACE}.{stage}",
             run_type="chain",
             project_name=self._project_name,
@@ -105,6 +107,12 @@ class LangSmithClientTraceSink:
             },
             tags=[REPO, SURFACE, stage],
         )
+        trace_id = _resolve_run_attr(run, "id", "run_id", "trace_id")
+        trace_url = _resolve_run_attr(run, "url", "trace_url")
+        if trace_id:
+            self.latest_trace_id = trace_id
+        if trace_url:
+            self.latest_trace_url = trace_url
 
 
 def build_langsmith_trace_sink(
@@ -440,11 +448,42 @@ def _safe_trace_payload(payload: Any) -> dict[str, Any]:
     if not isinstance(payload, Mapping):
         return {}
     safe: dict[str, Any] = {}
-    for key in ("request_id", "status", "row_count", "error_code"):
+    for key in (
+        "request_id",
+        "status",
+        "row_count",
+        "error_code",
+        "sql_validation_status",
+        "read_only_status",
+    ):
         value = payload.get(key)
         if value is not None:
             safe[key] = value
     return safe
+
+
+def _resolve_run_attr(run: Any, *names: str) -> str | None:
+    if run is None:
+        return None
+    for name in names:
+        value = getattr(run, name, None)
+        normalized = _normalize_trace_ref(value)
+        if normalized:
+            return normalized
+    if isinstance(run, Mapping):
+        for name in names:
+            value = run.get(name)
+            normalized = _normalize_trace_ref(value)
+            if normalized:
+                return normalized
+    return None
+
+
+def _normalize_trace_ref(value: Any) -> str | None:
+    if value is None:
+        return None
+    token = str(value).strip()
+    return token or None
 
 
 def _stage_status(

--- a/tests/langchain/test_nl_sql_safety.py
+++ b/tests/langchain/test_nl_sql_safety.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sqlite3
 from collections.abc import Mapping
+from contextlib import contextmanager
 from typing import Any
 
 import pytest
@@ -187,6 +188,45 @@ def test_nl_sql_trace_entrypoints_and_lifecycle_contract_is_explicit() -> None:
         "nl.prompt.received",
         "nl.sql.error",
     )
+
+
+def test_nl_sql_chain_enters_langsmith_context_with_nl_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context_calls: list[dict[str, Any]] = []
+
+    @contextmanager
+    def _fake_langsmith_tracing_context(**kwargs: Any):
+        context_calls.append(kwargs)
+        yield None
+
+    monkeypatch.setattr(
+        "pension_data.langchain.nl_sql_chain.langsmith_tracing_context",
+        _fake_langsmith_tracing_context,
+    )
+    connection = _seed_connection()
+    try:
+        response = run_nl_sql_chain(
+            connection=connection,
+            request=NLToSQLRequest(question="Show funded ratio values by id", max_rows=10),
+            chain=StaticChain("SELECT id, value FROM sample_metrics WHERE metric = 'funded_ratio'"),
+            trace_sink=InMemoryLangSmithTraceSink(events=[]),
+            policy=_sample_policy(),
+        )
+    finally:
+        connection.close()
+
+    assert response.status == "ok"
+    assert len(context_calls) == 1
+    call = context_calls[0]
+    assert call["name"] == "nl_to_sql.query"
+    assert call["run_type"] == "chain"
+    assert call["metadata"]["surface"] == "nl-to-sql"
+    assert call["metadata"]["entrypoint"] == "pension_data.langchain.nl_sql_chain.run_nl_sql_chain"
+    assert call["metadata"]["max_rows"] == 10
+    assert call["metadata"]["timeout_ms"] == 2_000
+    assert isinstance(call["inputs"]["request_id"], str)
+    assert call["inputs"]["request_id"].startswith("nlq:")
 
 
 def test_nl_sql_chain_returns_specific_error_for_max_rows_overflow() -> None:

--- a/tests/langchain/test_nl_sql_safety.py
+++ b/tests/langchain/test_nl_sql_safety.py
@@ -135,6 +135,9 @@ def test_nl_sql_chain_executes_read_only_sql_and_emits_langsmith_traces() -> Non
     assert response.provenance[0].evidence_refs == ()
     assert response.provenance[0].confidence is None
     assert [event.stage for event in traces.events] == list(nl_to_sql_trace_stages(status="ok"))
+    assert traces.events[2].stage == "nl.sql.validated"
+    assert traces.events[2].payload["sql_validation_status"] == "pass"
+    assert traces.events[2].payload["read_only_status"] == "read_only"
 
 
 def test_nl_sql_chain_rejects_unsafe_generated_sql_and_emits_error_trace() -> None:
@@ -171,11 +174,13 @@ def test_nl_sql_trace_entrypoints_and_lifecycle_contract_is_explicit() -> None:
     assert nl_to_sql_trace_stages(status="ok") == (
         "nl.prompt.received",
         "nl.sql.generated",
+        "nl.sql.validated",
         "nl.sql.executed",
     )
     assert nl_to_sql_trace_stages(status="error") == (
         "nl.prompt.received",
         "nl.sql.generated",
+        "nl.sql.validated",
         "nl.sql.error",
     )
     assert nl_to_sql_trace_stages(status="error", error_stage="validation") == (
@@ -282,7 +287,7 @@ def test_nl_route_requires_nl_scope_and_emits_audit_event() -> None:
     assert result.audit_event["request_origin"] == "unit-test"
     assert result.audit_event["query_status"] == "ok"
     assert result.audit_event["returned_rows"] == 2
-    assert len(traces.events) == 3
+    assert len(traces.events) == 4
 
 
 def test_nl_sql_chain_rejects_disallowed_relation() -> None:

--- a/tests/langchain/test_nl_sql_safety.py
+++ b/tests/langchain/test_nl_sql_safety.py
@@ -163,6 +163,8 @@ def test_nl_sql_chain_rejects_unsafe_generated_sql_and_emits_error_trace() -> No
     assert [event.stage for event in traces.events] == list(
         nl_to_sql_trace_stages(status="error", error_stage="validation")
     )
+    assert traces.events[1].stage == "nl.sql.generated"
+    assert traces.events[1].payload["sql"] == "DELETE FROM sample_metrics"
     assert traces.events[-1].stage == "nl.sql.error"
     assert traces.events[-1].payload["error_code"] == "UNSAFE_SQL"
 
@@ -184,7 +186,18 @@ def test_nl_sql_trace_entrypoints_and_lifecycle_contract_is_explicit() -> None:
         "nl.sql.validated",
         "nl.sql.error",
     )
+    assert nl_to_sql_trace_stages(status="error", error_stage="execution") == (
+        "nl.prompt.received",
+        "nl.sql.generated",
+        "nl.sql.validated",
+        "nl.sql.error",
+    )
     assert nl_to_sql_trace_stages(status="error", error_stage="validation") == (
+        "nl.prompt.received",
+        "nl.sql.generated",
+        "nl.sql.error",
+    )
+    assert nl_to_sql_trace_stages(status="error", error_stage="request") == (
         "nl.prompt.received",
         "nl.sql.error",
     )
@@ -460,11 +473,13 @@ def test_nl_sql_chain_rejects_select_alias_bypass_attempt() -> None:
 
 def test_nl_sql_chain_returns_invalid_request_for_policy_bound_violation() -> None:
     connection = _seed_connection()
+    traces = InMemoryLangSmithTraceSink(events=[])
     try:
         response = run_nl_sql_chain(
             connection=connection,
             request=NLToSQLRequest(question="Show funded ratio values by id", max_rows=5000),
             chain=StaticChain("SELECT id, value FROM sample_metrics"),
+            trace_sink=traces,
             policy=_sample_policy(max_rows=100),
         )
     finally:
@@ -474,6 +489,9 @@ def test_nl_sql_chain_returns_invalid_request_for_policy_bound_violation() -> No
     assert response.error is not None
     assert response.error.code == "INVALID_REQUEST"
     assert "policy max_rows" in response.error.message
+    assert [event.stage for event in traces.events] == list(
+        nl_to_sql_trace_stages(status="error", error_stage="request")
+    )
 
 
 def test_nl_sql_chain_emits_provenance_metadata_when_fields_present() -> None:

--- a/tests/observability/test_langsmith_fleet.py
+++ b/tests/observability/test_langsmith_fleet.py
@@ -94,14 +94,18 @@ def test_build_fleet_records_uses_no_secret_status_when_key_missing(
     assert {record["status"] for record in records[:3]} == {"no_secret"}
     assert records[3]["status"] == "skipped"
     for record in records:
+        assert record["domain"]["query_intent"] == "funded_ratio_lookup"
         assert record["request_id"] == "nlq:abc"
         assert record["schema_version"] == langsmith_fleet.SCHEMA_VERSION
         assert record["repo"] == "stranske/Pension-Data"
         assert record["surface"] == "nl-to-sql"
         assert record["github_issue"] == "stranske/Pension-Data#445"
         assert record["domain"]["query_category"] == "funded_ratio_lookup"
+        assert record["domain"]["query_category_or_intent"] == "funded_ratio_lookup"
         assert record["domain"]["sql_validation_status"] == "pass"
+        assert record["domain"]["sql_validation"] == "pass"
         assert record["domain"]["read_only_status"] == "read_only"
+        assert record["domain"]["read_only_safety_status"] == "read_only"
         assert record["domain"]["row_count"] == 2
         assert record["domain"]["max_rows"] == 10
         serialized = json.dumps(record)
@@ -150,6 +154,7 @@ def test_build_fleet_records_enables_langsmith_defaults_when_key_present(
     assert records[3]["domain"]["replay_dataset_id"] == "ds:funded_ratio"
     assert records[3]["domain"]["replay_run_id"] == "run:001"
     assert records[3]["domain"]["replay_match_status"] == "match"
+    assert records[3]["domain"]["golden_corpus_outcome"] == "match"
     import os
 
     assert os.environ[langsmith_fleet.ENV_LANGCHAIN_PROJECT] == langsmith_fleet.DEFAULT_PROJECT
@@ -322,6 +327,7 @@ def test_build_fleet_records_from_response_round_trip(
         assert record["domain"]["sql_validation_status"] == "pass"
         assert record["domain"]["read_only_status"] == "read_only"
         assert record["domain"]["row_count"] == 2
+        assert record["domain"]["evidence_available"] is False
         assert record["domain"]["max_rows"] == 10
         assert record["domain"]["trace_event_count"] == len(traces.events)
         assert record["domain"]["latency_ms"] >= 0
@@ -364,6 +370,37 @@ def test_build_fleet_records_from_response_unsafe_sql_blocked() -> None:
         assert record["domain"]["sql_validation_status"] == "unsafe"
         assert record["domain"]["read_only_status"] == "blocked"
         assert record["domain"]["row_count"] == 0
+
+
+def test_build_fleet_records_from_response_sets_evidence_available_true() -> None:
+    connection = _seed_connection()
+    traces = InMemoryLangSmithTraceSink(events=[])
+    try:
+        request = NLToSQLRequest(question="Show funded ratio evidence", max_rows=10)
+        response = run_nl_sql_chain(
+            connection=connection,
+            request=request,
+            chain=_StaticChain(
+                "SELECT id, source_document_id, evidence_refs FROM sample_metrics "
+                "WHERE metric = 'funded_ratio'"
+            ),
+            trace_sink=traces,
+            policy=_policy(),
+        )
+    finally:
+        connection.close()
+
+    context = langsmith_fleet.FleetRunContext(
+        run_id=response.metadata.request_id,
+        query_category="funded_ratio_lookup",
+    )
+    records = langsmith_fleet.build_fleet_records_from_response(
+        context=context,
+        response=response,
+        request=request,
+    )
+    for record in records[:3]:
+        assert record["domain"]["evidence_available"] is True
 
 
 def test_write_fleet_records_emits_deterministic_ndjson(tmp_path: Path) -> None:
@@ -491,7 +528,9 @@ def test_run_nl_query_endpoint_emits_fleet_artifact_when_category_set(
         assert record["request_id"] == result.response.metadata.request_id
         assert record["session_id"] == result.audit_event["correlation_id"]
         assert record["domain"]["query_category"] == "funded_ratio_lookup"
+        assert record["domain"]["query_intent"] == "funded_ratio_lookup"
         assert record["domain"]["sql_validation_status"] == "pass"
+        assert record["domain"]["evidence_available"] is False
         assert record["domain"]["row_count"] == 2
         assert record["trace_id"] == "trace-xyz"
         assert record["trace_url"] == "https://smith.langchain.com/r/trace-xyz"

--- a/tests/observability/test_langsmith_fleet.py
+++ b/tests/observability/test_langsmith_fleet.py
@@ -94,6 +94,7 @@ def test_build_fleet_records_uses_no_secret_status_when_key_missing(
     assert {record["status"] for record in records[:3]} == {"no_secret"}
     assert records[3]["status"] == "skipped"
     for record in records:
+        assert record["request_id"] == "nlq:abc"
         assert record["schema_version"] == langsmith_fleet.SCHEMA_VERSION
         assert record["repo"] == "stranske/Pension-Data"
         assert record["surface"] == "nl-to-sql"
@@ -141,6 +142,7 @@ def test_build_fleet_records_enables_langsmith_defaults_when_key_present(
 
     statuses = [record["status"] for record in records]
     assert statuses == ["success", "success", "success", "success"]
+    assert records[0]["request_id"] == "nlq:def"
     assert records[0]["trace_id"] == "trace-123"
     assert records[0]["trace_url"] == "https://smith.langchain.com/r/trace-123"
     assert records[0]["provider"] == "openai"
@@ -486,6 +488,8 @@ def test_run_nl_query_endpoint_emits_fleet_artifact_when_category_set(
     ]
     for record in records[:3]:
         assert record["status"] == "no_secret"
+        assert record["request_id"] == result.response.metadata.request_id
+        assert record["session_id"] == result.audit_event["correlation_id"]
         assert record["domain"]["query_category"] == "funded_ratio_lookup"
         assert record["domain"]["sql_validation_status"] == "pass"
         assert record["domain"]["row_count"] == 2

--- a/tests/observability/test_langsmith_fleet.py
+++ b/tests/observability/test_langsmith_fleet.py
@@ -179,8 +179,12 @@ def test_langsmith_trace_sink_emits_sanitized_stage_runs(
     calls: list[dict[str, Any]] = []
 
     class _FakeClient:
-        def create_run(self, **kwargs: Any) -> None:
+        def create_run(self, **kwargs: Any) -> dict[str, str]:
             calls.append(kwargs)
+            return {
+                "id": f"run-{len(calls)}",
+                "url": f"https://smith.langchain.com/r/run-{len(calls)}",
+            }
 
     sink = langsmith_fleet.build_langsmith_trace_sink(client=_FakeClient())
     assert sink is not None
@@ -204,6 +208,8 @@ def test_langsmith_trace_sink_emits_sanitized_stage_runs(
     assert call["name"] == "nl-to-sql.nl.sql.generated"
     assert call["inputs"] == {"request_id": "nlq:123", "stage": "nl.sql.generated"}
     assert call["outputs"] == {"request_id": "nlq:123", "status": "ok", "row_count": 2}
+    assert sink.latest_trace_id == "run-1"
+    assert sink.latest_trace_url == "https://smith.langchain.com/r/run-1"
     serialized = json.dumps(call, default=str)
     assert "raw question" not in serialized
     assert "SELECT sensitive_value" not in serialized
@@ -527,8 +533,58 @@ def test_run_nl_query_endpoint_uses_default_langsmith_sink(
     assert [event.stage for event in emitted] == [
         "nl.prompt.received",
         "nl.sql.generated",
+        "nl.sql.validated",
         "nl.sql.executed",
     ]
+
+
+def test_run_nl_query_endpoint_correlates_default_sink_trace_to_fleet_and_audit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pension_data.api.auth import SCOPE_NL, APIKeyStore
+    from pension_data.api.routes import nl as nl_route
+
+    class _RecordingSink:
+        latest_trace_id = "trace-auto"
+        latest_trace_url = "https://smith.langchain.com/r/trace-auto"
+
+        def emit(self, event: LangSmithTraceEvent) -> None:
+            if event.stage == "nl.sql.executed":
+                self.latest_trace_id = "trace-executed"
+                self.latest_trace_url = "https://smith.langchain.com/r/trace-executed"
+
+    monkeypatch.setattr(nl_route, "build_langsmith_trace_sink", lambda: _RecordingSink())
+    key_store = APIKeyStore()
+    secret, _ = key_store.create_key(scopes=(SCOPE_NL,))
+    fleet_path = tmp_path / "langsmith" / langsmith_fleet.ARTIFACT_NAME
+    connection = _seed_connection()
+    try:
+        result = nl_route.run_nl_query_endpoint(
+            api_key_header=secret,
+            key_store=key_store,
+            connection=connection,
+            request=NLToSQLRequest(question="Show funded ratio values by id", max_rows=10),
+            chain=_StaticChain(
+                "SELECT id, value FROM sample_metrics WHERE metric = 'funded_ratio'"
+            ),
+            log_path=tmp_path / "nl_operations.jsonl",
+            policy=_policy(),
+            query_category="funded_ratio_lookup",
+            fleet_artifact_path=fleet_path,
+        )
+    finally:
+        connection.close()
+
+    records = [json.loads(line) for line in fleet_path.read_text(encoding="utf-8").splitlines()]
+    assert {record["trace_id"] for record in records[:3]} == {"trace-executed"}
+    assert {record["trace_url"] for record in records[:3]} == {
+        "https://smith.langchain.com/r/trace-executed"
+    }
+    assert result.audit_event["langsmith_trace_id"] == "trace-executed"
+    assert (
+        result.audit_event["langsmith_trace_url"] == "https://smith.langchain.com/r/trace-executed"
+    )
 
 
 def test_run_nl_query_endpoint_skips_fleet_artifact_when_no_category(


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:445 -->
> **Source:** Issue #445

Closes #445

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The NL-to-SQL surface is one of the highest-value AI workflows in Pension-Data. The repo docs call for LangSmith tracing, replay against golden corpora, read-only SQL safety, page-level evidence, partial-record preservation, and reviewable findings artifacts. Current collection does not consistently expose the full query lifecycle needed to debug correctness, safety, latency, and result quality.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [stranske/Workflows#2150](https://github.com/stranske/Workflows/issues/2150)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Identify the NL-to-SQL entry points and lifecycle stages that should be traced.
- [ ] Implement or wire a real LangSmith sink/context when `LANGSMITH_API_KEY` is available.
- [x] Add shared metadata for request/session, provider, model, latency, status, trace ID/URL, and error category.
- [x] Add domain metadata for query intent/category, SQL validation status, read-only safety status, row count, evidence availability, replay dataset/run ID, and golden-corpus outcome where available.
- [ ] Attach trace ID/URL to response metadata, logs, or artifacts that operators already inspect.
- [ ] Emit a dashboard-compatible `langsmith-fleet/v1` NDJSON artifact with shared fields plus Pension-Data domain metadata.
- [x] Add fixtures or tests for a successful traced query, validation failure, execution failure, and no-secret fallback.
- [ ] Update docs/runbooks that explain how NL-to-SQL traces support debugging and evaluation.

#### Acceptance criteria
- [x] NL-to-SQL calls use LangSmith config when a key is configured.
- [ ] Missing `LANGSMITH_API_KEY` causes a clean no-op without changing query behavior.
- [ ] Traces include prompt handling, SQL generation, validation, execution, and error stages.
- [ ] Trace metadata includes row count and safety metadata without exposing sensitive row payloads.
- [ ] Dashboard artifact records validate against the Workflows fleet contract from stranske/Workflows#2150.
- [ ] Tests cover trace metadata creation, dashboard record emission, validation/error cases, and no-secret fallback.
- [ ] Replay/evaluation artifacts can be correlated with trace IDs or stable run IDs.

<!-- auto-status-summary:end -->