### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -4,8 +4,8 @@
 # NOTE: Only include dev tools here (linters, formatters, test runners).
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
-BLACK_VERSION=26.3.1
-RUFF_VERSION=0.15.13
+BLACK_VERSION=26.5.1
+RUFF_VERSION=0.15.14
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,9 @@ source_collection = [
 dev = [
     "pytest==9.0.3",
     "pytest-cov==7.1.0",
-    "ruff>=0.15.13",
+    "ruff>=0.15.14",
     "mypy>=2.1.0",
-    "black==26.3.1",
+    "black>=26.5.1",
     # app behavior baseline kit (tests/baseline/) -- shared core + golden-master glue.
     # pytest-regressions' num_regression fixture needs numpy AND pandas.
     "app-baseline-kit @ git+https://github.com/stranske/Workflows.git#subdirectory=packages/app-baseline-kit",

--- a/requirements.lock
+++ b/requirements.lock
@@ -14,7 +14,7 @@ anyio==4.12.1
     #   starlette
 ast-serialize==0.3.0
     # via mypy
-black==26.3.1
+black==26.5.1
     # via pension-data (pyproject.toml)
 certifi==2026.2.25
     # via
@@ -194,7 +194,7 @@ requests==2.32.5
     #   tiktoken
 requests-toolbelt==1.0.0
     # via langsmith
-ruff==0.15.13
+ruff==0.15.14
     # via pension-data (pyproject.toml)
 six==1.17.0
     # via python-dateutil


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` to match the central
version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 4 version updates:
  - ruff: >=0.15.13 -> >=0.15.14
  - black: ==26.3.1 -> >=26.5.1
  - requirements.lock:black: 26.3.1 -> ==26.5.1
  - requirements.lock:ruff: 0.15.13 -> ==0.15.14

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`