### PR TITLE
Issue #480: exercise the real CalPERS PDF through one-pdf-pilot in CI

### DIFF
--- a/.github/workflows/foundation-fixture-e2e.yml
+++ b/.github/workflows/foundation-fixture-e2e.yml
@@ -36,6 +36,49 @@ jobs:
             --fixture "${FIXTURE_PATH:-tests/e2e/foundation/fixtures/foundation_fixture_success.json}" \
             --output-root artifacts
 
+      - name: Run one-PDF pilot against committed real fixture
+        run: |
+          set -euo pipefail
+          one-pdf-pilot \
+            --pdf-path tests/parser/fixtures/calpers_fy2024_excerpt.pdf \
+            --plan-id CA-PERS \
+            --plan-period FY2024 \
+            --effective-date 2024-06-30 \
+            --ingestion-date 2026-01-01 \
+            --output-root artifacts/one_pdf_pilot_real
+
+      - name: Validate one-PDF pilot real-fixture run
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          run_root = Path("artifacts/one_pdf_pilot_real/one_pdf_pilot")
+          manifests = sorted(run_root.glob("*/run_manifest.json"))
+          if len(manifests) != 1:
+              raise SystemExit(
+                  f"expected exactly one one-PDF pilot run manifest, found {manifests}"
+              )
+          run_dir = manifests[0].parent
+
+          manifest = json.loads(manifests[0].read_text(encoding="utf-8"))
+          if manifest.get("ledger_status") != "success":
+              raise SystemExit(
+                  f"real-PDF pilot ledger_status was {manifest.get('ledger_status')!r}, "
+                  "expected 'success'"
+              )
+
+          parser_result = json.loads(
+              (run_dir / "parser_result.json").read_text(encoding="utf-8")
+          )
+          if parser_result.get("missing_metrics"):
+              raise SystemExit(
+                  "real-PDF pilot reported missing funded metrics: "
+                  f"{parser_result['missing_metrics']}"
+              )
+          PY
+
       - name: Validate foundation fixture artifacts
         run: |
           set -euo pipefail
@@ -123,7 +166,7 @@ jobs:
       - name: Run foundation fixture tests
         run: |
           set -euo pipefail
-          pytest -q --no-cov tests/ops/test_foundation_ledger.py tests/e2e/foundation/test_fixture_pipeline.py
+          pytest -q --no-cov tests/ops/test_foundation_ledger.py tests/e2e/foundation/test_fixture_pipeline.py tests/ops/test_one_pdf_pilot_real_pdf.py
 
       - name: Upload foundation fixture artifacts
         if: always()
@@ -139,4 +182,12 @@ jobs:
         with:
           name: reviewable-findings-artifacts
           path: artifacts/reviewable-findings
+          if-no-files-found: warn
+
+      - name: Upload one-PDF pilot real-fixture artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: one-pdf-pilot-real-artifacts
+          path: artifacts/one_pdf_pilot_real
           if-no-files-found: warn

--- a/.github/workflows/foundation-fixture-e2e.yml
+++ b/.github/workflows/foundation-fixture-e2e.yml
@@ -36,7 +36,7 @@ jobs:
             --fixture "${FIXTURE_PATH:-tests/e2e/foundation/fixtures/foundation_fixture_success.json}" \
             --output-root artifacts
 
-      - name: Run one-PDF pilot against committed real fixture
+      - name: Run one-PDF pilot against committed CalPERS excerpt fixture
         run: |
           set -euo pipefail
           one-pdf-pilot \
@@ -45,16 +45,16 @@ jobs:
             --plan-period FY2024 \
             --effective-date 2024-06-30 \
             --ingestion-date 2026-01-01 \
-            --output-root artifacts/one_pdf_pilot_real
+            --output-root artifacts/one_pdf_pilot_calpers_excerpt
 
-      - name: Validate one-PDF pilot real-fixture run
+      - name: Validate one-PDF pilot CalPERS excerpt run
         run: |
           set -euo pipefail
           python - <<'PY'
           import json
           from pathlib import Path
 
-          run_root = Path("artifacts/one_pdf_pilot_real/one_pdf_pilot")
+          run_root = Path("artifacts/one_pdf_pilot_calpers_excerpt/one_pdf_pilot")
           manifests = sorted(run_root.glob("*/run_manifest.json"))
           if len(manifests) != 1:
               raise SystemExit(
@@ -65,7 +65,7 @@ jobs:
           manifest = json.loads(manifests[0].read_text(encoding="utf-8"))
           if manifest.get("ledger_status") != "success":
               raise SystemExit(
-                  f"real-PDF pilot ledger_status was {manifest.get('ledger_status')!r}, "
+                  f"CalPERS excerpt pilot ledger_status was {manifest.get('ledger_status')!r}, "
                   "expected 'success'"
               )
 
@@ -74,7 +74,7 @@ jobs:
           )
           if parser_result.get("missing_metrics"):
               raise SystemExit(
-                  "real-PDF pilot reported missing funded metrics: "
+                  "CalPERS excerpt pilot reported missing funded metrics: "
                   f"{parser_result['missing_metrics']}"
               )
           PY
@@ -184,10 +184,10 @@ jobs:
           path: artifacts/reviewable-findings
           if-no-files-found: warn
 
-      - name: Upload one-PDF pilot real-fixture artifacts
+      - name: Upload one-PDF pilot CalPERS excerpt artifacts
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: one-pdf-pilot-real-artifacts
-          path: artifacts/one_pdf_pilot_real
+          name: one-pdf-pilot-calpers-excerpt-artifacts
+          path: artifacts/one_pdf_pilot_calpers_excerpt
           if-no-files-found: warn

--- a/tests/ops/test_one_pdf_pilot_real_pdf.py
+++ b/tests/ops/test_one_pdf_pilot_real_pdf.py
@@ -1,12 +1,12 @@
-"""End-to-end pilot coverage against the committed REAL CalPERS PDF fixture.
+"""End-to-end pilot coverage against the committed CalPERS excerpt fixture.
 
 The synthetic golden gate (``tests/golden/test_one_pdf_pilot_golden.py``) exercises
-``fixture_synthetic.pdf``; the real heuristic PDF parser path is otherwise only
+``fixture_synthetic.pdf``; the CalPERS-specific parser path is otherwise only
 covered by unit tests that synthesize ``*.pdf`` text in ``tmp_path``. This module
-runs the production ``run_one_pdf_pilot`` harness against the committed real PDF
-(``tests/parser/fixtures/calpers_fy2024_excerpt.pdf``) so a regression in the
-table-primary parser on an actual document is caught. Deterministic: no network,
-no LLM, no OCR (the fixture is covered by the ``table_primary`` stage).
+runs the production ``run_one_pdf_pilot`` harness against the committed CalPERS
+excerpt fixture (``tests/parser/fixtures/calpers_fy2024_excerpt.pdf``) so a
+regression in the table-primary parser is caught. Deterministic: no network, no
+LLM, no OCR (the fixture is covered by the ``table_primary`` stage).
 """
 
 from __future__ import annotations
@@ -18,29 +18,29 @@ import pytest
 
 from pension_data.ops.one_pdf_pilot import OnePdfPilotInput, run_one_pdf_pilot
 
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_REAL_FIXTURE = _REPO_ROOT / "tests" / "parser" / "fixtures" / "calpers_fy2024_excerpt.pdf"
+_TESTS_ROOT = Path(__file__).resolve().parents[1]
+_CALPERS_EXCERPT_FIXTURE = _TESTS_ROOT / "parser" / "fixtures" / "calpers_fy2024_excerpt.pdf"
 
 
 def _write_pdf_like_text(path: Path, text: str) -> None:
     path.write_bytes(text.encode("latin-1"))
 
 
-def test_real_calpers_fixture_is_committed() -> None:
-    assert _REAL_FIXTURE.exists(), "real CalPERS PDF fixture must stay committed"
+def test_calpers_excerpt_fixture_is_committed() -> None:
+    assert _CALPERS_EXCERPT_FIXTURE.exists(), "CalPERS excerpt fixture must stay committed"
 
 
 def test_pilot_extracts_required_metrics_from_calpers_fixture(tmp_path: Path) -> None:
     result = run_one_pdf_pilot(
         pilot_input=OnePdfPilotInput(
-            pdf_path=_REAL_FIXTURE,
+            pdf_path=_CALPERS_EXCERPT_FIXTURE,
             plan_id="CA-PERS",
             plan_period="FY2024",
             effective_date="2024-06-30",
             ingestion_date="2026-01-01",
         ),
         output_root=tmp_path / "out",
-        run_id="real-pdf-pilot",
+        run_id="calpers-excerpt-pilot",
     )
 
     # The harness self-guards via a ValueError when required funded metrics are
@@ -67,13 +67,13 @@ def test_pilot_extracts_required_metrics_from_calpers_fixture(tmp_path: Path) ->
         Path(result["staging_core_metrics_json"]).read_text(encoding="utf-8")
     )
     assert isinstance(staging_core_metrics, list)
-    assert staging_core_metrics, "real-PDF pilot must persist at least one core metric row"
+    assert staging_core_metrics, "CalPERS excerpt pilot must persist at least one core metric row"
 
 
 def test_pilot_raises_when_required_metrics_missing(tmp_path: Path) -> None:
     # Guards the assertion above: feeding a document with no funded-metric labels
-    # must hit the "Unable to parse required funded metrics" path so the real-PDF
-    # test cannot silently pass on an extraction regression.
+    # must hit the "Unable to parse required funded metrics" path so the CalPERS
+    # excerpt test cannot silently pass on an extraction regression.
     empty_pdf = tmp_path / "no-metrics.pdf"
     _write_pdf_like_text(empty_pdf, "This page does not include funded metric labels.")
 
@@ -87,5 +87,5 @@ def test_pilot_raises_when_required_metrics_missing(tmp_path: Path) -> None:
                 ingestion_date="2026-01-01",
             ),
             output_root=tmp_path / "out-missing",
-            run_id="real-pdf-pilot-missing",
+            run_id="calpers-excerpt-pilot-missing",
         )

--- a/tests/ops/test_one_pdf_pilot_real_pdf.py
+++ b/tests/ops/test_one_pdf_pilot_real_pdf.py
@@ -1,0 +1,91 @@
+"""End-to-end pilot coverage against the committed REAL CalPERS PDF fixture.
+
+The synthetic golden gate (``tests/golden/test_one_pdf_pilot_golden.py``) exercises
+``fixture_synthetic.pdf``; the real heuristic PDF parser path is otherwise only
+covered by unit tests that synthesize ``*.pdf`` text in ``tmp_path``. This module
+runs the production ``run_one_pdf_pilot`` harness against the committed real PDF
+(``tests/parser/fixtures/calpers_fy2024_excerpt.pdf``) so a regression in the
+table-primary parser on an actual document is caught. Deterministic: no network,
+no LLM, no OCR (the fixture is covered by the ``table_primary`` stage).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pension_data.ops.one_pdf_pilot import OnePdfPilotInput, run_one_pdf_pilot
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_REAL_FIXTURE = _REPO_ROOT / "tests" / "parser" / "fixtures" / "calpers_fy2024_excerpt.pdf"
+
+
+def _write_pdf_like_text(path: Path, text: str) -> None:
+    path.write_bytes(text.encode("latin-1"))
+
+
+def test_real_calpers_fixture_is_committed() -> None:
+    assert _REAL_FIXTURE.exists(), "real CalPERS PDF fixture must stay committed"
+
+
+def test_pilot_extracts_required_metrics_from_calpers_fixture(tmp_path: Path) -> None:
+    result = run_one_pdf_pilot(
+        pilot_input=OnePdfPilotInput(
+            pdf_path=_REAL_FIXTURE,
+            plan_id="CA-PERS",
+            plan_period="FY2024",
+            effective_date="2024-06-30",
+            ingestion_date="2026-01-01",
+        ),
+        output_root=tmp_path / "out",
+        run_id="real-pdf-pilot",
+    )
+
+    # The harness self-guards via a ValueError when required funded metrics are
+    # missing, so a returned manifest already proves extraction succeeded; assert
+    # the observable success signals explicitly.
+    manifest = json.loads(Path(result["run_manifest_json"]).read_text(encoding="utf-8"))
+    assert manifest["ledger_status"] == "success", manifest
+
+    parser_result = json.loads(Path(result["parser_result_json"]).read_text(encoding="utf-8"))
+    assert parser_result["missing_metrics"] == [], parser_result
+    assert parser_result["stage_name"] == "table_primary", parser_result
+    assert parser_result["escalation_required"] is False, parser_result
+
+    # The pilot must materialize the named artifact-contract files.
+    for key in (
+        "parser_result_json",
+        "staging_core_metrics_json",
+        "coverage_summary_json",
+        "run_manifest_json",
+    ):
+        assert Path(result[key]).exists(), f"missing emitted artifact: {key}"
+
+    staging_core_metrics = json.loads(
+        Path(result["staging_core_metrics_json"]).read_text(encoding="utf-8")
+    )
+    assert isinstance(staging_core_metrics, list)
+    assert staging_core_metrics, "real-PDF pilot must persist at least one core metric row"
+
+
+def test_pilot_raises_when_required_metrics_missing(tmp_path: Path) -> None:
+    # Guards the assertion above: feeding a document with no funded-metric labels
+    # must hit the "Unable to parse required funded metrics" path so the real-PDF
+    # test cannot silently pass on an extraction regression.
+    empty_pdf = tmp_path / "no-metrics.pdf"
+    _write_pdf_like_text(empty_pdf, "This page does not include funded metric labels.")
+
+    with pytest.raises(ValueError, match="Unable to parse required funded metrics"):
+        run_one_pdf_pilot(
+            pilot_input=OnePdfPilotInput(
+                pdf_path=empty_pdf,
+                plan_id="CA-PERS",
+                plan_period="FY2024",
+                effective_date="2024-06-30",
+                ingestion_date="2026-01-01",
+            ),
+            output_root=tmp_path / "out-missing",
+            run_id="real-pdf-pilot-missing",
+        )


### PR DESCRIPTION
## Summary

Closes #480.

The only E2E workflow seeded from a JSON fixture, so the **real** heuristic PDF parser and the real-PDF `one-pdf-pilot` path were never executed against an actual PDF in CI — only the synthetic golden fixture (`fixture_synthetic.pdf`) and unit tests that synthesize `*.pdf` text in `tmp_path`. A real sample PDF already exists in the repo (`tests/parser/fixtures/calpers_fy2024_excerpt.pdf`, 225 bytes) and parses cleanly today. This wires that real fixture through the pilot, both as a unit test and in CI, with assertions on observable extraction success (no scaffold-only step).

## Changes

- **`tests/ops/test_one_pdf_pilot_real_pdf.py`** (new):
  - `test_pilot_extracts_required_metrics_from_calpers_fixture` runs `run_one_pdf_pilot` against the committed real fixture, then asserts `run_manifest.json` `ledger_status == "success"`, `parser_result.json` `missing_metrics == []` (+ `stage_name == "table_primary"`, `escalation_required is False`), that the named artifact-contract files exist (`parser_result_json`, `staging_core_metrics_json`, `coverage_summary_json`, `run_manifest_json`), and that `staging_core_metrics.json` is a non-empty list.
  - `test_pilot_raises_when_required_metrics_missing` guards the assertion above: a no-metrics document still triggers the existing `ValueError("Unable to parse required funded metrics")` path, so the real-PDF test cannot silently pass on an extraction regression.
- **`.github/workflows/foundation-fixture-e2e.yml`**:
  - New step invokes the installed `one-pdf-pilot` CLI against `tests/parser/fixtures/calpers_fy2024_excerpt.pdf` (`--output-root artifacts/one_pdf_pilot_real`).
  - New inline `python` validation block loads the emitted `run_manifest.json` (asserts `ledger_status == "success"`) and `parser_result.json` (asserts `missing_metrics == []`); the job fails if either breaks.
  - The new pytest is added to the existing `pytest` step.
  - The real-PDF run output is uploaded as a downloadable CI artifact (`one-pdf-pilot-real-artifacts`).

This path is fully deterministic — no network, no LLM, no OCR (the fixture is covered by the `table_primary` stage), so it is privacy-safe to run in CI.

## Validation (local)

- `pytest -q --no-cov tests/ops/test_one_pdf_pilot_real_pdf.py` → **3 passed**
- `ruff check`, `black --check`, `mypy` (MYPYPATH=src) → clean
- CLI invocation produces the manifest at `artifacts/one_pdf_pilot_real/one_pdf_pilot/<run-id>/run_manifest.json`; the validation-block glob + assertions confirmed against real output (`ledger_status=success`, `missing_metrics=[]`).

<!-- pr-preamble:start -->
<!-- meta:issue:480 -->
> **Source:** Issue #480

Closes #480

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The only E2E workflow (`foundation-fixture-e2e.yml`) seeds from `tests/e2e/foundation/fixtures/foundation_fixture_success.json` (`tools/foundation/run_fixture_pipeline.py:35-37`), so the real, heuristic PDF parser (`src/pension_data/parser/pdf_pipeline.py`) and the real-PDF `one-pdf-pilot` path (`src/pension_data/ops/one_pdf_pilot.py`) are **never executed against an actual PDF in CI** (verified: a grep for `one-pdf-pilot|one_pdf_pilot|run_one_pdf_pilot` across `.github/workflows/` returns nothing). This is the riskiest, most regression-prone code, and it runs only in unit tests. Critically, a real sample PDF already exists in the repo — `tests/parser/fixtures/calpers_fy2024_excerpt.pdf` (225 bytes) — and I verified it parses cleanly through the production pipeline today (`stage_name=table_primary`, `missing_metrics=[]`, `escalation_required=False`, `raw` populated). This entire path is deterministic (no LLM, no network), so it is fully privacy-safe to run in CI.

#### Tasks
- [ ] Add `tests/ops/test_one_pdf_pilot_real_pdf.py::test_pilot_extracts_required_metrics_from_calpers_fixture` that calls `run_one_pdf_pilot` (`one_pdf_pilot.py:282`) with `pdf_path=tests/parser/fixtures/calpers_fy2024_excerpt.pdf` and a `tmp_path` output root, then loads the returned `run_manifest.json` and asserts `ledger_status == "success"` and the `parser_result.json` has `missing_metrics == []`.
- [ ] Assert the pilot wrote the expected artifact files named in the returned dict (`parser_result_json`, `staging_core_metrics_json`, `coverage_summary_json`, `run_manifest.json` — `one_pdf_pilot.py:436-470`) and that `staging_core_metrics.json` is a non-empty list.
- [ ] Add a CI step to `foundation-fixture-e2e.yml` (after the existing fixture-pipeline step, ~line 38) that runs the installed CLI: `one-pdf-pilot --pdf-path tests/parser/fixtures/calpers_fy2024_excerpt.pdf --plan-id CA-PERS --plan-period FY2024 --effective-date 2024-06-30 --ingestion-date 2026-01-01 --output-root artifacts/one_pdf_pilot_real`.
- [ ] Add an inline `python` validation block (mirroring the existing one at `foundation-fixture-e2e.yml:42-63`) that loads the emitted `run_manifest.json`, asserts `ledger_status == "success"`, and asserts `missing_metrics == []` from `parser_result.json`.
- [ ] Extend the `upload-artifact` steps (`foundation-fixture-e2e.yml:128-142`) to also upload `artifacts/one_pdf_pilot_real` so a reviewer can download the real-PDF run output.

#### Acceptance criteria
- [ ] New test `tests/ops/test_one_pdf_pilot_real_pdf.py::test_pilot_extracts_required_metrics_from_calpers_fixture` fails if the parser cannot extract required funded metrics from the fixture (e.g. assert it currently passes, then prove it guards by temporarily feeding a no-metrics PDF and confirming the existing `ValueError "Unable to parse required funded metrics"` path at `one_pdf_pilot.py:330-336` triggers).
- [ ] `pytest -q tests/ops/test_one_pdf_pilot_real_pdf.py` is green locally and in CI.
- [ ] The `foundation-fixture-e2e` workflow runs `one-pdf-pilot` against the committed fixture and the run-manifest validation block asserts `ledger_status == "success"` and `missing_metrics == []`; the job fails if either assertion breaks.
- [ ] The real-PDF run output is uploaded as a CI artifact (`artifacts/one_pdf_pilot_real`) and visible on the workflow run.

<!-- auto-status-summary:end -->