### PR TITLE
Issue #470: Wire reviewable findings artifact CI

### DIFF
--- a/.github/workflows/foundation-fixture-e2e.yml
+++ b/.github/workflows/foundation-fixture-e2e.yml
@@ -62,6 +62,64 @@ jobs:
               raise SystemExit("foundation fixture ledger does not include all expected stages")
           PY
 
+      - name: Prepare reviewable findings generator inputs
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          from pension_data.coverage.readiness import write_coverage_artifacts
+          from pension_data.extract.persistence import extraction_persistence_contract
+
+          artifact_root = Path("artifacts")
+          coverage_payload = json.loads(
+              (artifact_root / "foundation" / "coverage_readiness.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          write_coverage_artifacts(coverage_payload, output_root=artifact_root)
+
+          persistence_dir = artifact_root / "extraction_persistence"
+          persistence_dir.mkdir(parents=True, exist_ok=True)
+          (persistence_dir / "persistence_contract.json").write_text(
+              json.dumps(extraction_persistence_contract(), indent=2, sort_keys=True),
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Build reviewable findings artifact
+        run: |
+          set -euo pipefail
+          python scripts/langchain/build_reviewable_findings_artifact.py \
+            --persistence-contract artifacts/extraction_persistence/persistence_contract.json \
+            --readiness-csv artifacts/coverage/readiness_rows.csv \
+            --output artifacts/reviewable-findings/extraction-quality-dashboard.json
+          python - <<'PY'
+          import json
+
+          from pension_data.langchain.review_artifact import (
+              validate_reviewable_findings_artifact,
+          )
+
+          with open(
+              "artifacts/reviewable-findings/extraction-quality-dashboard.json",
+              encoding="utf-8",
+          ) as handle:
+              validate_reviewable_findings_artifact(json.load(handle))
+          PY
+
+      - name: Verify reviewable findings generator fails on missing readiness CSV
+        run: |
+          set -euo pipefail
+          if python scripts/langchain/build_reviewable_findings_artifact.py \
+            --persistence-contract artifacts/extraction_persistence/persistence_contract.json \
+            --readiness-csv artifacts/coverage/missing-readiness.csv \
+            --output artifacts/reviewable-findings/should-not-exist.json; then
+            echo "generator unexpectedly succeeded with a missing readiness CSV" >&2
+            exit 1
+          fi
+
       - name: Run foundation fixture tests
         run: |
           set -euo pipefail
@@ -73,4 +131,12 @@ jobs:
         with:
           name: foundation-fixture-artifacts
           path: artifacts/foundation
+          if-no-files-found: warn
+
+      - name: Upload reviewable findings artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: reviewable-findings-artifacts
+          path: artifacts/reviewable-findings
           if-no-files-found: warn

--- a/docs/contracts/reviewable-findings-artifact-contract.md
+++ b/docs/contracts/reviewable-findings-artifact-contract.md
@@ -90,8 +90,9 @@ two-layer model.
 ## Generation Plan
 
 The first generator reads extraction persistence outputs and source-readiness artifacts, then writes
-`docs/data/reviewable-findings/extraction-quality-dashboard.json` as a CI/release artifact. The
-`Foundation Fixture E2E` workflow prepares `artifacts/extraction_persistence/persistence_contract.json`
-and `artifacts/coverage/readiness_rows.csv`, runs
+`artifacts/reviewable-findings/extraction-quality-dashboard.json` as a CI/release artifact. The
+`.github/workflows/foundation-fixture-e2e.yml` `Foundation Fixture E2E` workflow prepares
+`artifacts/extraction_persistence/persistence_contract.json` and
+`artifacts/coverage/readiness_rows.csv`, runs
 `scripts/langchain/build_reviewable_findings_artifact.py`, validates the output with
 `validate_reviewable_findings_artifact(...)`, and uploads `artifacts/reviewable-findings/`.

--- a/docs/contracts/reviewable-findings-artifact-contract.md
+++ b/docs/contracts/reviewable-findings-artifact-contract.md
@@ -89,6 +89,9 @@ two-layer model.
 
 ## Generation Plan
 
-The first generator should read extraction persistence outputs and source-readiness artifacts, then
-write `docs/data/reviewable-findings/extraction-quality-dashboard.json` as a CI/release artifact.
-It should fail validation with `validate_reviewable_findings_artifact(...)` before publishing.
+The first generator reads extraction persistence outputs and source-readiness artifacts, then writes
+`docs/data/reviewable-findings/extraction-quality-dashboard.json` as a CI/release artifact. The
+`Foundation Fixture E2E` workflow prepares `artifacts/extraction_persistence/persistence_contract.json`
+and `artifacts/coverage/readiness_rows.csv`, runs
+`scripts/langchain/build_reviewable_findings_artifact.py`, validates the output with
+`validate_reviewable_findings_artifact(...)`, and uploads `artifacts/reviewable-findings/`.

--- a/docs/data/reviewable-findings/README.md
+++ b/docs/data/reviewable-findings/README.md
@@ -23,8 +23,9 @@ sample for static UI hosting and reviewer workflows, but it is not the productio
 In-process callers must also provide both source paths; calling the builder without source artifacts
 is treated as a contract error.
 
-The `Foundation Fixture E2E` workflow prepares those source artifacts under `artifacts/`, runs the
-generator with `artifacts/extraction_persistence/persistence_contract.json` and
+The `.github/workflows/foundation-fixture-e2e.yml` `Foundation Fixture E2E` workflow prepares those
+source artifacts under `artifacts/`, runs the generator with
+`artifacts/extraction_persistence/persistence_contract.json` and
 `artifacts/coverage/readiness_rows.csv`, validates the generated dashboard artifact, and uploads
 `artifacts/reviewable-findings/` for review.
 

--- a/docs/data/reviewable-findings/README.md
+++ b/docs/data/reviewable-findings/README.md
@@ -13,7 +13,7 @@ from that data. The required source artifact paths are passed as CLI arguments:
 
 - `--persistence-contract` (default `extraction_persistence/persistence_contract.json`): the
   contract JSON written by `write_extraction_persistence_artifacts()` after an extraction run.
-- `--readiness-csv` (default `coverage/source_authority_readiness.csv`): the readiness CSV
+- `--readiness-csv` (default `coverage/readiness_rows.csv`): the readiness CSV
   written by `write_coverage_artifacts()` (or an equivalent source-authority readiness export).
 
 When either source artifact is missing, unreadable, or fails to parse the generator raises
@@ -22,6 +22,11 @@ hand-authored fixture. The checked-in artifact at the published path remains a s
 sample for static UI hosting and reviewer workflows, but it is not the production data path.
 In-process callers must also provide both source paths; calling the builder without source artifacts
 is treated as a contract error.
+
+The `Foundation Fixture E2E` workflow prepares those source artifacts under `artifacts/`, runs the
+generator with `artifacts/extraction_persistence/persistence_contract.json` and
+`artifacts/coverage/readiness_rows.csv`, validates the generated dashboard artifact, and uploads
+`artifacts/reviewable-findings/` for review.
 
 The persistence contract is used to validate that the source data describes required readiness
 columns before findings are derived from the readiness CSV. Real-data generation includes

--- a/scripts/langchain/build_reviewable_findings_artifact.py
+++ b/scripts/langchain/build_reviewable_findings_artifact.py
@@ -13,7 +13,7 @@ from pension_data.langchain.review_artifact import (
 )
 
 DEFAULT_PERSISTENCE_CONTRACT_PATH = "extraction_persistence/persistence_contract.json"
-DEFAULT_READINESS_CSV_PATH = "coverage/source_authority_readiness.csv"
+DEFAULT_READINESS_CSV_PATH = "coverage/readiness_rows.csv"
 
 
 def parse_args() -> argparse.Namespace:

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,0 +1,9 @@
+## 2026-05-27T09:09Z - codex opener materialized issue #470
+
+- Repo: `stranske/Pension-Data`
+- Issue: `#470` - Wire reviewable findings generator to CI and fix default readiness CSV path mismatch
+- Branch: `codex/issue-470-reviewable-findings-ci`
+- Lane: opener materialization
+- Changes: fixed the reviewable findings generator default readiness CSV path to `coverage/readiness_rows.csv`; extended `Foundation Fixture E2E` to prepare generator source artifacts, build and validate `artifacts/reviewable-findings/extraction-quality-dashboard.json`, assert missing readiness CSV failure, and upload the reviewable-findings artifact; updated contract/docs with the CI path.
+- Validation: `pytest -q tests/langchain/test_review_artifact_contract.py tests/langchain/test_chain_to_artifact_pipeline.py`; `pytest -q --no-cov tests/ops/test_foundation_ledger.py tests/e2e/foundation/test_fixture_pipeline.py`; `ruff check scripts/langchain/build_reviewable_findings_artifact.py`; `ruff format --check scripts/langchain/build_reviewable_findings_artifact.py`; local foundation fixture pipeline plus generator validation and missing-readiness negative path under `/tmp/pension-470-reviewable-findings`.
+- Next action: open ready-for-review PR with `agent:codex`, `agents:keepalive`, `autofix`, `repo-review-approved`, and `priority:low`; keepalive owns CI follow-up.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,9 +1,0 @@
-## 2026-05-27T09:09Z - codex opener materialized issue #470
-
-- Repo: `stranske/Pension-Data`
-- Issue: `#470` - Wire reviewable findings generator to CI and fix default readiness CSV path mismatch
-- Branch: `codex/issue-470-reviewable-findings-ci`
-- Lane: opener materialization
-- Changes: fixed the reviewable findings generator default readiness CSV path to `coverage/readiness_rows.csv`; extended `Foundation Fixture E2E` to prepare generator source artifacts, build and validate `artifacts/reviewable-findings/extraction-quality-dashboard.json`, assert missing readiness CSV failure, and upload the reviewable-findings artifact; updated contract/docs with the CI path.
-- Validation: `pytest -q tests/langchain/test_review_artifact_contract.py tests/langchain/test_chain_to_artifact_pipeline.py`; `pytest -q --no-cov tests/ops/test_foundation_ledger.py tests/e2e/foundation/test_fixture_pipeline.py`; `ruff check scripts/langchain/build_reviewable_findings_artifact.py`; `ruff format --check scripts/langchain/build_reviewable_findings_artifact.py`; local foundation fixture pipeline plus generator validation and missing-readiness negative path under `/tmp/pension-470-reviewable-findings`.
-- Next action: open ready-for-review PR with `agent:codex`, `agents:keepalive`, `autofix`, `repo-review-approved`, and `priority:low`; keepalive owns CI follow-up.


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:470 -->
> **Source:** Issue #470

Closes #470

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`docs/contracts/reviewable-findings-artifact-contract.md` Generation Plan (lines 90–94) commits the generator to run as a CI/release step. No `.github/workflows/*.yml` references `build_reviewable_findings_artifact` or the generator command — the contract describes a pipeline that CI never runs. `docs/data/reviewable-findings/README.md` documents the generator command and its `--readiness-csv` argument, but the path documented there does not match what `write_coverage_artifacts()` actually writes.

`scripts/langchain/build_reviewable_findings_artifact.py:16` sets `DEFAULT_READINESS_CSV_PATH = "coverage/source_authority_readiness.csv"`, but `write_coverage_artifacts()` (`src/pension_data/coverage/readiness.py:413–414`) writes `coverage/readiness_rows.csv`. No file named `source_authority_readiness.csv` exists in the repo. Because `build_extraction_quality_dashboard_artifact()` (`src/pension_data/langchain/review_artifact.py:482–485`) raises `ReviewableFindingsArtifactError` on a missing source path, any CI job using defaults exits non-zero before producing an artifact.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#445](https://github.com/stranske/Pension-Data/issues/445)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Fix `DEFAULT_READINESS_CSV_PATH` in `scripts/langchain/build_reviewable_findings_artifact.py:16` from `"coverage/source_authority_readiness.csv"` to `"coverage/readiness_rows.csv"` to match `write_coverage_artifacts()` (`src/pension_data/coverage/readiness.py:413–414`).
- [ ] Confirm: `rg "source_authority_readiness.csv" scripts/langchain/build_reviewable_findings_artifact.py` returns no matches; `--help` shows `coverage/readiness_rows.csv` as the `--readiness-csv` default.
- [ ] Add a CI job (extend `.github/workflows/foundation-fixture-e2e.yml` or standalone): run `tools/foundation/run_fixture_pipeline.py --output-root artifacts`, then call the generator with `--persistence-contract artifacts/extraction_persistence/persistence_contract.json --readiness-csv artifacts/coverage/readiness_rows.csv --output artifacts/reviewable-findings/extraction-quality-dashboard.json`; assert exit 0; upload `artifacts/reviewable-findings/` via `actions/upload-artifact@v7`.
- [ ] Add a negative-path step passing a non-existent `--readiness-csv` and assert exit non-zero.
- [ ] Update `docs/contracts/reviewable-findings-artifact-contract.md` Generation Plan (lines 90–94) to name the CI job and confirm `coverage/readiness_rows.csv`.
- [ ] Update `docs/data/reviewable-findings/README.md` `--readiness-csv` default from `source_authority_readiness.csv` to `coverage/readiness_rows.csv`.

#### Acceptance criteria
- [ ] `rg "source_authority_readiness.csv" scripts/langchain/build_reviewable_findings_artifact.py` returns no matches.
- [ ] `rg "build_reviewable_findings_artifact" .github/workflows/` matches at least one workflow running on PRs to main.
- [ ] CI job generator step exits zero; uploaded artifact passes `validate_reviewable_findings_artifact`; negative-path step exits non-zero.
- [ ] `pytest -q tests/langchain/test_review_artifact_contract.py tests/langchain/test_chain_to_artifact_pipeline.py` passes with no regressions.
- [ ] `python -c "from pension_data.langchain.review_artifact import validate_reviewable_findings_artifact; import json; validate_reviewable_findings_artifact(json.load(open('docs/data/reviewable-findings/extraction-quality-dashboard.json')))"` exits zero.
- [ ] `docs/contracts/reviewable-findings-artifact-contract.md` Generation Plan names the CI job and `coverage/readiness_rows.csv`.

<!-- auto-status-summary:end -->