### PR TITLE
Issue #482: Add golden/reference CI runs for one-PDF pilot and guarded NL->SQL

### DIFF
--- a/.github/workflows/nl-sql-golden.yml
+++ b/.github/workflows/nl-sql-golden.yml
@@ -1,0 +1,90 @@
+name: NL-SQL Golden
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  nl-sql-golden:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Run NL->SQL golden corpus (deterministic stub chain, no live LLM)
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/golden_nl
+          set +e
+          PYTHONPATH=src:.:tools python tools/golden_nl/nl_sql_golden.py \
+            --corpus tests/golden/nl_sql/corpus.json \
+            --baseline tests/golden/nl_sql/baseline.json \
+            --emit-root artifacts/golden_nl
+          driver_exit=$?
+          set -e
+          # exit 0 = clean, 2 = drift (gated below); anything else is a hard failure
+          # (e.g. a provenance / UNSAFE_SQL invariant violation).
+          if [ "$driver_exit" -ne 0 ] && [ "$driver_exit" -ne 2 ]; then
+            exit "$driver_exit"
+          fi
+
+      - name: Gate NL->SQL golden drift
+        run: |
+          set -euo pipefail
+          PYTHONPATH=src:. python tools/ci_quality/replay_gate.py \
+            --diff artifacts/golden_nl/diff_report.json \
+            --max-unexpected 0 \
+            --report-out artifacts/golden_nl/replay_gate_report.json
+
+      - name: Replay recorded NL request against seeded fixture
+        run: |
+          set -euo pipefail
+          PYTHONPATH=src:. python scripts/langchain/nl_replay.py \
+            --db-path artifacts/golden_nl/seed.db \
+            --log-path artifacts/golden_nl/nl_operations.jsonl \
+            > artifacts/golden_nl/replay_actual.json
+          PYTHONPATH=src:. python - <<'PY'
+          import json
+          from pathlib import Path
+
+          actual = json.loads(Path("artifacts/golden_nl/replay_actual.json").read_text())
+          expected = json.loads(Path("artifacts/golden_nl/replay_expected.json").read_text())
+          mismatches = [
+              key
+              for key in ("status", "returned_rows")
+              if actual.get(key) != expected.get(key)
+          ]
+          if mismatches:
+              raise SystemExit(
+                  "nl_replay mismatch on "
+                  f"{mismatches}: actual={actual} expected={expected}"
+              )
+          print(
+              "Replay matches recorded run: "
+              f"status={actual['status']} returned_rows={actual['returned_rows']}"
+          )
+          PY
+
+      - name: Upload NL->SQL golden artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: nl-sql-golden
+          path: |
+            artifacts/golden_nl/snapshot.json
+            artifacts/golden_nl/diff_report.json
+            artifacts/golden_nl/replay_gate_report.json
+            artifacts/golden_nl/replay_actual.json
+            artifacts/golden_nl/replay_expected.json
+          if-no-files-found: warn

--- a/.github/workflows/one-pdf-pilot-golden.yml
+++ b/.github/workflows/one-pdf-pilot-golden.yml
@@ -1,0 +1,70 @@
+name: One-PDF Pilot Golden
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  one-pdf-pilot-golden:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Run one-PDF pilot on synthetic golden fixture
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/golden_pilot
+          PYTHONPATH=src:. python scripts/run_one_pdf_pilot.py \
+            --pdf-path tests/golden/one_pdf_pilot/fixture_synthetic.pdf \
+            --plan-id CA-PERS \
+            --plan-period FY2024 \
+            --effective-date 2024-06-30 \
+            --ingestion-date 2026-03-03 \
+            --output-root artifacts/golden_pilot/run \
+            --run-id pilot-golden
+
+      - name: Build pilot manifest diff against committed baseline
+        run: |
+          set -euo pipefail
+          set +e
+          PYTHONPATH=src:. python tools/ci_quality/manifest_gate.py \
+            --manifest artifacts/golden_pilot/run/one_pdf_pilot/pilot-golden/run_manifest.json \
+            --baseline tests/golden/one_pdf_pilot/run_manifest_baseline.json \
+            --snapshot-out artifacts/golden_pilot/current_snapshot.json \
+            --report-out artifacts/golden_pilot/diff_report.json
+          diff_exit=$?
+          set -e
+          if [ "$diff_exit" -ne 0 ] && [ "$diff_exit" -ne 2 ]; then
+            exit "$diff_exit"
+          fi
+
+      - name: Gate pilot manifest drift
+        run: |
+          set -euo pipefail
+          PYTHONPATH=src:. python tools/ci_quality/replay_gate.py \
+            --diff artifacts/golden_pilot/diff_report.json \
+            --max-unexpected 0 \
+            --report-out artifacts/golden_pilot/replay_gate_report.json
+
+      - name: Upload one-PDF pilot golden artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: one-pdf-pilot-golden
+          path: |
+            artifacts/golden_pilot/current_snapshot.json
+            artifacts/golden_pilot/diff_report.json
+            artifacts/golden_pilot/replay_gate_report.json
+          if-no-files-found: warn

--- a/docs/CI_SYSTEM_GUIDE.md
+++ b/docs/CI_SYSTEM_GUIDE.md
@@ -106,6 +106,33 @@ To add a domain-specific job:
 2. Add your job with appropriate triggers
 3. Include the job in the Gate aggregation (if using custom Gate)
 
+### Repository-Specific Golden Gates
+
+This repo pins each tool that embodies its role to a **golden reference run**: a
+committed baseline that must keep matching on every PR. Each gate produces a
+snapshot artifact and diffs it against the committed baseline with
+`tools/ci_quality/replay_gate.py --max-unexpected 0` (a green job with no baseline
+diff is not sufficient).
+
+| Workflow | Tool under gate | Baseline |
+|----------|-----------------|----------|
+| `extraction-golden-regression.yml` | Fallback extraction parser | `tests/golden/extraction_fallback_baseline.json` |
+| `entity-regression.yml` | Entity resolution | `tests/golden/` entity corpus |
+| `quality-replay.yml` | Quality replay | quality corpus |
+| `quality-sla-check.yml` | Quality SLA | SLA thresholds |
+| `foundation-fixture-e2e.yml` | Foundation fixture E2E | foundation fixture |
+| `one-pdf-pilot-golden.yml` | One-PDF pilot (`scripts/run_one_pdf_pilot.py`) | `tests/golden/one_pdf_pilot/run_manifest_baseline.json` |
+| `nl-sql-golden.yml` | NL→SQL chain (`run_nl_sql_chain` + `scripts/langchain/nl_replay.py`) | `tests/golden/nl_sql/baseline.json` |
+
+The `one-pdf-pilot-golden.yml` job runs the pilot on a tiny **synthetic** fixture
+with a pinned `--run-id`, then diffs the resulting `run_manifest.json`
+(`artifact_files` keys + `ledger_status`) against the committed baseline. The
+`nl-sql-golden.yml` job runs a committed corpus through a deterministic in-process
+stub chain (no live LLM), asserts per-row `source_document_id` provenance and that
+a `SELECT` omitting `source_document_id` is rejected with `UNSAFE_SQL`, then
+replays a recorded request via `scripts/langchain/nl_replay.py` against a seeded
+SQLite fixture.
+
 ---
 
 ## Agent Automation System

--- a/tests/ci_quality/test_manifest_gate.py
+++ b/tests/ci_quality/test_manifest_gate.py
@@ -2,12 +2,9 @@
 
 from __future__ import annotations
 
-import json
-from pathlib import Path
-
 import pytest
 
-from tools.ci_quality.manifest_gate import diff_manifest, extract_snapshot, run
+from tools.ci_quality.manifest_gate import diff_manifest, extract_snapshot
 
 _BASELINE = {
     "artifact_files_keys": ["alpha_json", "beta_json", "gamma_json"],

--- a/tests/ci_quality/test_manifest_gate.py
+++ b/tests/ci_quality/test_manifest_gate.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import pytest
 
-from tools.ci_quality.manifest_gate import diff_manifest, extract_snapshot
+from tools.ci_quality.manifest_gate import diff_manifest, extract_snapshot, run
 
 _BASELINE = {
     "artifact_files_keys": ["alpha_json", "beta_json", "gamma_json"],

--- a/tests/ci_quality/test_manifest_gate.py
+++ b/tests/ci_quality/test_manifest_gate.py
@@ -1,0 +1,69 @@
+"""Unit tests for the one-PDF pilot manifest golden gate."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.ci_quality.manifest_gate import diff_manifest, extract_snapshot
+
+_BASELINE = {
+    "artifact_files_keys": ["alpha_json", "beta_json", "gamma_json"],
+    "ledger_status": "success",
+}
+
+
+def _manifest(*, keys: list[str], ledger_status: str) -> dict[str, object]:
+    return {
+        "ledger_status": ledger_status,
+        "artifact_files": {key: f"/run/{key}.json" for key in keys},
+    }
+
+
+def test_extract_snapshot_returns_sorted_keys_and_status() -> None:
+    snapshot = extract_snapshot(_manifest(keys=["gamma_json", "alpha_json"], ledger_status="ok"))
+    assert snapshot == {
+        "artifact_files_keys": ["alpha_json", "gamma_json"],
+        "ledger_status": "ok",
+    }
+
+
+def test_extract_snapshot_rejects_malformed_manifest() -> None:
+    with pytest.raises(ValueError, match="artifact_files"):
+        extract_snapshot({"ledger_status": "success", "artifact_files": []})
+    with pytest.raises(ValueError, match="ledger_status"):
+        extract_snapshot({"artifact_files": {}})
+
+
+def test_clean_manifest_has_no_drift() -> None:
+    manifest = _manifest(keys=["alpha_json", "beta_json", "gamma_json"], ledger_status="success")
+    report = diff_manifest(baseline=_BASELINE, current_manifest=manifest)
+    assert report["unexpected_changes"] == 0
+    assert report["total_changes"] == 0
+    assert report["changes"] == []
+
+
+def test_added_and_removed_artifact_keys_are_unexpected_drift() -> None:
+    manifest = _manifest(keys=["alpha_json", "beta_json", "delta_json"], ledger_status="success")
+    report = diff_manifest(baseline=_BASELINE, current_manifest=manifest)
+    assert report["unexpected_changes"] == 2
+    fields = {change["field"] for change in report["changes"]}
+    assert fields == {"gamma_json", "delta_json"}
+    assert all(change["classification"] == "unexpected_drift" for change in report["changes"])
+
+
+def test_ledger_status_change_is_unexpected_drift() -> None:
+    manifest = _manifest(keys=["alpha_json", "beta_json", "gamma_json"], ledger_status="partial")
+    report = diff_manifest(baseline=_BASELINE, current_manifest=manifest)
+    assert report["unexpected_changes"] == 1
+    change = report["changes"][0]
+    assert change["field"] == "ledger_status"
+    assert change["baseline"] == "success"
+    assert change["current"] == "partial"
+
+
+def test_report_summary_counts_are_consistent() -> None:
+    manifest = _manifest(keys=["alpha_json"], ledger_status="partial")
+    report = diff_manifest(baseline=_BASELINE, current_manifest=manifest)
+    # 2 removed keys + 1 ledger status change
+    assert report["total_changes"] == 3
+    assert report["unexpected_changes"] == len(report["changes"])

--- a/tests/golden/nl_sql/baseline.json
+++ b/tests/golden/nl_sql/baseline.json
@@ -1,0 +1,25 @@
+{
+  "queries": [
+    {
+      "error_code": null,
+      "id": "all_curated_metric_facts",
+      "provenance_complete": true,
+      "returned_rows": 3,
+      "status": "ok"
+    },
+    {
+      "error_code": null,
+      "id": "funded_ratio_with_provenance",
+      "provenance_complete": true,
+      "returned_rows": 2,
+      "status": "ok"
+    },
+    {
+      "error_code": "UNSAFE_SQL",
+      "id": "omits_source_document_id",
+      "provenance_complete": true,
+      "returned_rows": 0,
+      "status": "error"
+    }
+  ]
+}

--- a/tests/golden/nl_sql/corpus.json
+++ b/tests/golden/nl_sql/corpus.json
@@ -1,0 +1,33 @@
+{
+  "table": "curated_metric_facts",
+  "schema": "CREATE TABLE curated_metric_facts (plan_id TEXT NOT NULL, plan_period TEXT NOT NULL, metric_family TEXT NOT NULL, metric_name TEXT NOT NULL, normalized_value REAL NOT NULL, normalized_unit TEXT, source_document_id TEXT NOT NULL)",
+  "rows": [
+    {"plan_id": "CA-PERS", "plan_period": "FY2024", "metric_family": "funded_status", "metric_name": "funded_ratio", "normalized_value": 0.784, "normalized_unit": "ratio", "source_document_id": "doc:ca-2024"},
+    {"plan_id": "CA-PERS", "plan_period": "FY2023", "metric_family": "funded_status", "metric_name": "funded_ratio", "normalized_value": 0.771, "normalized_unit": "ratio", "source_document_id": "doc:ca-2023"},
+    {"plan_id": "CA-PERS", "plan_period": "FY2024", "metric_family": "assumptions", "metric_name": "discount_rate", "normalized_value": 0.068, "normalized_unit": "ratio", "source_document_id": "doc:ca-2024"}
+  ],
+  "queries": [
+    {
+      "id": "funded_ratio_with_provenance",
+      "question": "List funded ratio facts with their source document provenance",
+      "sql": "SELECT plan_id, plan_period, metric_name, normalized_value, source_document_id FROM curated_metric_facts WHERE metric_family = 'funded_status'",
+      "expect_status": "ok",
+      "expect_unsafe": false
+    },
+    {
+      "id": "all_curated_metric_facts",
+      "question": "Show every curated metric fact with provenance",
+      "sql": "SELECT plan_id, plan_period, metric_name, normalized_value, source_document_id FROM curated_metric_facts",
+      "expect_status": "ok",
+      "expect_unsafe": false
+    },
+    {
+      "id": "omits_source_document_id",
+      "question": "List metric values without provenance",
+      "sql": "SELECT plan_id, metric_name, normalized_value FROM curated_metric_facts",
+      "expect_status": "error",
+      "expect_unsafe": true
+    }
+  ],
+  "replay_query_id": "funded_ratio_with_provenance"
+}

--- a/tests/golden/one_pdf_pilot/fixture_synthetic.pdf
+++ b/tests/golden/one_pdf_pilot/fixture_synthetic.pdf
@@ -1,0 +1,7 @@
+Funded Ratio: 78.4%
+AAL: $640 million
+AVA: $501.8 million
+Discount Rate: 6.8%
+Employer Contribution Rate: 12.4%
+Employee Contribution Rate: 7.5%
+Participant Count: 325000

--- a/tests/golden/one_pdf_pilot/run_manifest_baseline.json
+++ b/tests/golden/one_pdf_pilot/run_manifest_baseline.json
@@ -1,0 +1,17 @@
+{
+  "artifact_files_keys": [
+    "component_coverage_report_json",
+    "coverage_summary_json",
+    "extraction_warnings_json",
+    "orchestration_ledger_json",
+    "orchestration_published_rows_json",
+    "orchestration_review_queue_rows_json",
+    "orchestration_state_json",
+    "parser_result_json",
+    "persistence_contract_json",
+    "schema_component_datasets_manifest_json",
+    "staging_core_metrics_json",
+    "staging_manager_fund_vehicle_relationships_json"
+  ],
+  "ledger_status": "success"
+}

--- a/tests/golden/test_nl_sql_golden.py
+++ b/tests/golden/test_nl_sql_golden.py
@@ -1,0 +1,70 @@
+"""Golden gate test for the NL->SQL reference run (provenance + UNSAFE_SQL + replay)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tools.golden_nl.nl_sql_golden import (
+    _seed_replay_fixture,
+    diff_snapshot,
+    run_corpus,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CORPUS = _REPO_ROOT / "tests" / "golden" / "nl_sql" / "corpus.json"
+_BASELINE = _REPO_ROOT / "tests" / "golden" / "nl_sql" / "baseline.json"
+
+
+def _load_corpus() -> dict[str, object]:
+    return json.loads(_CORPUS.read_text(encoding="utf-8"))
+
+
+def test_corpus_and_baseline_are_committed() -> None:
+    assert _CORPUS.exists()
+    assert _BASELINE.exists()
+
+
+def test_corpus_run_has_no_violations_and_matches_baseline() -> None:
+    snapshot, violations = run_corpus(_load_corpus())
+    assert violations == []
+    baseline = json.loads(_BASELINE.read_text(encoding="utf-8"))
+    report = diff_snapshot(baseline=baseline, snapshot=snapshot)
+    assert report["unexpected_changes"] == 0, report
+
+
+def test_unsafe_sql_and_provenance_invariants() -> None:
+    snapshot, violations = run_corpus(_load_corpus())
+    assert violations == []
+    by_id = {row["id"]: row for row in snapshot}
+
+    unsafe = by_id["omits_source_document_id"]
+    assert unsafe["status"] == "error"
+    assert unsafe["error_code"] == "UNSAFE_SQL"
+
+    for safe_id in ("funded_ratio_with_provenance", "all_curated_metric_facts"):
+        row = by_id[safe_id]
+        assert row["status"] == "ok"
+        assert row["error_code"] is None
+        assert row["returned_rows"] > 0
+        assert row["provenance_complete"] is True
+
+
+def test_baseline_drift_is_detected() -> None:
+    snapshot, _ = run_corpus(_load_corpus())
+    baseline = json.loads(_BASELINE.read_text(encoding="utf-8"))
+    for row in baseline["queries"]:
+        if row["id"] == "funded_ratio_with_provenance":
+            row["returned_rows"] = row["returned_rows"] + 100
+    report = diff_snapshot(baseline=baseline, snapshot=snapshot)
+    assert report["unexpected_changes"] > 0
+
+
+def test_recorded_request_replays_deterministically(tmp_path: Path) -> None:
+    # _seed_replay_fixture raises if the recorded request does not replay to the
+    # same status / returned_rows against the seeded SQLite fixture.
+    expected = _seed_replay_fixture(_load_corpus(), tmp_path)
+    assert expected["status"] == "ok"
+    assert expected["returned_rows"] == 2
+    assert (tmp_path / "seed.db").exists()
+    assert (tmp_path / "nl_operations.jsonl").exists()

--- a/tests/golden/test_one_pdf_pilot_golden.py
+++ b/tests/golden/test_one_pdf_pilot_golden.py
@@ -1,0 +1,58 @@
+"""Golden gate test: the committed pilot baseline tracks a real pilot run."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pension_data.ops.one_pdf_pilot import OnePdfPilotInput, run_one_pdf_pilot
+from tools.ci_quality.manifest_gate import diff_manifest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_FIXTURE = _REPO_ROOT / "tests" / "golden" / "one_pdf_pilot" / "fixture_synthetic.pdf"
+_BASELINE = _REPO_ROOT / "tests" / "golden" / "one_pdf_pilot" / "run_manifest_baseline.json"
+
+
+def _run_pilot(tmp_path: Path) -> dict[str, object]:
+    result = run_one_pdf_pilot(
+        pilot_input=OnePdfPilotInput(
+            pdf_path=_FIXTURE,
+            plan_id="CA-PERS",
+            plan_period="FY2024",
+            effective_date="2024-06-30",
+            ingestion_date="2026-03-03",
+        ),
+        output_root=tmp_path / "out",
+        run_id="pilot-golden",
+    )
+    return json.loads(Path(result["run_manifest_json"]).read_text(encoding="utf-8"))
+
+
+def test_committed_fixture_exists() -> None:
+    assert _FIXTURE.exists(), "synthetic golden fixture must be committed"
+    assert _BASELINE.exists(), "committed pilot baseline must exist"
+
+
+def test_pilot_run_matches_committed_baseline(tmp_path: Path) -> None:
+    manifest = _run_pilot(tmp_path)
+    baseline = json.loads(_BASELINE.read_text(encoding="utf-8"))
+    report = diff_manifest(baseline=baseline, current_manifest=manifest)
+    assert report["unexpected_changes"] == 0, report
+
+
+def test_perturbing_a_baseline_key_is_detected(tmp_path: Path) -> None:
+    manifest = _run_pilot(tmp_path)
+    baseline = json.loads(_BASELINE.read_text(encoding="utf-8"))
+    baseline["artifact_files_keys"] = [
+        key for key in baseline["artifact_files_keys"] if key != "parser_result_json"
+    ] + ["unexpected_extra_json"]
+    report = diff_manifest(baseline=baseline, current_manifest=manifest)
+    assert report["unexpected_changes"] > 0
+
+
+def test_perturbing_ledger_status_is_detected(tmp_path: Path) -> None:
+    manifest = _run_pilot(tmp_path)
+    baseline = json.loads(_BASELINE.read_text(encoding="utf-8"))
+    baseline["ledger_status"] = "definitely-not-the-real-status"
+    report = diff_manifest(baseline=baseline, current_manifest=manifest)
+    assert any(change["field"] == "ledger_status" for change in report["changes"])

--- a/tools/ci_quality/manifest_gate.py
+++ b/tools/ci_quality/manifest_gate.py
@@ -1,0 +1,171 @@
+"""Diff a one-PDF pilot ``run_manifest.json`` against a committed golden baseline.
+
+The pilot manifest embeds run-specific absolute paths (output root + ``run_id``),
+so only the stable subset is compared: the **set of ``artifact_files`` keys** and
+the ``ledger_status`` value. Any added/removed artifact key or a changed ledger
+status is emitted as ``unexpected_drift`` in a diff report whose schema matches
+``tools/ci_quality/replay_gate.py`` so the same ``--max-unexpected 0`` gate step
+used by ``extraction-golden-regression.yml`` rejects the drift.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import TypedDict
+
+
+class ManifestSnapshot(TypedDict):
+    """Stable, diffable subset of a pilot run manifest."""
+
+    artifact_files_keys: list[str]
+    ledger_status: object
+
+
+class ManifestDiffChange(TypedDict):
+    """Single drift entry compatible with the replay gate schema."""
+
+    field: str
+    attribute: str
+    baseline: object
+    current: object
+    classification: str
+
+
+class ManifestDiffReport(TypedDict):
+    """Replay-gate-compatible diff report."""
+
+    total_changes: int
+    expected_changes: int
+    unexpected_changes: int
+    changes: list[ManifestDiffChange]
+
+
+def extract_snapshot(manifest: dict[str, object]) -> ManifestSnapshot:
+    """Extract the stable diffable subset from a live pilot manifest."""
+    artifact_files = manifest.get("artifact_files")
+    if not isinstance(artifact_files, dict):
+        raise ValueError("manifest.artifact_files must be an object")
+    if "ledger_status" not in manifest:
+        raise ValueError("manifest missing required key 'ledger_status'")
+    return {
+        "artifact_files_keys": sorted(str(key) for key in artifact_files),
+        "ledger_status": manifest["ledger_status"],
+    }
+
+
+def _load_baseline(baseline: dict[str, object]) -> ManifestSnapshot:
+    keys = baseline.get("artifact_files_keys")
+    if not isinstance(keys, list) or not all(isinstance(item, str) for item in keys):
+        raise ValueError("baseline.artifact_files_keys must be a list of strings")
+    if "ledger_status" not in baseline:
+        raise ValueError("baseline missing required key 'ledger_status'")
+    return {
+        "artifact_files_keys": sorted(keys),
+        "ledger_status": baseline["ledger_status"],
+    }
+
+
+def diff_manifest(
+    *, baseline: dict[str, object], current_manifest: dict[str, object]
+) -> ManifestDiffReport:
+    """Compare the stable subset of a live manifest against a golden baseline."""
+    base = _load_baseline(baseline)
+    snapshot = extract_snapshot(current_manifest)
+
+    changes: list[ManifestDiffChange] = []
+
+    base_keys = set(base["artifact_files_keys"])
+    current_keys = set(snapshot["artifact_files_keys"])
+    for key in sorted(base_keys - current_keys):
+        changes.append(
+            {
+                "field": key,
+                "attribute": "artifact_files_key_presence",
+                "baseline": True,
+                "current": False,
+                "classification": "unexpected_drift",
+            }
+        )
+    for key in sorted(current_keys - base_keys):
+        changes.append(
+            {
+                "field": key,
+                "attribute": "artifact_files_key_presence",
+                "baseline": False,
+                "current": True,
+                "classification": "unexpected_drift",
+            }
+        )
+
+    if base["ledger_status"] != snapshot["ledger_status"]:
+        changes.append(
+            {
+                "field": "ledger_status",
+                "attribute": "value",
+                "baseline": base["ledger_status"],
+                "current": snapshot["ledger_status"],
+                "classification": "unexpected_drift",
+            }
+        )
+
+    return {
+        "total_changes": len(changes),
+        "expected_changes": 0,
+        "unexpected_changes": len(changes),
+        "changes": changes,
+    }
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def run(argv: list[str] | None = None) -> int:
+    """Build snapshot + diff report from a live manifest and committed baseline."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest", required=True, type=Path, help="Path to live run_manifest.json"
+    )
+    parser.add_argument(
+        "--baseline", required=True, type=Path, help="Path to committed golden baseline JSON"
+    )
+    parser.add_argument(
+        "--snapshot-out", type=Path, help="Optional path for the extracted stable snapshot"
+    )
+    parser.add_argument(
+        "--report-out", type=Path, help="Optional path for the replay-gate-compatible diff report"
+    )
+    args = parser.parse_args(argv)
+
+    manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+    baseline = json.loads(args.baseline.read_text(encoding="utf-8"))
+    if not isinstance(manifest, dict) or not isinstance(baseline, dict):
+        print("manifest-gate error: manifest and baseline must be JSON objects")
+        return 1
+
+    snapshot = extract_snapshot(manifest)
+    report = diff_manifest(baseline=baseline, current_manifest=manifest)
+
+    if args.snapshot_out is not None:
+        _write_json(args.snapshot_out, snapshot)
+    if args.report_out is not None:
+        _write_json(args.report_out, report)
+
+    print(
+        "Manifest diff complete: "
+        f"{report['total_changes']} changes "
+        f"({report['unexpected_changes']} unexpected)"
+    )
+    return 2 if report["unexpected_changes"] > 0 else 0
+
+
+def main() -> int:
+    """Entry point."""
+    return run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tools/golden_nl/__init__.py
+++ b/tools/golden_nl/__init__.py
@@ -1,0 +1,1 @@
+"""Golden reference-run tooling for the NL->SQL query tool."""

--- a/tools/golden_nl/nl_sql_golden.py
+++ b/tools/golden_nl/nl_sql_golden.py
@@ -1,0 +1,286 @@
+"""Golden reference run for the NL->SQL query tool (deterministic, zero-egress).
+
+This driver exercises ``run_nl_sql_chain`` over a committed corpus using a
+deterministic in-process **stub chain** (never a live LLM/network provider) and
+the production ``default_nl_query_policy``. It enforces two invariants the repo's
+NL tool depends on and that have no other reference gate:
+
+* every returned row carries non-null ``source_document_id`` provenance, and
+* a generated ``SELECT`` that omits ``source_document_id`` is rejected with
+  ``error.code == "UNSAFE_SQL"`` (the guard at
+  ``src/pension_data/langchain/nl_sql_chain.py``).
+
+It emits a deterministic snapshot and a diff report (schema-compatible with
+``tools/ci_quality/replay_gate.py``) so drift is gated at ``--max-unexpected 0``,
+and it seeds a SQLite fixture + operation log so ``scripts/langchain/nl_replay.py``
+can replay a recorded request in CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, TypedDict
+
+from pension_data.langchain.nl_sql_chain import NLToSQLRequest, run_nl_sql_chain
+from pension_data.langchain.observability import (
+    append_nl_operation_log,
+    build_nl_operation_log_entry,
+    load_nl_operation_logs,
+    replay_logged_request,
+)
+from pension_data.query.sql_safety import default_nl_query_policy
+
+
+class _StubChain:
+    """Deterministic in-process chain returning a fixed SQL string (no network)."""
+
+    def __init__(self, sql: str) -> None:
+        self._sql = sql
+
+    def invoke(self, values: Mapping[str, Any]) -> str:
+        del values
+        return self._sql
+
+
+class QuerySnapshot(TypedDict):
+    """Deterministic per-query golden snapshot row."""
+
+    id: str
+    status: str
+    error_code: str | None
+    returned_rows: int
+    provenance_complete: bool
+
+
+def _seed_connection(connection: sqlite3.Connection, corpus: dict[str, Any]) -> None:
+    table = str(corpus["table"])
+    connection.execute(str(corpus["schema"]))
+    for row in corpus["rows"]:
+        columns = list(row.keys())
+        placeholders = ", ".join(["?"] * len(columns))
+        connection.execute(
+            f"INSERT INTO {table} ({', '.join(columns)}) VALUES ({placeholders})",
+            [row[column] for column in columns],
+        )
+    connection.commit()
+
+
+def _provenance_complete(returned_rows: int, provenance: tuple[Any, ...]) -> bool:
+    if len(provenance) != returned_rows:
+        return False
+    return all(row.source_document_id is not None for row in provenance)
+
+
+def run_corpus(corpus: dict[str, Any]) -> tuple[list[QuerySnapshot], list[str]]:
+    """Run every corpus query through the chain and return snapshot + violations."""
+    policy = default_nl_query_policy()
+    snapshot: list[QuerySnapshot] = []
+    violations: list[str] = []
+
+    for query in corpus["queries"]:
+        connection = sqlite3.connect(":memory:")
+        try:
+            _seed_connection(connection, corpus)
+            response = run_nl_sql_chain(
+                connection=connection,
+                request=NLToSQLRequest(question=str(query["question"])),
+                chain=_StubChain(str(query["sql"])),
+                policy=policy,
+            )
+        finally:
+            connection.close()
+
+        error_code = response.error.code if response.error is not None else None
+        complete = _provenance_complete(response.metadata.returned_rows, response.provenance)
+        snapshot.append(
+            {
+                "id": str(query["id"]),
+                "status": response.status,
+                "error_code": error_code,
+                "returned_rows": response.metadata.returned_rows,
+                "provenance_complete": complete,
+            }
+        )
+
+        if query.get("expect_unsafe"):
+            if response.status != "error" or error_code != "UNSAFE_SQL":
+                violations.append(
+                    f"query '{query['id']}' expected UNSAFE_SQL rejection but got "
+                    f"status={response.status} code={error_code}"
+                )
+        else:
+            if response.status != "ok":
+                violations.append(
+                    f"query '{query['id']}' expected status ok but got {response.status} "
+                    f"(error={error_code})"
+                )
+            elif response.metadata.returned_rows > 0 and not complete:
+                violations.append(
+                    f"query '{query['id']}' returned rows without complete source_document_id "
+                    "provenance"
+                )
+
+    snapshot.sort(key=lambda item: item["id"])
+    return snapshot, violations
+
+
+def diff_snapshot(*, baseline: dict[str, Any], snapshot: list[QuerySnapshot]) -> dict[str, Any]:
+    """Diff the golden snapshot against the committed baseline (replay-gate schema)."""
+    baseline_rows = {str(row["id"]): row for row in baseline.get("queries", [])}
+    current_rows = {row["id"]: row for row in snapshot}
+    changes: list[dict[str, Any]] = []
+
+    for query_id in sorted(set(baseline_rows) | set(current_rows)):
+        base_row = baseline_rows.get(query_id)
+        cur_row = current_rows.get(query_id)
+        if base_row is None or cur_row is None:
+            changes.append(
+                {
+                    "field": query_id,
+                    "attribute": "query_presence",
+                    "baseline": base_row is not None,
+                    "current": cur_row is not None,
+                    "classification": "unexpected_drift",
+                }
+            )
+            continue
+        for attribute in ("status", "error_code", "returned_rows", "provenance_complete"):
+            if base_row.get(attribute) != cur_row.get(attribute):
+                changes.append(
+                    {
+                        "field": query_id,
+                        "attribute": attribute,
+                        "baseline": base_row.get(attribute),
+                        "current": cur_row.get(attribute),
+                        "classification": "unexpected_drift",
+                    }
+                )
+
+    return {
+        "total_changes": len(changes),
+        "expected_changes": 0,
+        "unexpected_changes": len(changes),
+        "changes": changes,
+    }
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _seed_replay_fixture(corpus: dict[str, Any], emit_root: Path) -> dict[str, Any]:
+    """Seed a SQLite fixture + operation log so nl_replay.py can replay in CI."""
+    replay_query = next(
+        query for query in corpus["queries"] if query["id"] == corpus["replay_query_id"]
+    )
+
+    db_path = emit_root / "seed.db"
+    if db_path.exists():
+        db_path.unlink()
+    file_conn = sqlite3.connect(db_path)
+    try:
+        _seed_connection(file_conn, corpus)
+    finally:
+        file_conn.close()
+
+    # Run the request once (against an equivalent in-memory copy) to record a log row.
+    record_conn = sqlite3.connect(":memory:")
+    try:
+        _seed_connection(record_conn, corpus)
+        request = NLToSQLRequest(question=str(replay_query["question"]))
+        response = run_nl_sql_chain(
+            connection=record_conn,
+            request=request,
+            chain=_StubChain(str(replay_query["sql"])),
+            policy=default_nl_query_policy(),
+        )
+    finally:
+        record_conn.close()
+
+    log_path = emit_root / "nl_operations.jsonl"
+    if log_path.exists():
+        log_path.unlink()
+    entry = build_nl_operation_log_entry(
+        request=request,
+        response=response,
+        provider="stub",
+        model="golden-reference",
+        correlation_id="nl-golden",
+    )
+    append_nl_operation_log(path=log_path, entry=entry)
+
+    expected = {
+        "status": response.status,
+        "returned_rows": response.metadata.returned_rows,
+        "request_id": response.metadata.request_id,
+    }
+    _write_json(emit_root / "replay_expected.json", expected)
+
+    # Confirm the recorded request replays deterministically against the fixture DB.
+    replay_conn = sqlite3.connect(db_path)
+    try:
+        recorded = load_nl_operation_logs(log_path)[-1]
+        replayed = replay_logged_request(entry=recorded, connection=replay_conn)
+    finally:
+        replay_conn.close()
+    if (
+        replayed.status != response.status
+        or replayed.metadata.returned_rows != response.metadata.returned_rows
+    ):
+        raise SystemExit(
+            "nl-sql golden: replay self-check mismatch "
+            f"({replayed.status}/{replayed.metadata.returned_rows} != "
+            f"{response.status}/{response.metadata.returned_rows})"
+        )
+    return expected
+
+
+def run(argv: list[str] | None = None) -> int:
+    """Execute the NL->SQL golden run and emit snapshot/diff/replay artifacts."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--corpus", required=True, type=Path, help="Committed NL corpus JSON")
+    parser.add_argument("--baseline", required=True, type=Path, help="Committed snapshot baseline")
+    parser.add_argument(
+        "--emit-root",
+        required=True,
+        type=Path,
+        help="Output root for snapshot, diff report, and replay fixture artifacts",
+    )
+    args = parser.parse_args(argv)
+
+    corpus = json.loads(args.corpus.read_text(encoding="utf-8"))
+    snapshot, violations = run_corpus(corpus)
+
+    args.emit_root.mkdir(parents=True, exist_ok=True)
+    _write_json(args.emit_root / "snapshot.json", {"queries": snapshot})
+
+    if violations:
+        for violation in violations:
+            print(f"nl-sql golden violation: {violation}")
+        return 1
+
+    baseline = json.loads(args.baseline.read_text(encoding="utf-8"))
+    report = diff_snapshot(baseline=baseline, snapshot=snapshot)
+    _write_json(args.emit_root / "diff_report.json", report)
+
+    _seed_replay_fixture(corpus, args.emit_root)
+
+    print(
+        "NL->SQL golden complete: "
+        f"{len(snapshot)} queries, {report['unexpected_changes']} unexpected drift"
+    )
+    return 2 if report["unexpected_changes"] > 0 else 0
+
+
+def main() -> int:
+    """Entry point."""
+    return run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:482 -->
> **Source:** Issue #482

Closes #482

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
**Why.** Reference-run readiness requires a golden run **per tool** that must keep passing on every PR. The repo already has golden gates for the fallback parser (`.github/workflows/extraction-golden-regression.yml`), entities (`entity-regression.yml`), quality replay (`quality-replay.yml`), SLA (`quality-sla-check.yml`), and the foundation fixture (`foundation-fixture-e2e.yml`). But the **two tools that embody this repo's role have no reference run**: `grep -rniE "one_pdf_pilot|run_one_pdf|nl_sql|run_nl|nl_replay" .github/workflows/` returns empty (verified). A regression in the `run_manifest.json` artifact-file map (`src/pension_data/ops/one_pdf_pilot.py:431-476`) or in the `source_document_id`-required NL provenance guard (`src/pension_data/langchain/nl_sql_chain.py:380-414`) would ship undetected. The deterministic NL replay harness `scripts/langchain/nl_replay.py` exists but is wired to no workflow.

**Scope.** Two `pull_request`-to-`main` CI jobs mirroring the structure of `extraction-golden-regression.yml`:

#### Tasks
1. [ ] **One-PDF pilot golden:** run the pilot CLI (`scripts/run_one_pdf_pilot.py` -> `one_pdf_pilot_cli.main`) on a committed fixture with a pinned `--run-id`, then diff the resulting `run_manifest.json` (`artifact_files` keys + `ledger_status`) against a committed baseline with zero tolerance.
2. [ ] **NL->SQL golden:** run a small committed corpus through `run_nl_sql_chain` with a deterministic **stub chain** (no live LLM), asserting per-row provenance is populated and that a SELECT omitting `source_document_id` is rejected with `UNSAFE_SQL`; exercise `scripts/langchain/nl_replay.py` so replay is covered in CI.

#### Acceptance criteria
- [ ] NO live LLM calls in CI. The NL gate MUST use a deterministic in-process stub chain (the `_ReplayChain`/`NLToSQLChain` Protocol pattern), never a network provider — this also satisfies the data-egress constraint (no prompt/row leaves CI).
- [ ] Do NOT change pilot or NL logic to make the gate pass; the gate validates current behavior.
- [ ] A workflow file that only installs deps and runs `pytest` does NOT satisfy this — the job must produce a snapshot artifact and **diff it against a committed baseline** with `--max-unexpected 0`, the same gate mechanism as the extraction job. A green job with no baseline diff is rejected.
- [ ] Do NOT commit a real proprietary pension PDF as the fixture; use a tiny synthetic/fixture document only.

<!-- auto-status-summary:end -->