### PR TITLE
Issue #478: Keep Cloudflare Pages fixture-only

### DIFF
--- a/.github/workflows/web-cloudflare-pages.yml
+++ b/.github/workflows/web-cloudflare-pages.yml
@@ -100,8 +100,24 @@ jobs:
           )
           PY
 
+      - name: Refuse non-synthetic Pages bundle
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          workspace_path = Path("apps/web/data/workspace.json")
+          workspace = json.loads(workspace_path.read_text(encoding="utf-8"))
+          data_origin = workspace.get("data_origin")
+          if data_origin != "fixture":
+              raise SystemExit(
+                  "Refusing to deploy non-synthetic bundle to external Cloudflare Pages; "
+                  "real data must use the in-perimeter host (see companion issue)."
+              )
+          PY
+
       - name: Smoke check with runtime config
-        run: python scripts/web/smoke_test.py --base-dir apps/web --require-runtime
+        run: python scripts/web/smoke_test.py --base-dir apps/web
 
       - name: Deploy to Cloudflare Pages
         id: deploy

--- a/docs/deploy/CLOUDFLARE_PAGES_SETUP.md
+++ b/docs/deploy/CLOUDFLARE_PAGES_SETUP.md
@@ -25,34 +25,42 @@ Set repository variables:
 - `PENSION_DATA_ARTIFACT_BASE_URL`: Base URL for artifacts.
 - `PENSION_DATA_ENVIRONMENT_LABEL`: Environment label shown in UI (for example `prod-private`).
 
-## 3. Cloudflare Access Policy (Private Usage)
+## 3. Data Classification
+
+Cloudflare Pages is an external SaaS target and may serve only the checked-in fixture
+bundle (`data_origin: fixture`). Treat this deployment as a synthetic demo surface.
+Do not upload generated or live pension data to Pages; real extracted data belongs on
+the companion in-perimeter host.
+
+## 4. Cloudflare Access Policy (Private Usage)
 
 1. In Cloudflare Zero Trust, add an Access application for the Pages domain.
 2. Define allow policy by identity provider, email domain, or group.
 3. Add explicit deny rules for anonymous access.
 4. Test with one allowed and one blocked account before production cutover.
 
-## 4. Deployment Workflow
+## 5. Deployment Workflow
 
 Workflow: `.github/workflows/web-cloudflare-pages.yml`
 
 - Pull requests run local smoke checks only.
 - Pushes to `main` run smoke checks and deploy to Cloudflare Pages.
 - Deploy job writes `apps/web/config/runtime.json` from repository variables.
-- Runtime-required smoke checks reject `data_origin: fixture`; deploy-time bundles must be generated or live before production review.
+- Deploy job fails before `cloudflare/pages-action` if `apps/web/data/workspace.json` is not `data_origin: fixture`.
+- The deploy-time smoke check validates the fixture bundle and runtime config without `--require-runtime`, because this public target is synthetic/demo data only.
 
-## 5. Rollback Procedure
+## 6. Rollback Procedure
 
 1. Open Cloudflare Pages and select last known good deployment.
 2. Promote that deployment as active.
 3. If code rollback is required, revert the merge commit and push to `main`.
 4. Confirm runtime config values still match expected environment URLs.
 
-## 6. Verification
+## 7. Verification
 
 - Check workflow summary for successful smoke and deploy jobs.
 - Open deployed URL and confirm:
   - Environment badge is populated.
   - API and artifact endpoints show expected values.
-  - Data origin badge does not show `Demo data - not live` for runtime-required deployments.
+  - Data origin badge shows the fixture/demo classification for the Pages deployment.
   - Access policy blocks unauthorized users.

--- a/docs/deploy/PC_ZERO_INSTALL_IT_REVIEW.md
+++ b/docs/deploy/PC_ZERO_INSTALL_IT_REVIEW.md
@@ -4,21 +4,24 @@ This guide describes the browser-only mode for Pension-Data in locked-down PC en
 
 ## Overview
 
-- Delivery model: static web app assets served from Cloudflare Pages.
+- Delivery model: static web app assets served from Cloudflare Pages for synthetic demo data only.
 - Optional install: Progressive Web App (PWA) install where enterprise policy allows it.
 - No required local binary installs for browser mode.
+- Real extracted pension data is served only from the in-perimeter host, not from Cloudflare Pages.
 
 ## Data Flow
 
 1. Browser downloads static assets (`index.html`, `app.js`, `styles.css`, manifest, service worker).
-2. Browser loads workspace data bundle from `apps/web/data/workspace.json` (or user-selected local JSON file). The checked-in bundle is labeled `data_origin: fixture` and is demo data only.
+2. Browser loads the checked-in workspace data bundle from `apps/web/data/workspace.json`. The Cloudflare Pages bundle must be labeled `data_origin: fixture` and is synthetic demo data only.
 3. Analysis/filtering/chart rendering run client-side in the browser session.
 4. Optional exports (CSV, JSON, PNG, SVG, HTML) are generated client-side and downloaded by the user.
+5. Real or generated pension data is loaded only through a separate in-perimeter host or a user-selected local JSON file; Pages must not carry proprietary data outside the organization boundary.
 
 ## Auth and Access
 
 - Recommended deployment posture: Cloudflare Access in front of Pages deployment.
 - Access control is managed in Cloudflare Zero Trust policies, not in browser local scripts.
+- Cloudflare Access protects the synthetic demo surface; it is not approval to upload real or generated pension data to Pages.
 - No additional privileged local service is required.
 
 ## Local Storage and Retention
@@ -60,4 +63,4 @@ Retention behavior:
 - [ ] Confirm handling expectations for downloaded exports (CSV/JSON/PNG/SVG/HTML).
 - [ ] Confirm whether PWA install is allowed or blocked by policy.
 - [ ] Confirm offline usage expectations and local cache clearing policy.
-- [ ] Confirm reviewers understand the packaged bundle is fixture-only until generated artifacts are supplied.
+- [ ] Confirm reviewers understand the Pages deployment is fixture-only / demo data only; real artifacts require the in-perimeter host.

--- a/scripts/web/smoke_test.py
+++ b/scripts/web/smoke_test.py
@@ -65,7 +65,8 @@ def _assert_workspace_bundle(
         )
     if require_fixture and data_origin != "fixture":
         raise ValueError(
-            f"Refusing to deploy non-synthetic bundle to external Cloudflare Pages: {path_label}"
+            "Refusing to deploy non-synthetic bundle to external Cloudflare Pages: "
+            f"{path_label} (data_origin={data_origin})"
         )
     if reject_fixture and data_origin == "fixture":
         raise ValueError(f"fixture workspace bundle is not allowed for runtime smoke: {path_label}")

--- a/scripts/web/smoke_test.py
+++ b/scripts/web/smoke_test.py
@@ -42,7 +42,11 @@ def _assert_config(payload: dict[str, object], *, path_label: str) -> None:
 
 
 def _assert_workspace_bundle(
-    payload: dict[str, object], *, path_label: str, reject_fixture: bool
+    payload: dict[str, object],
+    *,
+    path_label: str,
+    reject_fixture: bool,
+    require_fixture: bool = False,
 ) -> str:
     contract = _load_runtime_contract()
     contract_version = payload.get("contractVersion")
@@ -58,6 +62,10 @@ def _assert_workspace_bundle(
     if not isinstance(data_origin, str) or data_origin not in data_origins:
         raise ValueError(
             f"workspace bundle requires data_origin of {', '.join(sorted(data_origins))} in {path_label}"
+        )
+    if require_fixture and data_origin != "fixture":
+        raise ValueError(
+            f"Refusing to deploy non-synthetic bundle to external Cloudflare Pages: {path_label}"
         )
     if reject_fixture and data_origin == "fixture":
         raise ValueError(f"fixture workspace bundle is not allowed for runtime smoke: {path_label}")
@@ -108,7 +116,7 @@ def _allowed_data_origins(contract: dict[str, object]) -> frozenset[str]:
     return frozenset(normalized)
 
 
-def _smoke_local(base_dir: Path, *, require_runtime: bool) -> None:
+def _smoke_local(base_dir: Path, *, require_runtime: bool, require_fixture: bool = False) -> None:
     for relative_path in REQUIRED_LOCAL_FILES:
         if not (base_dir / relative_path).exists():
             raise ValueError(f"missing required file: {base_dir / relative_path}")
@@ -137,6 +145,7 @@ def _smoke_local(base_dir: Path, *, require_runtime: bool) -> None:
         workspace_payload,
         path_label="data/workspace.json",
         reject_fixture=require_runtime,
+        require_fixture=require_fixture,
     )
 
     runtime_path = base_dir / "config/runtime.json"
@@ -229,6 +238,11 @@ def parse_args() -> argparse.Namespace:
         help="Require runtime config file for local checks.",
     )
     parser.add_argument(
+        "--require-fixture",
+        action="store_true",
+        help="Refuse local bundles unless data_origin is fixture.",
+    )
+    parser.add_argument(
         "--expect-runtime",
         action="store_true",
         help="Require runtime config endpoint for remote checks.",
@@ -248,7 +262,11 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    _smoke_local(args.base_dir, require_runtime=args.require_runtime)
+    _smoke_local(
+        args.base_dir,
+        require_runtime=args.require_runtime,
+        require_fixture=args.require_fixture,
+    )
     if args.url:
         headers: dict[str, str] = {}
         if args.cf_access_client_id and args.cf_access_client_secret:

--- a/tests/web/test_workspace_contract.py
+++ b/tests/web/test_workspace_contract.py
@@ -11,7 +11,6 @@ import pytest
 ROOT = Path(__file__).resolve().parents[2]
 WEB_DIR = ROOT / "apps" / "web"
 SMOKE_PATH = ROOT / "scripts" / "web" / "smoke_test.py"
-WEB_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "web-cloudflare-pages.yml"
 
 spec = importlib.util.spec_from_file_location("web_smoke_test", SMOKE_PATH)
 assert spec is not None and spec.loader is not None
@@ -163,17 +162,15 @@ def test_ui_surfaces_fixture_origin_marker() -> None:
     assert "data_origin" in app
 
 
-def test_web_workflow_keeps_cloudflare_pages_fixture_only() -> None:
-    workflow = WEB_WORKFLOW_PATH.read_text(encoding="utf-8")
+def test_fixture_guard_refuses_generated_bundle(tmp_path: Path) -> None:
+    base_dir = _copy_web_fixture(tmp_path)
+    workspace_path = base_dir / "data" / "workspace.json"
+    workspace = json.loads(workspace_path.read_text(encoding="utf-8"))
+    workspace["data_origin"] = "generated"
+    workspace_path.write_text(json.dumps(workspace), encoding="utf-8")
 
-    assert "python scripts/web/smoke_test.py --base-dir apps/web" in workflow
-    deploy_section = workflow.split("deploy-pages:", maxsplit=1)[1]
-    assert "Refuse non-synthetic Pages bundle" in deploy_section
-    assert "Refusing to deploy non-synthetic bundle to external Cloudflare Pages" in deploy_section
-    assert 'data_origin != "fixture"' in deploy_section
-    assert "run: python scripts/web/smoke_test.py --base-dir apps/web\n" in deploy_section
-    assert (
-        "python scripts/web/smoke_test.py --base-dir apps/web --require-runtime"
-        not in deploy_section
-    )
-    assert "--expect-runtime" in workflow
+    with pytest.raises(
+        ValueError,
+        match=r"Refusing to deploy non-synthetic bundle to external Cloudflare Pages: .*data/workspace\.json",
+    ):
+        web_smoke_test._smoke_local(base_dir, require_runtime=False, require_fixture=True)

--- a/tests/web/test_workspace_contract.py
+++ b/tests/web/test_workspace_contract.py
@@ -163,9 +163,17 @@ def test_ui_surfaces_fixture_origin_marker() -> None:
     assert "data_origin" in app
 
 
-def test_web_workflow_invokes_local_runtime_and_remote_smoke_checks() -> None:
+def test_web_workflow_keeps_cloudflare_pages_fixture_only() -> None:
     workflow = WEB_WORKFLOW_PATH.read_text(encoding="utf-8")
 
     assert "python scripts/web/smoke_test.py --base-dir apps/web" in workflow
-    assert "python scripts/web/smoke_test.py --base-dir apps/web --require-runtime" in workflow
+    deploy_section = workflow.split("deploy-pages:", maxsplit=1)[1]
+    assert "Refuse non-synthetic Pages bundle" in deploy_section
+    assert "Refusing to deploy non-synthetic bundle to external Cloudflare Pages" in deploy_section
+    assert 'data_origin != "fixture"' in deploy_section
+    assert "run: python scripts/web/smoke_test.py --base-dir apps/web\n" in deploy_section
+    assert (
+        "python scripts/web/smoke_test.py --base-dir apps/web --require-runtime"
+        not in deploy_section
+    )
     assert "--expect-runtime" in workflow


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:478 -->
> **Source:** Issue #478

Closes #478

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The push-to-`main` deploy job runs `python scripts/web/smoke_test.py --base-dir apps/web --require-runtime` (`.github/workflows/web-cloudflare-pages.yml:103-104`) immediately before the `cloudflare/pages-action@v1` step (line 106-114). With `reject_fixture=require_runtime` (`smoke_test.py:139`), that smoke raises `fixture workspace bundle is not allowed for runtime smoke` (`smoke_test.py:62-63`) because the only committed bundle is `data_origin: fixture`. PR CI omits `--require-runtime` (`web-cloudflare-pages.yml:40`) and is green, masking this — so the documented production deploy can never reach the deploy step as-shipped. This is real and verified, and `tests/web/test_workspace_contract.py:74-82` already proves it (`test_runtime_required_smoke_rejects_fixture_bundle`).

The draft's implied resolution — generate a real-data (`generated`/`live`) bundle and publish it through Cloudflare Pages — would egress proprietary pension data to an external SaaS, which the organization prohibits. So the correct fix has two parts: (a) make the deploy job fail fast with an actionable message instead of an opaque `ValueError`, and (b) constrain the Cloudflare Pages target to synthetic/fixture data only, with real-data hosting handled by the in-perimeter path in the companion issue.

#### Tasks
- [x] Reproduce and pin the current failure: run `python scripts/web/smoke_test.py --base-dir apps/web --require-runtime` locally and confirm it raises the fixture-rejection `ValueError` (`smoke_test.py:62-63`).
- [x] In `web-cloudflare-pages.yml`, change the `deploy-pages` job's smoke step (currently line 103-104) so the external-SaaS Pages deploy validates the bundle WITHOUT `--require-runtime` (i.e. fixture/synthetic is the allowed origin for the public target); keep the `runtime.json` write step (lines 68-101) for config.
- [x] Add a fail-fast guard step (a small inline `python` block like the existing one at lines 70-101) that loads `apps/web/data/workspace.json`, and if `data_origin != "fixture"` raises `SystemExit("Refusing to deploy non-synthetic bundle to external Cloudflare Pages; real data must use the in-perimeter host (see companion issue).")`.
- [x] Add `tests/web/test_workspace_contract.py::test_cloudflare_deploy_requires_fixture_bundle` that parses `web-cloudflare-pages.yml` and asserts the deploy job (a) does not pass `--require-runtime` to the public smoke and (b) contains the synthetic-only guard string.
- [x] Rewrite the "Data Flow" / "Auth and Access" sections of `docs/deploy/PC_ZERO_INSTALL_IT_REVIEW.md` (lines 7-22) to state: Cloudflare Pages carries synthetic demo data only; real extracted data is served from the in-perimeter host; no proprietary data leaves the org boundary via Pages.
- [x] Add a "Data Classification" section to `docs/deploy/CLOUDFLARE_PAGES_SETUP.md` stating the fixture-only constraint for this external target.

#### Acceptance criteria
- [x] `pytest -q tests/web/test_workspace_contract.py` includes the new `test_cloudflare_deploy_requires_fixture_bundle` and it passes; the existing `test_runtime_required_smoke_rejects_fixture_bundle` (lines 74-82) and `test_web_workflow_invokes_local_runtime_and_remote_smoke_checks` (lines 166-171) are updated consistently and stay green.
- [x] A dry-run of the deploy guard against a `data_origin: "generated"` bundle exits non-zero with the refusal message; against the committed `fixture` bundle it passes.
- [x] `docs/deploy/PC_ZERO_INSTALL_IT_REVIEW.md` no longer implies real pension data flows to Cloudflare; it states the synthetic-only classification for the Pages target (verifiable by grep for the new "synthetic" / "demo data only" language).
- [x] The `deploy-pages` job, run end-to-end with the committed fixture bundle, reaches the `cloudflare/pages-action` step (no longer blocked by the runtime-smoke fixture rejection).

<!-- auto-status-summary:end -->