### PR TITLE
Issue #477: Build generated web workspace bundle

### DIFF
--- a/Issues.txt
+++ b/Issues.txt
@@ -56,7 +56,7 @@ Non-Goals
 - Implementing broad conversational memory.
 
 Tasks
-- [ ] Choose the first artifact slice: funding trend, allocation peer compare, holdings overlap, or extraction quality dashboard.
+- [x] Choose the first artifact slice: funding trend, allocation peer compare, holdings overlap, or extraction quality dashboard.
 - [ ] Define the minimal findings JSON schema consumed by the static UI and LangChain explainers.
 - [ ] Add a generation command or documented artifact path under `docs/data/` or a release artifact plan.
 - [ ] Add tests or schema validation for the artifact contract.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -28,6 +28,9 @@ Open `apps/web/index.html` in a browser or run a static file server.
   (enabled only for local contexts or when `enableQueryOverrides=true` in config)
 - Workspace bundle contract: `apps/contracts/runtime-contract.json` (versioned contract shared with desktop shell)
 - Workspace bundles must declare `data_origin` as `fixture`, `generated`, or `live`; runtime/deploy smoke checks reject fixture bundles for runtime-required paths.
+- Build a generated review-artifact bundle from a one-PDF pilot run with
+  `python scripts/web/build_workspace_bundle.py --pilot-run-dir <run-dir> --out apps/web/data/workspace.json`.
+  The generator reads `run_manifest.json` and `staging_core_metrics.json`, emits `data_origin: "generated"`, and validates the bundle before writing.
 
 ## Zero-Install Usage
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -28,7 +28,7 @@ Open `apps/web/index.html` in a browser or run a static file server.
   (enabled only for local contexts or when `enableQueryOverrides=true` in config)
 - Workspace bundle contract: `apps/contracts/runtime-contract.json` (versioned contract shared with desktop shell)
 - Workspace bundles must declare `data_origin` as `fixture`, `generated`, or `live`; runtime/deploy smoke checks reject fixture bundles for runtime-required paths.
-- Build a generated review-artifact bundle from a one-PDF pilot run with
+- Build a generated workspace bundle from a one-PDF pilot run with
   `python scripts/web/build_workspace_bundle.py --pilot-run-dir <run-dir> --out apps/web/data/workspace.json`.
   The generator reads `run_manifest.json` and `staging_core_metrics.json`, emits `data_origin: "generated"`, and validates the bundle before writing.
 

--- a/scripts/langchain/build_reviewable_findings_artifact.py
+++ b/scripts/langchain/build_reviewable_findings_artifact.py
@@ -6,6 +6,7 @@ import argparse
 import sys
 
 from pension_data.langchain.review_artifact import (
+    REVIEWABLE_FINDINGS_FIRST_SLICE_ID,
     REVIEWABLE_FINDINGS_ARTIFACT_PATH,
     ReviewableFindingsArtifactError,
     build_extraction_quality_dashboard_artifact,
@@ -19,6 +20,12 @@ DEFAULT_READINESS_CSV_PATH = "coverage/readiness_rows.csv"
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Generate the extraction quality dashboard reviewable findings artifact."
+    )
+    parser.add_argument(
+        "--slice",
+        default=REVIEWABLE_FINDINGS_FIRST_SLICE_ID,
+        choices=[REVIEWABLE_FINDINGS_FIRST_SLICE_ID],
+        help="Artifact slice to generate. Currently only extraction_quality_dashboard is supported.",
     )
     parser.add_argument(
         "--output",

--- a/scripts/langchain/build_reviewable_findings_artifact.py
+++ b/scripts/langchain/build_reviewable_findings_artifact.py
@@ -6,8 +6,8 @@ import argparse
 import sys
 
 from pension_data.langchain.review_artifact import (
-    REVIEWABLE_FINDINGS_FIRST_SLICE_ID,
     REVIEWABLE_FINDINGS_ARTIFACT_PATH,
+    REVIEWABLE_FINDINGS_FIRST_SLICE_ID,
     ReviewableFindingsArtifactError,
     build_extraction_quality_dashboard_artifact,
     write_reviewable_findings_artifact,

--- a/scripts/web/build_workspace_bundle.py
+++ b/scripts/web/build_workspace_bundle.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Build a generated web workspace bundle from one-pdf-pilot artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_PATH = ROOT / "apps" / "contracts" / "runtime-contract.json"
+SMOKE_PATH = ROOT / "scripts" / "web" / "smoke_test.py"
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _load_web_smoke_test() -> Any:
+    spec = importlib.util.spec_from_file_location("web_smoke_test", SMOKE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load web smoke test helper: {SMOKE_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _runtime_contract_version() -> str:
+    payload = _load_json(CONTRACT_PATH)
+    version = payload.get("version") if isinstance(payload, dict) else None
+    if not isinstance(version, str) or not version.strip():
+        raise ValueError(f"runtime contract missing version: {CONTRACT_PATH}")
+    return version
+
+
+def _artifact_path(pilot_run_dir: Path, manifest: Mapping[str, Any], key: str) -> Path:
+    artifact_files = manifest.get("artifact_files")
+    if not isinstance(artifact_files, Mapping):
+        raise ValueError("run_manifest.json missing artifact_files object")
+    raw_path = artifact_files.get(key)
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        raise ValueError(f"run_manifest.json missing artifact_files.{key}")
+    candidate = Path(raw_path)
+    if not candidate.is_absolute():
+        candidate = pilot_run_dir / candidate
+    return candidate
+
+
+def _as_text(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _as_number(value: Any, *, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _evidence_refs(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return []
+        try:
+            decoded = json.loads(stripped)
+        except json.JSONDecodeError:
+            return [stripped]
+        return _evidence_refs(decoded)
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        return [_as_text(item) for item in value if _as_text(item)]
+    return [_as_text(value)] if _as_text(value) else []
+
+
+def map_staging_row_to_ui_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    """Convert a staged core metric row into the static SPA row contract."""
+    value = row.get("normalized_value")
+    if value in (None, ""):
+        value = row.get("as_reported_value")
+    source_document_id = _as_text(row.get("source_document_id"))
+    return {
+        "confidence": _as_number(row.get("confidence")),
+        "entity": _as_text(row.get("plan_id")) or "unknown-plan",
+        "metric": _as_text(row.get("metric_name")),
+        "metric_family": _as_text(row.get("metric_family")) or "core_metric",
+        "plan_period": _as_text(row.get("plan_period")),
+        "provenance": {
+            "evidence_refs": _evidence_refs(row.get("evidence_refs")),
+            "source_document": source_document_id,
+        },
+        "value": value,
+    }
+
+
+def _load_staging_rows(path: Path) -> list[Mapping[str, Any]]:
+    payload = _load_json(path)
+    rows: Any
+    if isinstance(payload, list):
+        rows = payload
+    elif isinstance(payload, Mapping):
+        rows = payload.get("rows") or payload.get("staging_core_metrics_rows")
+    else:
+        rows = None
+    if not isinstance(rows, list) or not rows:
+        raise ValueError(f"staging core metrics file has no rows: {path}")
+    normalized: list[Mapping[str, Any]] = []
+    for index, row in enumerate(rows):
+        if not isinstance(row, Mapping):
+            raise ValueError(f"staging row {index} is not an object in {path}")
+        normalized.append(row)
+    return normalized
+
+
+def _last_updated(manifest: Mapping[str, Any]) -> str:
+    input_payload = manifest.get("input")
+    if isinstance(input_payload, Mapping):
+        for key in ("effective_date", "ingestion_date", "fetched_at"):
+            value = _as_text(input_payload.get(key))
+            if value:
+                return value
+    return datetime.now(UTC).date().isoformat()
+
+
+def build_workspace_bundle(pilot_run_dir: Path) -> dict[str, Any]:
+    pilot_run_dir = pilot_run_dir.resolve()
+    manifest_path = pilot_run_dir / "run_manifest.json"
+    manifest = _load_json(manifest_path)
+    if not isinstance(manifest, Mapping):
+        raise ValueError(f"run manifest must be an object: {manifest_path}")
+
+    staging_rows = _load_staging_rows(
+        _artifact_path(pilot_run_dir, manifest, "staging_core_metrics_json")
+    )
+    rows = [map_staging_row_to_ui_row(row) for row in staging_rows]
+    rows.sort(
+        key=lambda row: (
+            _as_text(row["entity"]),
+            _as_text(row["plan_period"]),
+            _as_text(row["metric_family"]),
+            _as_text(row["metric"]),
+        )
+    )
+    run_id = _as_text(manifest.get("run_id")) or pilot_run_dir.name
+    bundle = {
+        "contractVersion": _runtime_contract_version(),
+        "data_origin": "generated",
+        "datasets": [
+            {
+                "domain": "pension",
+                "freshness": "generated",
+                "id": f"one-pdf-pilot-{run_id}",
+                "kind": "core_metrics",
+                "lastUpdated": _last_updated(manifest),
+                "name": f"One-PDF Pilot Generated Metrics ({run_id})",
+                "rows": rows,
+            }
+        ],
+    }
+    smoke = _load_web_smoke_test()
+    smoke._assert_workspace_bundle(
+        bundle,
+        path_label="generated workspace bundle",
+        reject_fixture=True,
+    )
+    return bundle
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--pilot-run-dir",
+        type=Path,
+        required=True,
+        help="Directory containing run_manifest.json from one-pdf-pilot.",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        required=True,
+        help="Path for the generated workspace bundle JSON.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    bundle = build_workspace_bundle(args.pilot_run_dir)
+    _write_json(args.out, bundle)
+    print(f"wrote generated workspace bundle: {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/web/build_workspace_bundle.py
+++ b/scripts/web/build_workspace_bundle.py
@@ -53,9 +53,12 @@ def _artifact_path(pilot_run_dir: Path, manifest: Mapping[str, Any], key: str) -
     if not isinstance(raw_path, str) or not raw_path.strip():
         raise ValueError(f"run_manifest.json missing artifact_files.{key}")
     candidate = Path(raw_path)
-    if not candidate.is_absolute():
-        candidate = pilot_run_dir / candidate
-    return candidate
+    if candidate.is_absolute() or candidate.exists():
+        return candidate
+    root_candidate = ROOT / candidate
+    if root_candidate.exists():
+        return root_candidate
+    return pilot_run_dir / candidate
 
 
 def _as_text(value: Any) -> str:

--- a/tests/langchain/test_review_artifact_contract.py
+++ b/tests/langchain/test_review_artifact_contract.py
@@ -7,8 +7,10 @@ import tempfile
 from dataclasses import fields
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
+from scripts.langchain import build_reviewable_findings_artifact as artifact_cli
 
 from pension_data.langchain.findings_compare import CompareMetadata
 from pension_data.langchain.findings_explain import ExplainMetadata
@@ -45,6 +47,23 @@ def test_schema_file_matches_python_contract() -> None:
     assert schema["artifact_path"] == REVIEWABLE_FINDINGS_ARTIFACT_PATH
     assert schema["slice"]["first_slice"] == "extraction_quality_dashboard"
     assert "confidence" in schema["findings"]["required_filter_fields"]
+
+
+def test_cli_defaults_to_the_selected_first_artifact_slice() -> None:
+    with patch("sys.argv", ["build_reviewable_findings_artifact.py"]):
+        args = artifact_cli.parse_args()
+    assert args.slice == "extraction_quality_dashboard"
+
+
+def test_cli_rejects_unknown_slice_value() -> None:
+    with (
+        pytest.raises(SystemExit),
+        patch(
+            "sys.argv",
+            ["build_reviewable_findings_artifact.py", "--slice", "funding_trend"],
+        ),
+    ):
+        artifact_cli.parse_args()
 
 
 def test_langchain_required_output_fields_are_non_empty_and_exposed() -> None:

--- a/tests/web/test_build_workspace_bundle.py
+++ b/tests/web/test_build_workspace_bundle.py
@@ -1,0 +1,131 @@
+"""Tests for building generated web workspace bundles from pilot artifacts."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+BUILDER_PATH = ROOT / "scripts" / "web" / "build_workspace_bundle.py"
+SMOKE_PATH = ROOT / "scripts" / "web" / "smoke_test.py"
+
+builder_spec = importlib.util.spec_from_file_location("build_workspace_bundle", BUILDER_PATH)
+assert builder_spec is not None and builder_spec.loader is not None
+build_workspace_bundle = importlib.util.module_from_spec(builder_spec)
+builder_spec.loader.exec_module(build_workspace_bundle)
+
+smoke_spec = importlib.util.spec_from_file_location("web_smoke_test", SMOKE_PATH)
+assert smoke_spec is not None and smoke_spec.loader is not None
+web_smoke_test = importlib.util.module_from_spec(smoke_spec)
+smoke_spec.loader.exec_module(web_smoke_test)
+
+
+def _write_fixture_pilot_run(tmp_path: Path) -> Path:
+    run_dir = tmp_path / "pilot-run"
+    persistence_dir = run_dir / "persistence"
+    persistence_dir.mkdir(parents=True)
+    staging_path = persistence_dir / "staging_core_metrics.json"
+    staging_path.write_text(
+        json.dumps(
+            [
+                {
+                    "confidence": 0.92,
+                    "evidence_refs": ["p12:t4:r2", "p13:t1:r1"],
+                    "metric_family": "funded_status",
+                    "metric_name": "funded_ratio",
+                    "normalized_value": 0.81,
+                    "plan_id": "ca-pers",
+                    "plan_period": "FY2024",
+                    "source_document_id": "calpers-fy2024",
+                },
+                {
+                    "as_reported_value": "$41000000",
+                    "confidence": "0.87",
+                    "evidence_refs": json.dumps(["p22:cashflow"]),
+                    "metric_family": "cash_flow",
+                    "metric_name": "employer_contributions",
+                    "normalized_value": None,
+                    "plan_id": "ca-pers",
+                    "plan_period": "FY2024",
+                    "source_document_id": "calpers-fy2024",
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "run_manifest.json").write_text(
+        json.dumps(
+            {
+                "artifact_files": {
+                    "staging_core_metrics_json": str(staging_path),
+                },
+                "input": {
+                    "effective_date": "2026-05-30",
+                    "plan_id": "ca-pers",
+                    "plan_period": "FY2024",
+                    "source_document_id": "calpers-fy2024",
+                },
+                "run_id": "run-123",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return run_dir
+
+
+def test_generator_emits_runtime_valid_generated_bundle(tmp_path: Path) -> None:
+    run_dir = _write_fixture_pilot_run(tmp_path)
+    payload = build_workspace_bundle.build_workspace_bundle(run_dir)
+
+    web_smoke_test._assert_workspace_bundle(
+        payload,
+        path_label="data/workspace.json",
+        reject_fixture=True,
+    )
+    assert payload["data_origin"] == "generated"
+    dataset = payload["datasets"][0]
+    assert dataset["id"] == "one-pdf-pilot-run-123"
+    assert dataset["lastUpdated"] == "2026-05-30"
+    assert dataset["rows"]
+    assert dataset["rows"][0] == {
+        "confidence": 0.87,
+        "entity": "ca-pers",
+        "metric": "employer_contributions",
+        "metric_family": "cash_flow",
+        "plan_period": "FY2024",
+        "provenance": {
+            "evidence_refs": ["p22:cashflow"],
+            "source_document": "calpers-fy2024",
+        },
+        "value": "$41000000",
+    }
+
+
+def test_cli_writes_bundle_that_runtime_smoke_accepts(tmp_path: Path) -> None:
+    run_dir = _write_fixture_pilot_run(tmp_path)
+    out = tmp_path / "workspace.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(BUILDER_PATH),
+            "--pilot-run-dir",
+            str(run_dir),
+            "--out",
+            str(out),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "wrote generated workspace bundle" in result.stdout
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    web_smoke_test._assert_workspace_bundle(
+        payload,
+        path_label="data/workspace.json",
+        reject_fixture=True,
+    )

--- a/tests/web/test_build_workspace_bundle.py
+++ b/tests/web/test_build_workspace_bundle.py
@@ -104,6 +104,55 @@ def test_generator_emits_runtime_valid_generated_bundle(tmp_path: Path) -> None:
     }
 
 
+def test_generator_accepts_paths_already_rooted_at_output_root(tmp_path: Path, monkeypatch) -> None:
+    run_dir = tmp_path / "outputs" / "one_pdf_pilot" / "run-456"
+    persistence_dir = run_dir / "extraction_persistence"
+    persistence_dir.mkdir(parents=True)
+    staging_path = persistence_dir / "staging_core_metrics.json"
+    staging_path.write_text(
+        json.dumps(
+            [
+                {
+                    "confidence": 0.93,
+                    "metric_family": "funded_status",
+                    "metric_name": "funded_ratio",
+                    "normalized_value": 0.82,
+                    "plan_id": "ca-pers",
+                    "plan_period": "FY2025",
+                    "source_document_id": "calpers-fy2025",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "run_manifest.json").write_text(
+        json.dumps(
+            {
+                "artifact_files": {
+                    "staging_core_metrics_json": (
+                        "outputs/one_pdf_pilot/run-456/"
+                        "extraction_persistence/staging_core_metrics.json"
+                    ),
+                },
+                "input": {"effective_date": "2026-05-30"},
+                "run_id": "run-456",
+            }
+        ),
+        encoding="utf-8",
+    )
+    contract_path = tmp_path / "apps" / "contracts" / "runtime-contract.json"
+    contract_path.parent.mkdir(parents=True)
+    contract_path.write_text(
+        (ROOT / "apps" / "contracts" / "runtime-contract.json").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(tmp_path)
+    payload = build_workspace_bundle.build_workspace_bundle(run_dir)
+
+    assert payload["datasets"][0]["rows"][0]["metric"] == "funded_ratio"
+
+
 def test_cli_writes_bundle_that_runtime_smoke_accepts(tmp_path: Path) -> None:
     run_dir = _write_fixture_pilot_run(tmp_path)
     out = tmp_path / "workspace.json"


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:477 -->
> **Source:** Issue #477

Closes #477

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The product's stated purpose is exploring real extracted pension facts (`README.md:3`), but the only data the SPA can load is the hand-curated demo bundle at `apps/web/data/workspace.json`, which is `"data_origin": "fixture"` (verified: file header lines 1-3) carrying synthetic CA-PERS / NY-STRS / TX-ERS rows. The runtime contract already defines a `generated` origin (`apps/contracts/runtime-contract.json:5` — `"dataOrigins": ["fixture", "generated", "live"]`), the SPA already supports rendering it (`apps/web/app.js:11-13`, `DATA_ORIGIN_LABELS.generated`), and the pilot already emits all the source data needed (`run_one_pdf_pilot` writes `staging_core_metrics.json` plus a `run_manifest.json`, `src/pension_data/ops/one_pdf_pilot.py:402-470`). What is missing is the deterministic mapping step: nothing converts pilot/staging output into a contract-conformant `generated` bundle (a grep of `scripts/` and `.github/workflows/` finds only `scripts/web/smoke_test.py` reading `data/workspace.json`; no writer exists). A bundle generator is a pure deterministic program operating on already-extracted facts, so it is fully inside the privacy perimeter — no data egress, no LLM.

#### Tasks
- [x] Add `scripts/web/build_workspace_bundle.py` with a `--pilot-run-dir` argument and `--out` argument; load `staging_core_metrics.json` and `run_manifest.json` from that dir.
- [ ] Implement a `map_staging_row_to_ui_row()` function that converts each staging row (`metric_name`, `normalized_value`, `evidence_refs`, `source_document_id` — column names from `src/pension_data/db/staging_persistence.py:11-30`) into the UI row shape (`entity`, `plan_period`, `metric_family`, `metric`, `value`, `confidence`, `provenance.{source_document, evidence_refs}`) consumed by `apps/web/app.js:343` and `flattenRows` (`app.js:556-571`).
- [ ] Set `contractVersion` from `RUNTIME_CONTRACT_VERSION` (`apps/web/app.js:8`, currently `"1.0.0"`, which must equal `apps/contracts/runtime-contract.json:2`) and set `data_origin: "generated"`; group rows into at least one dataset object carrying the `datasetRequiredFields` from the contract (`id, name, domain, kind, freshness, lastUpdated, rows` — `runtime-contract.json:6`).
- [ ] Reuse `scripts/web/smoke_test.py`'s `_assert_workspace_bundle` (import it the same way `tests/web/test_workspace_contract.py:16-19` does) to self-validate the bundle before writing.
- [x] Add `tests/web/test_build_workspace_bundle.py` that runs the generator on a small fixture pilot-run directory and asserts the emitted bundle passes `_assert_workspace_bundle(..., reject_fixture=True)`.
- [x] Document the generate-then-load flow in `apps/web/README.md` (extend the "Runtime Config" section, lines 23-30).

#### Acceptance criteria
- [ ] New failing-first test `tests/web/test_build_workspace_bundle.py::test_generator_emits_runtime_valid_generated_bundle` asserts the generated bundle passes `web_smoke_test._assert_workspace_bundle(payload, path_label="data/workspace.json", reject_fixture=True)` and has a non-empty `datasets[0].rows`; the test fails before the generator exists and passes after.
- [ ] Running `python scripts/web/build_workspace_bundle.py --pilot-run-dir <real pilot output> --out apps/web/data/workspace.json` produces a file whose `data_origin == "generated"` and that loads in the SPA with no console error (the SPA's own validators at `app.js:108-117` accept it).
- [ ] `python scripts/web/smoke_test.py --base-dir apps/web --require-runtime` passes when the generated bundle (plus a `config/runtime.json`) is present, where it currently raises `fixture workspace bundle is not allowed for runtime smoke` (`smoke_test.py:62-63`).
- [ ] `pytest -q tests/web/` stays green, including the existing `test_packaged_workspace_declares_fixture_origin` (the committed demo bundle is untouched).

<!-- auto-status-summary:end -->