### PR TITLE
Make deployment docs privacy-safe for real data

### DIFF
--- a/docs/UI_LANGCHAIN_OPTIONS.md
+++ b/docs/UI_LANGCHAIN_OPTIONS.md
@@ -12,7 +12,7 @@ This document compares practical options for adding a higher-quality UI and a La
 ### Shape
 - Run the existing `apps/web/` browser workspace against a user-selected local JSON bundle, or package the same workflow with stlite/Pyodide/JupyterLite so analysis executes in the work browser.
 - For shared access to `data_origin: live` bundles, serve the static assets and deterministic API routes from an internal/on-prem host such as the Issue-2 `pension-data-serve` FastAPI app bound to the organization network.
-- Keep public GitHub Pages or Cloudflare Pages deployments limited to fixture/synthetic-data demos.
+- Treat the prior GitHub Pages/Cloudflare + Actions model as fixture/synthetic demo-only; it is not the recommended path for real pension data.
 - Generate findings JSON artifacts inside the organization boundary and publish them only to approved internal artifact locations.
 
 ### Pros

--- a/docs/UI_LANGCHAIN_OPTIONS.md
+++ b/docs/UI_LANGCHAIN_OPTIONS.md
@@ -29,7 +29,7 @@ This document compares practical options for adding a higher-quality UI and a La
 - Internal hosting requires the organization's normal access-control and network review.
 - LLM-dependent interactions require an authorized no-train endpoint or must be disabled.
 
-### Data Zones & LLM Boundary
+### Data zones & LLM boundary
 
 - `data_origin: fixture` is safe for public demo hosting when the bundle contains only checked-in fixture data.
 - `data_origin: generated` and `data_origin: live` remain inside the organization boundary: browser-local file loading, client-side WASM/stlite/Pyodide, JupyterLite, or an internal host.

--- a/docs/UI_LANGCHAIN_OPTIONS.md
+++ b/docs/UI_LANGCHAIN_OPTIONS.md
@@ -1,4 +1,4 @@
-# UI + LangChain Options (No Dedicated Paid Server)
+# UI + LangChain Options (Privacy-Safe Browser Access)
 
 This document compares practical options for adding a higher-quality UI and a LangChain findings interaction layer under these constraints:
 
@@ -7,26 +7,35 @@ This document compares practical options for adding a higher-quality UI and a La
 - Mac installs are possible, but Mac cannot fully cover work usage.
 - Avoid paying for a separate server.
 
-## Option 1: Static Web UI on GitHub Pages + LangChain via GitHub Actions (Recommended)
+## Option 1: Zero-Egress Browser UI or Internal Hosting (Recommended for Real Data)
 
 ### Shape
-- Build a static frontend (React/Vite or SvelteKit static export).
-- Publish to GitHub Pages.
-- Generate findings JSON artifacts from CI/workflows and publish to `docs/data/` or release assets.
-- Trigger LangChain workflows from issue comments/PR comments or manual dispatch.
-- Write LangChain outputs back as JSON summaries and PR/issue comments.
+- Run the existing `apps/web/` browser workspace against a user-selected local JSON bundle, or package the same workflow with stlite/Pyodide/JupyterLite so analysis executes in the work browser.
+- For shared access to `data_origin: live` bundles, serve the static assets and deterministic API routes from an internal/on-prem host such as the Issue-2 `pension-data-serve` FastAPI app bound to the organization network.
+- Keep public GitHub Pages or Cloudflare Pages deployments limited to fixture/synthetic-data demos.
+- Generate findings JSON artifacts inside the organization boundary and publish them only to approved internal artifact locations.
 
 ### Pros
 - No local install needed for end users.
 - Works on locked-down work PCs (browser only).
 - No separate hosting bill.
+- Real pension data stays in the browser session or on an internal host.
 - Easy audit trail (GitHub history + workflow logs).
 - Can still be a high-quality, modern interface (advanced design system, rich charts,
   responsive layouts, keyboard-first interactions, and polished motion in a static SPA).
 
 ### Cons
-- No always-on conversational backend; interactions are asynchronous.
-- Rate limits/token limits depend on workflow execution budgets.
+- Public Pages can demonstrate only fixture/synthetic data.
+- Internal hosting requires the organization's normal access-control and network review.
+- LLM-dependent interactions require an authorized no-train endpoint or must be disabled.
+
+### Data Zones & LLM Boundary
+
+- `data_origin: fixture` is safe for public demo hosting when the bundle contains only checked-in fixture data.
+- `data_origin: generated` and `data_origin: live` remain inside the organization boundary: browser-local file loading, client-side WASM/stlite/Pyodide, JupyterLite, or an internal host.
+- Deterministic analysis routes, including `run_saved_view_endpoint` and `run_metric_history_endpoint`, may run on real data in the browser or on internal hosting because they do not require LLM egress.
+- LLM-backed NL/query/findings features must either target an authorized no-train provider endpoint through `OPENAI_BASE_URL` or `ANTHROPIC_BASE_URL`, or remain disabled in `PENSION_DATA_DATA_ZONE=proprietary`.
+- A public-hosted app must refuse to pass deployment smoke checks if its served `workspace.json` declares `data_origin: live`.
 
 ## Option 2: Packaged Mac Desktop App + Embedded Local LangChain
 
@@ -44,10 +53,11 @@ This document compares practical options for adding a higher-quality UI and a La
 - Limited at work if Mac use is restricted.
 - Ongoing desktop packaging/signing maintenance.
 
-## Option 3: Hybrid Model (Pages UI for Work + Mac Pro App for Power Use)
+## Option 3: Hybrid Model (Fixture Demo + Internal App + Mac Pro App)
 
 ### Shape
-- Option 1 as the baseline for universal access.
+- Option 1 as the baseline for real-data work access.
+- Public Pages/Cloudflare as a fixture-only product demo.
 - Option 2 as an advanced client for deeper analyst workflows.
 - Keep shared schema for findings so both UIs read the same data model.
 
@@ -61,23 +71,24 @@ This document compares practical options for adding a higher-quality UI and a La
 ## Option 4: Internal Network Share Build (No Install, Local Browser App)
 
 ### Shape
-- Build static app assets and distribute via shared drive or internal artifact channel.
+- Build static app assets and distribute via shared drive, internal artifact channel, or internal web host.
 - Users open `index.html` locally; data files updated by export scripts.
-- LangChain interactions run via workflow_dispatch and write result files.
+- Optional LangChain interactions run only through authorized no-train endpoints or are disabled.
 
 ### Pros
 - No installer needed.
 - Minimal infrastructure cost.
 
 ### Cons
-- Harder update/version discipline than GitHub Pages.
+- Harder update/version discipline than managed internal hosting.
 - Cross-origin and file-access browser constraints can be finicky.
 
 ## Recommended Path
 
-1. Start with **Option 1** to satisfy work constraints quickly.
-2. Add **Option 3** over time by introducing a Mac desktop power-client when UX depth is needed.
-3. Keep LangChain execution in CI first; only move to local embedded inference if latency becomes a hard blocker.
+1. Start with **Option 1** for real work: browser-local/WASM or internal hosting for `generated` and `live` bundles.
+2. Keep GitHub Pages / Cloudflare Pages as a fixture-only external demo surface.
+3. Add **Option 3** over time by introducing a Mac desktop power-client when UX depth is needed.
+4. Keep LLM execution behind authorized no-train endpoints; disable LLM features in the proprietary zone until that endpoint is configured.
 
 ## First Reviewable Artifact
 

--- a/docs/deploy/CLOUDFLARE_PAGES_SETUP.md
+++ b/docs/deploy/CLOUDFLARE_PAGES_SETUP.md
@@ -66,3 +66,16 @@ Workflow: `.github/workflows/web-cloudflare-pages.yml`
   - API and artifact endpoints show expected values.
   - Data origin badge shows the fixture/demo classification for the Pages deployment.
   - Access policy blocks unauthorized users.
+
+## 8. Reviewer Gate
+
+Run this check during review and confirm no public-hosting guidance points to publishing live bundles:
+
+```bash
+grep -rniE "data_origin.*live" docs apps/web
+```
+
+Expected review outcome:
+- `docs/deploy/CLOUDFLARE_PAGES_SETUP.md` includes the fixture-only warning banner.
+- Any `data_origin.*live` hits in docs are prohibition language or internal-hosting guidance, not public-hosting instructions.
+- `apps/web/data/workspace.json` remains `data_origin: fixture` for the public demo bundle.

--- a/docs/deploy/CLOUDFLARE_PAGES_SETUP.md
+++ b/docs/deploy/CLOUDFLARE_PAGES_SETUP.md
@@ -1,6 +1,8 @@
-# Cloudflare Pages Setup (Private Access)
+# Synthetic-Data Demo Hosting (Cloudflare Pages)
 
-This guide configures the `apps/web` scaffold for Cloudflare Pages deployment with private access controls.
+> For fixture/synthetic data only. Do not publish bundles whose `data_origin` is `live`.
+
+This guide configures the `apps/web` scaffold for a Cloudflare Pages synthetic/demo deployment with private access controls. Cloudflare Pages is not the real-data hosting path.
 
 ## 1. Create Cloudflare Pages Project
 

--- a/docs/deploy/PC_ZERO_INSTALL_IT_REVIEW.md
+++ b/docs/deploy/PC_ZERO_INSTALL_IT_REVIEW.md
@@ -20,6 +20,8 @@ This guide describes the browser-only mode for Pension-Data in locked-down PC en
 
 ## Internal API Host
 
+Use the internal host for `data_origin: live` bundles and any shared real-data browser session. It serves the same `apps/web/` assets inside the organization perimeter and keeps deterministic saved-view / metric-history analysis in-process instead of moving pension data to public Pages.
+
 Start the internal host from an approved workstation or server:
 
 ```bash

--- a/scripts/web/smoke_test.py
+++ b/scripts/web/smoke_test.py
@@ -210,6 +210,7 @@ def _smoke_url(base_url: str, *, expect_runtime: bool, headers: dict[str, str] |
         workspace_payload,
         path_label="data/workspace.json",
         reject_fixture=expect_runtime,
+        require_fixture=not expect_runtime,
     )
 
     if expect_runtime:

--- a/tests/docs/test_public_hosting_data_origin_guard.py
+++ b/tests/docs/test_public_hosting_data_origin_guard.py
@@ -1,0 +1,65 @@
+"""Guardrails for public-hosting docs and synthetic-data deployment language."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DOCS_DIR = ROOT / "docs"
+WEB_DIR = ROOT / "apps" / "web"
+
+UI_OPTIONS_DOC = DOCS_DIR / "UI_LANGCHAIN_OPTIONS.md"
+CLOUDFLARE_DOC = DOCS_DIR / "deploy" / "CLOUDFLARE_PAGES_SETUP.md"
+
+PUBLIC_HOSTING_DOCS: tuple[Path, ...] = (
+    UI_OPTIONS_DOC,
+    CLOUDFLARE_DOC,
+)
+
+PROHIBITED_ALLOW_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"cloudflare\\s+pages.{0,120}data_origin\\s*:\\s*live", re.IGNORECASE),
+    re.compile(r"github\\s+pages.{0,120}data_origin\\s*:\\s*live", re.IGNORECASE),
+    re.compile(r"publish.{0,120}data_origin\\s*:\\s*live", re.IGNORECASE),
+)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_ui_options_includes_real_data_recommendation_and_llm_boundary() -> None:
+    text = _read(UI_OPTIONS_DOC)
+
+    assert (
+        "## Option 1: Zero-Egress Browser UI or Internal Hosting (Recommended for Real Data)"
+        in text
+    )
+    assert "GitHub Pages / Cloudflare Pages" in text
+    assert "fixture-only" in text
+    assert "## Data zones & LLM boundary" in text
+    assert "OPENAI_BASE_URL" in text
+    assert "ANTHROPIC_BASE_URL" in text
+    assert "PENSION_DATA_DATA_ZONE=proprietary" in text
+
+
+def test_cloudflare_doc_has_fixture_only_banner() -> None:
+    text = _read(CLOUDFLARE_DOC)
+    assert (
+        "> For fixture/synthetic data only. Do not publish bundles whose `data_origin` is `live`."
+        in text
+    )
+
+
+def test_public_hosting_docs_do_not_allow_live_bundle_publication() -> None:
+    for doc in PUBLIC_HOSTING_DOCS:
+        text = _read(doc)
+        for pattern in PROHIBITED_ALLOW_PATTERNS:
+            assert not pattern.search(
+                text
+            ), f"public-hosting doc must not allow live bundle publication: {doc}"
+
+
+def test_review_gate_grep_signal_has_no_live_bundle_in_web_scaffold() -> None:
+    workspace = _read(WEB_DIR / "data" / "workspace.json")
+    assert '"data_origin": "live"' not in workspace

--- a/tests/web/test_workspace_contract.py
+++ b/tests/web/test_workspace_contract.py
@@ -161,6 +161,44 @@ def test_remote_public_deploy_rejects_live_bundle(monkeypatch: pytest.MonkeyPatc
         web_smoke_test._smoke_url("https://example.test", expect_runtime=False, headers=None)
 
 
+def test_remote_public_deploy_accepts_fixture_bundle(monkeypatch: pytest.MonkeyPatch) -> None:
+    fixture_workspace = json.loads(
+        (WEB_DIR / "data" / "workspace.json").read_text(encoding="utf-8")
+    )
+
+    def fake_fetch_text(url: str, *, headers: dict[str, str] | None = None) -> str:
+        del headers
+        if url.endswith("/"):
+            return (
+                "<html><body>Cloudflare Web Workspace Foundation"
+                '<span data-testid="environment-badge"></span>'
+                '<span data-testid="data-origin-badge"></span></body></html>'
+            )
+        if url.endswith("config/default.json"):
+            return json.dumps(
+                {
+                    "environment": "prod",
+                    "apiBaseUrl": "https://api.example.test",
+                    "artifactBaseUrl": "https://artifacts.example.test",
+                }
+            )
+        if url.endswith("manifest.webmanifest"):
+            return json.dumps({"name": "Pension Data", "start_url": "/"})
+        if (
+            url.endswith("sw.js")
+            or url.endswith("icons/pension-data-mark-192.png")
+            or url.endswith("icons/pension-data-mark-512.png")
+        ):
+            return "ok"
+        if url.endswith("data/workspace.json"):
+            return json.dumps(fixture_workspace)
+        raise AssertionError(f"unexpected url: {url}")
+
+    monkeypatch.setattr(web_smoke_test, "_fetch_text", fake_fetch_text)
+
+    web_smoke_test._smoke_url("https://example.test", expect_runtime=False, headers=None)
+
+
 def test_missing_or_unknown_origin_fails_workspace_validation() -> None:
     workspace = json.loads((WEB_DIR / "data" / "workspace.json").read_text())
     workspace.pop("data_origin")

--- a/tests/web/test_workspace_contract.py
+++ b/tests/web/test_workspace_contract.py
@@ -120,6 +120,47 @@ def test_remote_expect_runtime_rejects_fixture_bundle(monkeypatch: pytest.Monkey
         web_smoke_test._smoke_url("https://example.test", expect_runtime=True, headers=None)
 
 
+def test_remote_public_deploy_rejects_live_bundle(monkeypatch: pytest.MonkeyPatch) -> None:
+    live_workspace = json.loads((WEB_DIR / "data" / "workspace.json").read_text(encoding="utf-8"))
+    live_workspace["data_origin"] = "live"
+
+    def fake_fetch_text(url: str, *, headers: dict[str, str] | None = None) -> str:
+        del headers
+        if url.endswith("/"):
+            return (
+                "<html><body>Cloudflare Web Workspace Foundation"
+                '<span data-testid="environment-badge"></span>'
+                '<span data-testid="data-origin-badge"></span></body></html>'
+            )
+        if url.endswith("config/default.json"):
+            return json.dumps(
+                {
+                    "environment": "prod",
+                    "apiBaseUrl": "https://api.example.test",
+                    "artifactBaseUrl": "https://artifacts.example.test",
+                }
+            )
+        if url.endswith("manifest.webmanifest"):
+            return json.dumps({"name": "Pension Data", "start_url": "/"})
+        if (
+            url.endswith("sw.js")
+            or url.endswith("icons/pension-data-mark-192.png")
+            or url.endswith("icons/pension-data-mark-512.png")
+        ):
+            return "ok"
+        if url.endswith("data/workspace.json"):
+            return json.dumps(live_workspace)
+        raise AssertionError(f"unexpected url: {url}")
+
+    monkeypatch.setattr(web_smoke_test, "_fetch_text", fake_fetch_text)
+
+    with pytest.raises(
+        ValueError,
+        match=r"Refusing to deploy non-synthetic bundle to external Cloudflare Pages: .*data/workspace\.json",
+    ):
+        web_smoke_test._smoke_url("https://example.test", expect_runtime=False, headers=None)
+
+
 def test_missing_or_unknown_origin_fails_workspace_validation() -> None:
     workspace = json.loads((WEB_DIR / "data" / "workspace.json").read_text())
     workspace.pop("data_origin")


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:485 -->
> **Source:** Issue #485

Closes #485

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Pension-Data's deployment guidance currently steers real data toward external/community SaaS. `docs/UI_LANGCHAIN_OPTIONS.md` Option 1 ("Recommended") is "Static Web UI on **GitHub Pages** + LangChain via **GitHub Actions**," and `docs/deploy/CLOUDFLARE_PAGES_SETUP.md` configures the `apps/web` scaffold for Cloudflare Pages with a `PENSION_DATA_API_BASE_URL` variable. The repo's smoke test even pings a *deployed* Cloudflare URL (`scripts/web/smoke_test.py:224`). The organization cannot expose proprietary pension data to external/community SaaS, and cannot send it to public LLMs without authorization. Missing behavior: a documented privacy posture that distinguishes the zero-egress client-side path, internal hosting, and synthetic-only external demos — and that isolates the LLM boundary. (Note: the client-side data flow itself is already largely compliant — `docs/deploy/PC_ZERO_INSTALL_IT_REVIEW.md` documents that filtering/charts run in-browser and loaded bundles "remain local to browser context"; the gap is the *hosting/CI/LLM* guidance built on top of it.)

#### Tasks
- [x] Rewrite `docs/UI_LANGCHAIN_OPTIONS.md` Option 1 so the "Recommended" path for **real data** is client-side WASM (run the existing `apps/web/` SPA, or a stlite/Pyodide build, entirely in the work browser with the user-selected local JSON bundle — the file-picker flow already documented in `docs/deploy/PC_ZERO_INSTALL_IT_REVIEW.md` "Local File Interaction") **or** internal hosting; mark public GitHub Pages / Cloudflare Pages as **fixture/synthetic-data demos only**.
- [x] Add an explicit "Data zones & LLM boundary" section to `docs/UI_LANGCHAIN_OPTIONS.md` stating: deterministic analysis (filter/chart/export, `run_saved_view_endpoint`/`run_metric_history_endpoint`) may run on real data client-side or on internal hosting; LLM-dependent features (NL query, findings explain/compare) must target an authorized no-train endpoint via `OPENAI_BASE_URL`/`ANTHROPIC_BASE_URL` (`src/pension_data/langchain/foundation.py:51,56`) or be disabled in the proprietary zone (cross-reference Issue 2's `PENSION_DATA_DATA_ZONE` flag).
- [x] Re-title and re-scope `docs/deploy/CLOUDFLARE_PAGES_SETUP.md` to "Synthetic-Data Demo Hosting" and add a top banner: "For fixture/synthetic data only — do not publish bundles whose `data_origin` is `live`."
- [x] Update `scripts/web/smoke_test.py` so the deployed-URL check (the `--url` path at `scripts/web/smoke_test.py:224`) asserts the served bundle's `data_origin` is `fixture` (it must refuse to "pass" against a deployment serving `live` data), keeping the local-file integrity checks (`smoke_test.py:71,113,144`) intact.
- [x] Add an internal-hosting subsection to `docs/deploy/PC_ZERO_INSTALL_IT_REVIEW.md` describing the on-prem option (serve `apps/web/` from an internal web host / the Issue-2 FastAPI app bound to the org network) as the path for `data_origin: live` bundles.

#### Acceptance criteria
- [x] **Failing-then-passing test:** extend `scripts/web/smoke_test.py`'s deployed-URL check so it raises (non-zero exit) when the served `workspace.json` declares `data_origin: live`, and passes for `fixture`. Add or extend a case in `tests/web/test_workspace_contract.py` asserting this guard. The current `main` smoke does not enforce data-origin on the deployed path (`smoke_test.py:167-171` checks only heading/badge markers), so the new assertion fails before the fix.
- [ ] `docs/UI_LANGCHAIN_OPTIONS.md` no longer recommends GitHub Pages/Cloudflare for real data; its "Recommended" path for live data is client-side WASM or internal hosting, and it contains a "Data zones & LLM boundary" section naming the `base_url`/disable mechanism.
- [ ] **Documented review gate:** a reviewer confirms (and the PR records) that `grep -rniE "data_origin.*live" docs apps/web` shows no live bundle is referenced by any public-hosting doc, and that `CLOUDFLARE_PAGES_SETUP.md` carries the fixture-only banner.

<!-- auto-status-summary:end -->