### PR TITLE
fix(ci): format web test + enforce gate format_check — fixes red main (#635)

### DIFF
--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -69,7 +69,7 @@ jobs:
     with:
       python-versions: '["3.12", "3.13"]'
       coverage-min: "80"
-      format_check: false  # Using ruff for formatting
+      format_check: true  # Black is the repo formatter (pyproject [tool.black]); enforce on PRs so unformatted code can't merge and redden main (issue #635)
       working-directory: "."
       artifact-prefix: "gate-"
       # Enable soft coverage gate for trend tracking and hotspot reporting

--- a/tests/web/test_no_external_cdn.py
+++ b/tests/web/test_no_external_cdn.py
@@ -16,9 +16,9 @@ EXTERNAL_ASSET_RE = re.compile(
 def test_offline_web_bundle_uses_no_external_scripts_or_styles() -> None:
     for path in [WEB_ROOT / "index.html", WEB_ROOT / "app.js"]:
         content = path.read_text(encoding="utf-8")
-        assert not EXTERNAL_ASSET_RE.search(content), (
-            f"{path} references an external script/style asset"
-        )
+        assert not EXTERNAL_ASSET_RE.search(
+            content
+        ), f"{path} references an external script/style asset"
         assert "cdn.plot.ly" not in content
 
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:635 -->
> **Source:** Issue #635

Closes #635

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`main` has been CI-red since 2026-06-25. `ci.yml` (runs on `push: [main]`) fails its black `lint-format` job on a single file, `tests/web/test_no_external_cdn.py` (committed unformatted in PR #608 "Adopt design-system CSS bundle"). This is NOT a black version skew — black 26.3.1 (the dev-lock pin) and 26.5.1 (the canonical `autofix-versions.env` pin) reformat the file identically. The root cause that lets it recur: `pr-00-gate.yml:72` sets `format_check: false` (comment "Using ruff for formatting"), but this repo formats with **Black** (`pyproject.toml [tool.black]`, README `black --check`), and only `ci.yml` (post-merge, main-only) runs black — so unformatted code passes the PR Gate and reddens main after merge.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#608](https://github.com/stranske/Pension-Data/issues/608)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Run `black tests/web/test_no_external_cdn.py` with black 26.5.1 and commit the formatting-only diff.
  - [ ] Run `black tests/web/test_no_external_cdn.py` with black 26.5.1 (verify: tests pass)
  - [ ] Run `black tests/web/test_no_external_cdn.py` with commit the formatting-only diff. (verify: tests pass)
- [ ] Update `.github/workflows/pr-00-gate.yml` to set the reusable CI call `format_check: true` at line ~72, matching `ci.yml`.
  - [ ] matching `ci.yml`. (verify: confirm completion in repo)
- [ ] Verify `black --check .` passes repo-wide with the CI-pinned black.

#### Acceptance criteria
- [ ] `black --check . --exclude '/(\.venv|node_modules|\.git)/'` exits 0 with the CI-pinned black version.
- [ ] `.github/workflows/pr-00-gate.yml` runs the black format check on `pull_request`, and a deliberately mis-formatted file in a test branch fails the Gate format job.
- [ ] `main` `ci.yml` `lint-format` job is green on the merge commit.

**Head SHA:** 5eb8be62dc4d5b412f1e1ac44dfb144603cf052c
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Pension-Data/actions/runs/28347848223) |
| Cross-Repo Smoke | ⏭️ skipped | [View run](https://github.com/stranske/Pension-Data/actions/runs/28347619851) |
| Entity Regression Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/28347619693) |
| Extraction Golden Regression | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/28347619698) |
| Foundation Fixture E2E | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/28347619673) |
| Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/28347619880) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/28347619684) |
| NL-SQL Golden | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/28347619679) |
| One-PDF Pilot Golden | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/28347619695) |
| PostgreSQL Integration | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/28347619671) |
| Quality Replay Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/28347619713) |
| Quality SLA Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/28347619669) |
<!-- auto-status-summary:end -->