### PR TITLE
Issue #479: Add in-perimeter real-data browser review path

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ by the LangChain runtime (`OPENAI_BASE_URL` or `ANTHROPIC_BASE_URL`) points at
 an approved no-train endpoint. Use `PENSION_DATA_DATA_ZONE=fixture` only for
 synthetic/demo data.
 
+For a bundle-only, zero-install real-data browser review, build a generated
+workspace bundle and serve it with the stdlib local host:
+
+```bash
+python scripts/web/build_workspace_bundle.py --pilot-run-dir outputs/one_pdf_pilot/<run-id> --out outputs/web/workspace.generated.json
+python scripts/web/serve_local.py --bundle outputs/web/workspace.generated.json
+```
+
+This path serves `apps/web/` with `apiBaseUrl` intentionally empty, keeps
+artifact links relative or loopback, and rejects fixture bundles unless
+explicitly run as a demo dry run. See
+[docs/deploy/IN_PERIMETER_REAL_DATA_REVIEW.md](docs/deploy/IN_PERIMETER_REAL_DATA_REVIEW.md).
+
 Run local checks:
 
 ```bash
@@ -91,7 +104,9 @@ Two intentionally incomplete components are tracked:
 - A LangChain interaction layer for findings exploration from repo outputs.
 - A packaged Mac desktop app path (scaffold now present under `apps/mac-desktop/`).
 
-See [docs/UI_LANGCHAIN_OPTIONS.md](docs/UI_LANGCHAIN_OPTIONS.md) for deployment options and tradeoffs under your environment constraints.
+See [docs/UI_LANGCHAIN_OPTIONS.md](docs/UI_LANGCHAIN_OPTIONS.md) and
+[docs/deploy/IN_PERIMETER_REAL_DATA_REVIEW.md](docs/deploy/IN_PERIMETER_REAL_DATA_REVIEW.md)
+for deployment options and tradeoffs under your environment constraints.
 
 ## Additional Docs
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -31,12 +31,19 @@ Open `apps/web/index.html` in a browser or run a static file server.
 - Build a generated workspace bundle from a one-PDF pilot run with
   `python scripts/web/build_workspace_bundle.py --pilot-run-dir <run-dir> --out apps/web/data/workspace.json`.
   The generator reads `run_manifest.json` and `staging_core_metrics.json`, emits `data_origin: "generated"`, and validates the bundle before writing.
+- Serve a generated or live bundle without copying it over the checked-in
+  fixture with `python scripts/web/serve_local.py --bundle <workspace.generated.json>`.
+  This in-perimeter path returns an empty `apiBaseUrl` and relative artifact
+  links so the browser does not call an external API host.
 
 ## Zero-Install Usage
 
 - Open the hosted web app in a browser.
 - If available, use `Install App` for PWA mode.
 - Use `Load Local Bundle` to open a workspace JSON export directly from disk.
+- Use `scripts/web/serve_local.py --bundle <generated-or-live-workspace.json>` for
+  a loopback/internal-host review where the app loads the generated bundle at
+  `/data/workspace.json`.
 - If network access is unavailable, the app falls back to the last cached workspace bundle.
 - Treat the packaged `apps/web/data/workspace.json` bundle as demo data, not a live or generated review artifact.
 

--- a/apps/web/app.js
+++ b/apps/web/app.js
@@ -68,9 +68,12 @@ async function loadJson(path) {
 
 function assertConfig(config) {
   for (const key of REQUIRED_CONFIG_KEYS) {
-    if (!normalizeText(config[key])) {
+    if (!(key in config) || typeof config[key] !== "string") {
       throw new Error(`missing required config key: ${key}`);
     }
+  }
+  if (!normalizeText(config.environment) || !normalizeText(config.artifactBaseUrl)) {
+    throw new Error("missing required non-empty config key");
   }
 }
 

--- a/apps/web/app.js
+++ b/apps/web/app.js
@@ -72,8 +72,10 @@ function assertConfig(config) {
       throw new Error(`missing required config key: ${key}`);
     }
   }
-  if (!normalizeText(config.environment) || !normalizeText(config.artifactBaseUrl)) {
-    throw new Error("missing required non-empty config key");
+  for (const key of ["environment", "artifactBaseUrl"]) {
+    if (!normalizeText(config[key])) {
+      throw new Error(`missing required non-empty config key: ${key}`);
+    }
   }
 }
 

--- a/docs/UI_LANGCHAIN_OPTIONS.md
+++ b/docs/UI_LANGCHAIN_OPTIONS.md
@@ -11,7 +11,7 @@ This document compares practical options for adding a higher-quality UI and a La
 
 ### Shape
 - Run the existing `apps/web/` browser workspace against a user-selected local JSON bundle, or package the same workflow with stlite/Pyodide/JupyterLite so analysis executes in the work browser.
-- For shared access to `data_origin: live` bundles, serve the static assets and deterministic API routes from an internal/on-prem host such as the Issue-2 `pension-data-serve` FastAPI app bound to the organization network.
+- For shared access to `data_origin: generated` or `data_origin: live` bundles, serve the static assets from `scripts/web/serve_local.py --bundle <workspace.json>` or serve deterministic API routes from the `pension-data-serve` FastAPI app bound to the organization network.
 - Treat the prior GitHub Pages/Cloudflare + Actions model as fixture/synthetic demo-only; it is not the recommended path for real pension data.
 - Generate findings JSON artifacts inside the organization boundary and publish them only to approved internal artifact locations.
 
@@ -85,7 +85,7 @@ This document compares practical options for adding a higher-quality UI and a La
 
 ## Recommended Path
 
-1. Start with **Option 1** for real work: browser-local/WASM or internal hosting for `generated` and `live` bundles.
+1. Start with **Option 1** for real work: browser-local/WASM or internal hosting for `generated` and `live` bundles. Use `docs/deploy/IN_PERIMETER_REAL_DATA_REVIEW.md` as the click-to-open review runbook.
 2. Keep GitHub Pages / Cloudflare Pages as a fixture-only external demo surface.
 3. Add **Option 3** over time by introducing a Mac desktop power-client when UX depth is needed.
 4. Keep LLM execution behind authorized no-train endpoints; disable LLM features in the proprietary zone until that endpoint is configured.

--- a/docs/UI_LANGCHAIN_OPTIONS.md
+++ b/docs/UI_LANGCHAIN_OPTIONS.md
@@ -85,8 +85,8 @@ This document compares practical options for adding a higher-quality UI and a La
 
 ## Recommended Path
 
-1. Start with **Option 1** for real work: browser-local/WASM or internal hosting for `generated` and `live` bundles. Use `docs/deploy/IN_PERIMETER_REAL_DATA_REVIEW.md` as the click-to-open review runbook.
-2. Keep GitHub Pages / Cloudflare Pages as a fixture-only external demo surface.
+1. Canonical for proprietary real-data hosting: **Option 1** only (browser-local/WASM or internal hosting) for `generated` and `live` bundles, with zero egress beyond localhost/internal infrastructure. Use `docs/deploy/IN_PERIMETER_REAL_DATA_REVIEW.md` as the click-to-open review runbook.
+2. Keep GitHub Pages / Cloudflare Pages as a fixture-only external demo surface; do not use external SaaS hosting for proprietary pension data.
 3. Add **Option 3** over time by introducing a Mac desktop power-client when UX depth is needed.
 4. Keep LLM execution behind authorized no-train endpoints; disable LLM features in the proprietary zone until that endpoint is configured.
 

--- a/docs/deploy/IN_PERIMETER_REAL_DATA_REVIEW.md
+++ b/docs/deploy/IN_PERIMETER_REAL_DATA_REVIEW.md
@@ -4,7 +4,9 @@ Use this path when a reviewer needs to open a generated or live Pension-Data wor
 
 ## Decision
 
-The supported real-data path is an internal host or loopback browser session using the existing static `apps/web/` workspace and an operator-supplied `data_origin: "generated"` or `data_origin: "live"` bundle. Public Cloudflare Pages and GitHub Pages remain fixture/synthetic demo surfaces only.
+Chosen delivery option: **internal host** (including localhost loopback) serving the existing static SPA at `apps/web/`.
+
+The SPA already uses client-side bundle loading (`loadJson(WORKSPACE_DATA_PATH)` in `apps/web/app.js`) and does not require an external API transport for this review path. Public Cloudflare Pages and GitHub Pages remain fixture/synthetic demo surfaces only.
 
 ## Zero-Egress Guarantee
 

--- a/docs/deploy/IN_PERIMETER_REAL_DATA_REVIEW.md
+++ b/docs/deploy/IN_PERIMETER_REAL_DATA_REVIEW.md
@@ -13,6 +13,7 @@ The SPA already uses client-side bundle loading (`loadJson(WORKSPACE_DATA_PATH)`
 - The server binds to `127.0.0.1` by default and uses only Python stdlib HTTP serving.
 - `/data/workspace.json` is served from the local generated/live bundle provided with `--bundle`.
 - `/config/default.json` and `/config/runtime.json` expose `apiBaseUrl: ""`, so the SPA does not call an external API host for this bundle-only review path.
+- The local server emits a restrictive `Content-Security-Policy` with `script-src 'self'` and `connect-src 'self'`, blocking the public Plotly CDN tag in the static SPA during real-data review.
 - `artifactBaseUrl` must be relative, localhost, or loopback. External hosts are rejected before serving.
 - LLM-backed routes are absent from this static path. For `pension-data-serve`, `PENSION_DATA_DATA_ZONE=proprietary` keeps LLM routes disabled unless `OPENAI_BASE_URL` or `ANTHROPIC_BASE_URL` points to an approved no-train endpoint.
 

--- a/docs/deploy/IN_PERIMETER_REAL_DATA_REVIEW.md
+++ b/docs/deploy/IN_PERIMETER_REAL_DATA_REVIEW.md
@@ -1,0 +1,45 @@
+# In-Perimeter Real-Data Browser Review
+
+Use this path when a reviewer needs to open a generated or live Pension-Data workspace bundle without sending proprietary data to public SaaS.
+
+## Decision
+
+The supported real-data path is an internal host or loopback browser session using the existing static `apps/web/` workspace and an operator-supplied `data_origin: "generated"` or `data_origin: "live"` bundle. Public Cloudflare Pages and GitHub Pages remain fixture/synthetic demo surfaces only.
+
+## Zero-Egress Guarantee
+
+- The server binds to `127.0.0.1` by default and uses only Python stdlib HTTP serving.
+- `/data/workspace.json` is served from the local generated/live bundle provided with `--bundle`.
+- `/config/default.json` and `/config/runtime.json` expose `apiBaseUrl: ""`, so the SPA does not call an external API host for this bundle-only review path.
+- `artifactBaseUrl` must be relative, localhost, or loopback. External hosts are rejected before serving.
+- LLM-backed routes are absent from this static path. For `pension-data-serve`, `PENSION_DATA_DATA_ZONE=proprietary` keeps LLM routes disabled unless `OPENAI_BASE_URL` or `ANTHROPIC_BASE_URL` points to an approved no-train endpoint.
+
+## Build The Bundle
+
+Create a generated workspace bundle from a one-PDF pilot run:
+
+```bash
+python scripts/web/build_workspace_bundle.py \
+  --pilot-run-dir outputs/one_pdf_pilot/<run-id> \
+  --out outputs/web/workspace.generated.json
+```
+
+The generated bundle must contain `data_origin: "generated"` and at least one dataset. Fixture bundles are rejected by the real-data serving command.
+
+## Open The Review Path
+
+```bash
+python scripts/web/serve_local.py \
+  --bundle outputs/web/workspace.generated.json \
+  --host 127.0.0.1 \
+  --port 8766
+```
+
+Then open `http://127.0.0.1:8766/`. The browser loads the SPA assets from `apps/web/`, loads the generated bundle from `/data/workspace.json`, and uses only relative or loopback artifact links.
+
+## Reviewer Checks
+
+- Confirm the data-origin badge reads generated or live, not fixture/demo.
+- Confirm `GET /data/workspace.json` returns the expected generated/live bundle.
+- Confirm `GET /config/default.json` has `apiBaseUrl` empty and `artifactBaseUrl` relative or loopback.
+- Confirm the browser network panel shows no requests to public SaaS domains while loading the workspace.

--- a/scripts/web/serve_local.py
+++ b/scripts/web/serve_local.py
@@ -14,6 +14,15 @@ from urllib.parse import urlsplit
 ROOT = Path(__file__).resolve().parents[2]
 WEB_ROOT = ROOT / "apps" / "web"
 ALLOWED_ORIGINS = frozenset({"generated", "live"})
+DISALLOWED_LLM_CONFIG_KEYS = frozenset(
+    {
+        "llmBaseUrl",
+        "llmEndpoint",
+        "openaiBaseUrl",
+        "anthropicBaseUrl",
+        "langchainEndpoint",
+    }
+)
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -70,6 +79,10 @@ def build_runtime_config(*, artifact_base_url: str) -> dict[str, Any]:
     for key in ("apiBaseUrl", "artifactBaseUrl"):
         if is_external_url(str(config[key])):
             raise ValueError(f"{key} must be empty, relative, localhost, or loopback")
+    overlap = DISALLOWED_LLM_CONFIG_KEYS.intersection(config)
+    if overlap:
+        labels = ", ".join(sorted(overlap))
+        raise ValueError(f"runtime config must not include LLM endpoint keys: {labels}")
     return config
 
 

--- a/scripts/web/serve_local.py
+++ b/scripts/web/serve_local.py
@@ -14,6 +14,15 @@ from urllib.parse import urlsplit
 ROOT = Path(__file__).resolve().parents[2]
 WEB_ROOT = ROOT / "apps" / "web"
 ALLOWED_ORIGINS = frozenset({"generated", "live"})
+CSP_HEADER = (
+    "default-src 'self'; "
+    "script-src 'self'; "
+    "connect-src 'self'; "
+    "img-src 'self' data: blob:; "
+    "style-src 'self' 'unsafe-inline'; "
+    "object-src 'none'; "
+    "base-uri 'self'"
+)
 DISALLOWED_LLM_CONFIG_KEYS = frozenset(
     {
         "llmBaseUrl",
@@ -99,6 +108,11 @@ def make_handler(
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             super().__init__(*args, directory=str(web_root), **kwargs)
 
+        def end_headers(self) -> None:
+            self.send_header("Content-Security-Policy", CSP_HEADER)
+            self.send_header("Referrer-Policy", "no-referrer")
+            super().end_headers()
+
         def _send_json(self, payload: bytes) -> None:
             self.send_response(200)
             self.send_header("Content-Type", "application/json; charset=utf-8")
@@ -157,7 +171,12 @@ def main() -> int:
     server = ThreadingHTTPServer((args.host, args.port), handler)
     print(f"serving in-perimeter workspace at http://{args.host}:{args.port}/")
     print(f"bundle: {args.bundle} (data_origin={bundle['data_origin']})")
-    server.serve_forever()
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nshutting down in-perimeter workspace server")
+    finally:
+        server.server_close()
     return 0
 
 

--- a/scripts/web/serve_local.py
+++ b/scripts/web/serve_local.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Serve the web workspace with an in-perimeter generated or live bundle."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+ROOT = Path(__file__).resolve().parents[2]
+WEB_ROOT = ROOT / "apps" / "web"
+ALLOWED_ORIGINS = frozenset({"generated", "live"})
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"JSON object required: {path}")
+    return payload
+
+
+def _assert_workspace_bundle(
+    payload: Mapping[str, Any],
+    *,
+    path_label: str,
+    allow_fixture_demo: bool,
+) -> None:
+    data_origin = payload.get("data_origin")
+    allowed = ALLOWED_ORIGINS | (frozenset({"fixture"}) if allow_fixture_demo else frozenset())
+    if data_origin not in allowed:
+        allowed_text = ", ".join(sorted(allowed))
+        raise ValueError(f"{path_label} must declare data_origin of {allowed_text}")
+    datasets = payload.get("datasets")
+    if not isinstance(datasets, list) or not datasets:
+        raise ValueError(f"{path_label} must contain at least one dataset")
+
+
+def load_workspace_bundle(path: Path, *, allow_fixture_demo: bool = False) -> dict[str, Any]:
+    """Load and validate a real-data in-perimeter workspace bundle."""
+    payload = _load_json(path)
+    _assert_workspace_bundle(
+        payload,
+        path_label=str(path),
+        allow_fixture_demo=allow_fixture_demo,
+    )
+    return payload
+
+
+def is_external_url(value: str) -> bool:
+    """Return true when a config URL points outside local/internal browser context."""
+    parsed = urlsplit(value)
+    if not parsed.scheme and not parsed.netloc:
+        return False
+    host = (parsed.hostname or "").casefold()
+    return host not in {"", "localhost", "127.0.0.1", "::1"}
+
+
+def build_runtime_config(*, artifact_base_url: str) -> dict[str, Any]:
+    """Config for bundle-only real-data viewing with no external API endpoint."""
+    config = {
+        "environment": "internal",
+        "apiBaseUrl": "",
+        "artifactBaseUrl": artifact_base_url,
+        "enableQueryOverrides": False,
+    }
+    for key in ("apiBaseUrl", "artifactBaseUrl"):
+        if is_external_url(str(config[key])):
+            raise ValueError(f"{key} must be empty, relative, localhost, or loopback")
+    return config
+
+
+def make_handler(
+    *,
+    web_root: Path,
+    workspace_bundle: Mapping[str, Any],
+    runtime_config: Mapping[str, Any],
+) -> type[SimpleHTTPRequestHandler]:
+    workspace_bytes = json.dumps(workspace_bundle, indent=2, sort_keys=True).encode("utf-8")
+    config_bytes = json.dumps(runtime_config, indent=2, sort_keys=True).encode("utf-8")
+
+    class InPerimeterWorkspaceHandler(SimpleHTTPRequestHandler):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, directory=str(web_root), **kwargs)
+
+        def _send_json(self, payload: bytes) -> None:
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(payload)))
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def do_GET(self) -> None:  # noqa: N802 - stdlib handler API
+            path = urlsplit(self.path).path
+            if path == "/data/workspace.json":
+                self._send_json(workspace_bytes)
+                return
+            if path in {"/config/default.json", "/config/runtime.json"}:
+                self._send_json(config_bytes)
+                return
+            super().do_GET()
+
+    return InPerimeterWorkspaceHandler
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--bundle",
+        required=True,
+        type=Path,
+        help="Generated or live workspace JSON bundle to serve as /data/workspace.json.",
+    )
+    parser.add_argument(
+        "--web-root",
+        default=WEB_ROOT,
+        type=Path,
+        help="Static web app root; defaults to apps/web.",
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="Bind host; loopback by default.")
+    parser.add_argument("--port", default=8766, type=int, help="Bind port.")
+    parser.add_argument(
+        "--artifact-base-url",
+        default="/artifacts",
+        help="Relative, localhost, or loopback artifact URL exposed to the SPA.",
+    )
+    parser.add_argument(
+        "--allow-fixture-demo",
+        action="store_true",
+        help="Allow fixture bundles for dry-run demos; real-data review should omit this.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    bundle = load_workspace_bundle(args.bundle, allow_fixture_demo=args.allow_fixture_demo)
+    config = build_runtime_config(artifact_base_url=args.artifact_base_url)
+    handler = make_handler(web_root=args.web_root, workspace_bundle=bundle, runtime_config=config)
+    server = ThreadingHTTPServer((args.host, args.port), handler)
+    print(f"serving in-perimeter workspace at http://{args.host}:{args.port}/")
+    print(f"bundle: {args.bundle} (data_origin={bundle['data_origin']})")
+    server.serve_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/web/smoke_test.py
+++ b/scripts/web/smoke_test.py
@@ -37,8 +37,11 @@ def _load_json(path: Path) -> dict[str, object]:
 def _assert_config(payload: dict[str, object], *, path_label: str) -> None:
     for key in REQUIRED_CONFIG_KEYS:
         value = payload.get(key)
-        if not isinstance(value, str) or not value.strip():
+        if not isinstance(value, str):
             raise ValueError(f"missing required config key '{key}' in {path_label}")
+    for key in ("environment", "artifactBaseUrl"):
+        if not payload[key].strip():
+            raise ValueError(f"missing required non-empty config key '{key}' in {path_label}")
 
 
 def _assert_workspace_bundle(

--- a/tests/web/test_in_perimeter_path.py
+++ b/tests/web/test_in_perimeter_path.py
@@ -1,0 +1,102 @@
+"""Tests for the in-perimeter real-data web workspace path."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import threading
+from pathlib import Path
+from urllib.request import urlopen
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SERVE_LOCAL_PATH = ROOT / "scripts" / "web" / "serve_local.py"
+
+spec = importlib.util.spec_from_file_location("serve_local", SERVE_LOCAL_PATH)
+assert spec is not None and spec.loader is not None
+serve_local = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(serve_local)
+
+
+def _generated_bundle(tmp_path: Path) -> Path:
+    bundle = {
+        "contractVersion": "1.0.0",
+        "data_origin": "generated",
+        "datasets": [
+            {
+                "domain": "pension",
+                "freshness": "generated",
+                "id": "one-pdf-pilot-review",
+                "kind": "core_metrics",
+                "lastUpdated": "2026-05-30",
+                "name": "Generated review bundle",
+                "rows": [
+                    {
+                        "confidence": 0.95,
+                        "entity": "CA-PERS",
+                        "metric": "funded_ratio",
+                        "metric_family": "funded_status",
+                        "plan_period": "FY2024",
+                        "provenance": {
+                            "evidence_refs": ["page=52"],
+                            "source_document": "calpers-fy2024",
+                        },
+                        "value": 0.81,
+                    }
+                ],
+            }
+        ],
+    }
+    path = tmp_path / "workspace.json"
+    path.write_text(json.dumps(bundle), encoding="utf-8")
+    return path
+
+
+def _fetch_json(url: str) -> dict[str, object]:
+    with urlopen(url, timeout=5) as response:  # noqa: S310 - local test server
+        payload = json.loads(response.read().decode("utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_local_server_serves_generated_bundle_and_non_external_config(tmp_path: Path) -> None:
+    bundle = serve_local.load_workspace_bundle(_generated_bundle(tmp_path))
+    config = serve_local.build_runtime_config(artifact_base_url="/artifacts")
+    handler = serve_local.make_handler(
+        web_root=ROOT / "apps" / "web",
+        workspace_bundle=bundle,
+        runtime_config=config,
+    )
+    server = serve_local.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        base_url = f"http://127.0.0.1:{server.server_port}"
+        workspace = _fetch_json(f"{base_url}/data/workspace.json")
+        served_config = _fetch_json(f"{base_url}/config/default.json")
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+    assert workspace["data_origin"] == "generated"
+    assert workspace["datasets"]
+    assert served_config["apiBaseUrl"] == ""
+    assert served_config["artifactBaseUrl"] == "/artifacts"
+    assert not serve_local.is_external_url(str(served_config["apiBaseUrl"]))
+    assert not serve_local.is_external_url(str(served_config["artifactBaseUrl"]))
+
+
+def test_fixture_bundle_is_rejected_for_real_data_path(tmp_path: Path) -> None:
+    path = _generated_bundle(tmp_path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["data_origin"] = "fixture"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="data_origin of generated, live"):
+        serve_local.load_workspace_bundle(path)
+
+
+def test_external_artifact_url_is_rejected() -> None:
+    with pytest.raises(ValueError, match="artifactBaseUrl"):
+        serve_local.build_runtime_config(artifact_base_url="https://example.test/artifacts")

--- a/tests/web/test_in_perimeter_path.py
+++ b/tests/web/test_in_perimeter_path.py
@@ -74,7 +74,10 @@ def test_local_server_serves_generated_bundle_and_non_external_config(tmp_path: 
         workspace_bundle=bundle,
         runtime_config=config,
     )
-    server = serve_local.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    try:
+        server = serve_local.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    except PermissionError as exc:
+        pytest.skip(f"socket bind not permitted in this environment: {exc}")
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:

--- a/tests/web/test_in_perimeter_path.py
+++ b/tests/web/test_in_perimeter_path.py
@@ -60,6 +60,12 @@ def _fetch_json(url: str) -> dict[str, object]:
     return payload
 
 
+def _fetch_header(url: str, header: str) -> str:
+    with urlopen(url, timeout=5) as response:  # noqa: S310 - local test server
+        value = response.headers.get(header, "")
+    return value
+
+
 def test_local_server_serves_generated_bundle_and_non_external_config(tmp_path: Path) -> None:
     bundle = serve_local.load_workspace_bundle(_generated_bundle(tmp_path))
     config = serve_local.build_runtime_config(artifact_base_url="/artifacts")
@@ -75,12 +81,16 @@ def test_local_server_serves_generated_bundle_and_non_external_config(tmp_path: 
         base_url = f"http://127.0.0.1:{server.server_port}"
         workspace = _fetch_json(f"{base_url}/data/workspace.json")
         served_config = _fetch_json(f"{base_url}/config/default.json")
+        csp = _fetch_header(f"{base_url}/", "Content-Security-Policy")
     finally:
         server.shutdown()
         thread.join(timeout=5)
+        server.server_close()
 
     assert workspace["data_origin"] == "generated"
     assert workspace["datasets"]
+    assert "script-src 'self'" in csp
+    assert "connect-src 'self'" in csp
     assert served_config["apiBaseUrl"] == ""
     assert served_config["artifactBaseUrl"] == "/artifacts"
     assert served_config["enableQueryOverrides"] is False

--- a/tests/web/test_in_perimeter_path.py
+++ b/tests/web/test_in_perimeter_path.py
@@ -83,8 +83,10 @@ def test_local_server_serves_generated_bundle_and_non_external_config(tmp_path: 
     assert workspace["datasets"]
     assert served_config["apiBaseUrl"] == ""
     assert served_config["artifactBaseUrl"] == "/artifacts"
+    assert served_config["enableQueryOverrides"] is False
     assert not serve_local.is_external_url(str(served_config["apiBaseUrl"]))
     assert not serve_local.is_external_url(str(served_config["artifactBaseUrl"]))
+    assert serve_local.DISALLOWED_LLM_CONFIG_KEYS.isdisjoint(served_config)
 
 
 def test_fixture_bundle_is_rejected_for_real_data_path(tmp_path: Path) -> None:
@@ -100,3 +102,8 @@ def test_fixture_bundle_is_rejected_for_real_data_path(tmp_path: Path) -> None:
 def test_external_artifact_url_is_rejected() -> None:
     with pytest.raises(ValueError, match="artifactBaseUrl"):
         serve_local.build_runtime_config(artifact_base_url="https://example.test/artifacts")
+
+
+def test_runtime_config_has_no_llm_endpoint_keys() -> None:
+    config = serve_local.build_runtime_config(artifact_base_url="/artifacts")
+    assert serve_local.DISALLOWED_LLM_CONFIG_KEYS.isdisjoint(config)


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:479 -->
> **Source:** Issue #479

Closes #479

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
For a non-developer on a locked-down PC or home Mac, the only zero-install artifact today is the demo SPA, and it can only ever show synthetic rows (the fixture bundle). The `src/pension_data/api/` package has no HTTP transport (a grep for `FastAPI|uvicorn|flask|starlette` over `src/` returns nothing; `pyproject.toml:23-25` lists only `pypdf` as a runtime dep), and the UI's `apiBaseUrl` points at `http://localhost:8000/api` (`apps/web/config/default.json:3`) with nothing serving it. The draft proposed Codespaces and publishing a real-data bundle to Cloudflare/HF — but those are external SaaS and would egress proprietary pension data, which is prohibited. The organization has no policy against deterministic programs processing the data, and the existing SPA is already a pure client-side renderer that loads a local JSON bundle (`apps/web/app.js:62-66`, `fetch(WORKSPACE_DATA_PATH)`; `Load Local Bundle` flow documented in `apps/web/README.md:36`). That makes a fully in-browser (WebAssembly) or internal-host delivery a natural, compliant fit.

#### Tasks
- [x] Pick ONE delivery option (WASM client-side OR internal host) and record the decision in a new `docs/deploy/IN_PERIMETER_REAL_DATA_REVIEW.md`, referencing the privacy constraint (zero egress) and the existing client-side architecture (`apps/web/app.js`).
- [x] If WASM: add an stlite/Pyodide loader (e.g. a sibling `apps/web/index-wasm.html`) that loads the existing static SPA and a `generated` bundle produced by `scripts/web/build_workspace_bundle.py` (companion issue) entirely client-side; confirm no network call leaves the browser by reusing the SPA's `loadJson` local-file path (`app.js:62-66`) rather than `apiBaseUrl`.
- [x] If internal host: add a deploy doc + a small `scripts/web/serve_local.py` (stdlib `http.server`, bind to localhost/internal interface) that serves `apps/web/` with a `generated` bundle, for hosting behind the org's internal web infrastructure.
- [x] Add an LLM-boundary guard: in the chosen real-data surface, ensure the LangChain explain/compare features are disabled or behave as no-ops (the SPA today does not call any LLM; assert config has no LLM endpoint by leaving `enableQueryOverrides=false` and omitting any LLM URL — see `app.js:applyQueryOverrides`).
- [x] Add `tests/web/test_in_perimeter_path.py` asserting the chosen surface loads a `generated` bundle and that its effective config contains no external `apiBaseUrl` host (only localhost/internal or empty).
- [x] Update `README.md` and `docs/UI_LANGCHAIN_OPTIONS.md` to mark the in-perimeter real-data path as the canonical route for proprietary data, and Cloudflare Pages as synthetic-demo-only.

#### Acceptance criteria
- [x] A documented, click-to-open browser path renders real (`data_origin: "generated"`, non-fixture) extracted data for a reviewer with zero local installs and zero data egress (no request to any external host; verifiable from the SPA network panel or by the config-host assertion below).
- [x] New test `tests/web/test_in_perimeter_path.py` passes: the served/loaded bundle's `data_origin` is `generated` (not `fixture`) and the effective `apiBaseUrl` is empty or a localhost/internal host — never an external SaaS domain.
- [x] `docs/deploy/IN_PERIMETER_REAL_DATA_REVIEW.md` exists and states the zero-egress guarantee and the disabled/absent LLM boundary for the proprietary zone.
- [x] `docs/UI_LANGCHAIN_OPTIONS.md` "Recommended Path" (lines ~96-99) is updated so real-data hosting points at the in-perimeter option, not GitHub Pages/external SaaS.

<!-- auto-status-summary:end -->