### PR TITLE
Vendor Plotly for offline web charts

### DIFF
--- a/apps/web/app.js
+++ b/apps/web/app.js
@@ -5,6 +5,9 @@ const SAVED_VIEWS_KEY = "pension-data.saved-views.v1";
 const OFFLINE_WORKSPACE_KEY = "pension-data.offline-workspace.v1";
 const OFFLINE_WORKSPACE_SOURCE_KEY = "pension-data.offline-workspace-source.v1";
 const SERVICE_WORKER_PATH = "./sw.js";
+const PLOTLY_VENDOR_PATH = "./vendor/plotly-2.35.2.min.js";
+const PLOTLY_LOAD_ERROR_TEXT =
+  "Chart rendering unavailable because the offline Plotly bundle did not load. Rebuild or re-serve the web bundle with apps/web/vendor/plotly-2.35.2.min.js included.";
 const RUNTIME_CONTRACT_VERSION = "1.0.0";
 const REQUIRED_CONFIG_KEYS = ["environment", "apiBaseUrl", "artifactBaseUrl"];
 const DATA_ORIGIN_LABELS = {
@@ -879,8 +882,7 @@ function renderChartSpec(spec) {
   state.currentChartSpec = normalized;
   document.getElementById("chart-spec").value = `${JSON.stringify(normalized, null, 2)}\n`;
   if (!window.Plotly || typeof window.Plotly.react !== "function") {
-    document.getElementById("chart-preview").textContent =
-      "Chart rendering unavailable because Plotly failed to load.";
+    document.getElementById("chart-preview").textContent = PLOTLY_LOAD_ERROR_TEXT;
     return;
   }
   window.Plotly.react("chart-preview", normalized.data, normalized.layout, {
@@ -904,6 +906,21 @@ function scheduleChartRefresh() {
   }, 180);
 }
 
+async function loadVendoredPlotlySource() {
+  const response = await fetch(PLOTLY_VENDOR_PATH, { cache: "force-cache" });
+  if (!response.ok) {
+    throw new Error(`failed to load ${PLOTLY_VENDOR_PATH}`);
+  }
+  return response.text();
+}
+
+function escapeInlineScript(source) {
+  return source
+    .replace(/<\/script/gi, "<\\/script")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
 function bindChartStudio() {
   document.getElementById("chart-build").addEventListener("click", buildChartFromTemplate);
   document.getElementById("chart-template").addEventListener("change", buildChartFromTemplate);
@@ -924,7 +941,7 @@ function bindChartStudio() {
   });
   document.getElementById("chart-export-png").addEventListener("click", async () => {
     if (!window.Plotly || typeof window.Plotly.toImage !== "function") {
-      window.alert("Chart export unavailable because Plotly failed to load.");
+      window.alert(PLOTLY_LOAD_ERROR_TEXT);
       return;
     }
     const dataUrl = await window.Plotly.toImage("chart-preview", {
@@ -937,7 +954,7 @@ function bindChartStudio() {
   });
   document.getElementById("chart-export-svg").addEventListener("click", async () => {
     if (!window.Plotly || typeof window.Plotly.toImage !== "function") {
-      window.alert("Chart export unavailable because Plotly failed to load.");
+      window.alert(PLOTLY_LOAD_ERROR_TEXT);
       return;
     }
     const dataUrl = await window.Plotly.toImage("chart-preview", {
@@ -947,16 +964,23 @@ function bindChartStudio() {
     });
     downloadFile("pension-data-chart.svg", dataUrl, "image/svg+xml");
   });
-  document.getElementById("chart-export-html").addEventListener("click", () => {
+  document.getElementById("chart-export-html").addEventListener("click", async () => {
     const spec = state.currentChartSpec || { data: [], layout: {} };
     const embeddedSpec = JSON.stringify(spec).replace(/</g, "\\u003c");
+    let plotlySource;
+    try {
+      plotlySource = await loadVendoredPlotlySource();
+    } catch {
+      window.alert(PLOTLY_LOAD_ERROR_TEXT);
+      return;
+    }
     const html = `<!doctype html>
 <html lang=\"en\">
   <head>
     <meta charset=\"UTF-8\" />
     <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\" />
     <title>Pension-Data Chart Export</title>
-    <script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script>
+    <script>${escapeInlineScript(plotlySource)}</script>
   </head>
   <body>
     <div id=\"chart\" style=\"width:100%;height:100vh;\"></div>

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -178,7 +178,7 @@
         <div id="chart-preview" class="chart-preview"></div>
       </section>
     </main>
-    <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
+    <script src="./vendor/plotly-2.35.2.min.js"></script>
     <script src="./app.js" type="module"></script>
   </body>
 </html>

--- a/apps/web/sw.js
+++ b/apps/web/sw.js
@@ -4,6 +4,7 @@ const CORE_ASSETS = [
   "./index.html",
   "./styles.css",
   "./app.js",
+  "./vendor/plotly-2.35.2.min.js",
   "./manifest.webmanifest",
   "./config/default.json",
   "./data/workspace.json",

--- a/tests/web/test_no_external_cdn.py
+++ b/tests/web/test_no_external_cdn.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+WEB_ROOT = Path("apps/web")
+PLOTLY_VENDOR = WEB_ROOT / "vendor" / "plotly-2.35.2.min.js"
+EXTERNAL_ASSET_RE = re.compile(
+    r"""<(?:script|link)\b[^>]+(?:src|href)=["']https?://""",
+    re.IGNORECASE,
+)
+
+
+def test_offline_web_bundle_uses_no_external_scripts_or_styles() -> None:
+    for path in [WEB_ROOT / "index.html", WEB_ROOT / "app.js"]:
+        content = path.read_text(encoding="utf-8")
+        assert not EXTERNAL_ASSET_RE.search(content), (
+            f"{path} references an external script/style asset"
+        )
+        assert "cdn.plot.ly" not in content
+
+
+def test_plotly_is_vendored_and_precached_for_offline_chart_studio() -> None:
+    index_html = (WEB_ROOT / "index.html").read_text(encoding="utf-8")
+    app_js = (WEB_ROOT / "app.js").read_text(encoding="utf-8")
+    service_worker = (WEB_ROOT / "sw.js").read_text(encoding="utf-8")
+
+    assert PLOTLY_VENDOR.exists()
+    assert (
+        "Licensed under the MIT license"
+        in PLOTLY_VENDOR.read_text(encoding="utf-8", errors="ignore")[:500]
+    )
+    assert "./vendor/plotly-2.35.2.min.js" in index_html
+    assert "./vendor/plotly-2.35.2.min.js" in app_js
+    assert "./vendor/plotly-2.35.2.min.js" in service_worker
+    assert "offline Plotly bundle did not load" in app_js
+    assert "escapeInlineScript(plotlySource)" in app_js


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:594 -->
> **Source:** Issue #594

Closes #594

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
_Scope section missing from source issue._

#### Tasks
- [x] **Vendor Plotly locally:** add `apps/web/vendor/plotly-2.35.2.min.js` (or equivalent) and change `apps/web/index.html:181` to reference the local copy instead of `https://cdn.plot.ly/...`.
- [x] Update the **Export-Interactive-HTML** template (`apps/web/app.js:959`) to reference/inline the vendored Plotly so exported charts also work offline.
- [x] Add the vendored Plotly to `apps/web/sw.js` `CORE_ASSETS` so it's precached for PWA/offline use.
- [x] Improve the failure message (`apps/web/app.js:883`): name the cause + remediation (offline bundle needs vendored Plotly) instead of a bare "failed to load."

#### Acceptance criteria
- [x] Named test: `tests/web/test_no_external_cdn.py` (or a static check) — assert `apps/web/index.html` and `apps/web/app.js` contain **no external `http(s)://` script/style/CDN references** (only relative/vendored), so the offline bundle is self-contained.
- [x] Deliberate-break → revert: point `index.html:181` back at `https://cdn.plot.ly/...` → confirm the test FAILS (external ref detected) → revert.

<!-- auto-status-summary:end -->
