### PR TITLE
test(web): harden offline-bundle external-ref check (styles.css + sw.js)

### DIFF
--- a/tests/web/test_no_external_cdn.py
+++ b/tests/web/test_no_external_cdn.py
@@ -20,6 +20,20 @@ def test_offline_web_bundle_uses_no_external_scripts_or_styles() -> None:
         assert "cdn.plot.ly" not in content
 
 
+def test_offline_web_styles_and_worker_have_no_external_urls() -> None:
+    # Defense-in-depth for the confidential-data offline posture: the served
+    # stylesheet and service worker are first-party code (not config), so they
+    # must contain no external URL at all — this catches CSS ``@import``/``url()``
+    # font/asset refs and any future external fetch in the worker, which the
+    # script/link-tag scan above (index.html + app.js only) would miss.
+    for name in ("styles.css", "sw.js"):
+        content = (WEB_ROOT / name).read_text(encoding="utf-8")
+        assert "http://" not in content and "https://" not in content, (
+            f"apps/web/{name} references an external URL; the offline bundle "
+            "must be fully self-contained"
+        )
+
+
 def test_plotly_is_vendored_and_precached_for_offline_chart_studio() -> None:
     index_html = (WEB_ROOT / "index.html").read_text(encoding="utf-8")
     app_js = (WEB_ROOT / "app.js").read_text(encoding="utf-8")

--- a/tests/web/test_no_external_cdn.py
+++ b/tests/web/test_no_external_cdn.py
@@ -28,7 +28,11 @@ def test_offline_web_styles_and_worker_have_no_external_urls() -> None:
     # script/link-tag scan above (index.html + app.js only) would miss.
     for name in ("styles.css", "sw.js"):
         content = (WEB_ROOT / name).read_text(encoding="utf-8")
-        assert "http://" not in content and "https://" not in content, (
+        normalized_content = content.lower()
+        assert (
+            "http://" not in normalized_content
+            and "https://" not in normalized_content
+        ), (
             f"apps/web/{name} references an external URL; the offline bundle "
             "must be fully self-contained"
         )


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:594 -->
> **Source:** Issue #594

Closes #594

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
_Scope section missing from source issue._

#### Tasks
- [ ] **Vendor Plotly locally:** add `apps/web/vendor/plotly-2.35.2.min.js` (or equivalent) and change `apps/web/index.html:181` to reference the local copy instead of `https://cdn.plot.ly/...`.
- [ ] Update the **Export-Interactive-HTML** template (`apps/web/app.js:959`) to reference/inline the vendored Plotly so exported charts also work offline.
- [ ] Add the vendored Plotly to `apps/web/sw.js` `CORE_ASSETS` so it's precached for PWA/offline use.
- [ ] Improve the failure message (`apps/web/app.js:883`): name the cause + remediation (offline bundle needs vendored Plotly) instead of a bare "failed to load."

#### Acceptance criteria
- [ ] Named test: `tests/web/test_no_external_cdn.py` (or a static check) — assert `apps/web/index.html` and `apps/web/app.js` contain **no external `http(s)://` script/style/CDN references** (only relative/vendored), so the offline bundle is self-contained.
- [ ] Deliberate-break → revert: point `index.html:181` back at `https://cdn.plot.ly/...` → confirm the test FAILS (external ref detected) → revert.

**Head SHA:** 5418ec9463607e8f17647945d0c731e3b56dd4cb
**Latest Runs:** ❔ in progress — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Pension-Data/actions/runs/28065058763) |
<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* Added a new offline validation that checks the web stylesheet and service worker are fully self-contained, asserting they contain no `http://` or `https://` URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->