### PR TITLE
Codex bootstrap for #646

### DIFF
--- a/agents/codex-646.md
+++ b/agents/codex-646.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #646 -->


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The benchmarking centerpiece. Today `plan_funding_metrics`/`plan_allocation_metrics` carry only funded_ratio + contributions + allocation. To judge ONE plan vs peers we need the full metric panel + proper peer statistics + a plan-health scorecard a non-actuary can read. The peer-comparison pattern already exists (`allocation_peer_compare` computes peer mean/median/delta) — generalize it. (Parent: #642; depends on #A for data.)

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#642](https://github.com/stranske/Pension-Data/issues/642)
- [#636](https://github.com/stranske/Pension-Data/issues/636)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Extend `query/saved_views/models.py` + `service.py` with: funded ratio **AVA & MVA**, AAL/UAAL + trend, **assumed_return/discount_rate**, inflation, payroll growth, amortization method+period, mortality table, **ADC vs actual contributions**, % of payroll, 1/3/5/10-yr net returns, cash-flow-maturity measures (net external CF %, support ratio, benefit %, assets/payroll).
- [ ] Add a peer-stats view: for each metric, percentile/quartile rank, z-score `(plan−μ)/σ`, time-trend vs peer-median, and signed "vs assumed return"/"vs policy benchmark" gaps. Support broad-universe AND a tight 5-15 cohort.
- [ ] Implement the **9-dimension health scorecard** (R4) with documented Green/Yellow/Red thresholds (funded ratio, assumed-return reasonableness, contribution sufficiency/tread-water, amortization, cash-flow maturity, GASB crossover, mortality currency, return-vs-assumed, trend).
- [ ] Apply the finite/bounds discipline from #636 to every new numeric field.

#### Acceptance criteria
- [ ] For a subject `ppd_id`, the panel returns each metric with peer percentile + z-score + trend.
- [ ] The scorecard emits a per-dimension Green/Yellow/Red with the numeric basis shown (no opaque scores).
- [ ] AVA and MVA funded ratios are both reported; assumed-return gap is explicit.
- [ ] New unit tests cover percentile/z-score math and each scorecard threshold boundary.

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why
The benchmarking centerpiece. Today `plan_funding_metrics`/`plan_allocation_metrics` carry only funded_ratio + contributions + allocation. To judge ONE plan vs peers we need the full metric panel + proper peer statistics + a plan-health scorecard a non-actuary can read. The peer-comparison pattern already exists (`allocation_peer_compare` computes peer mean/median/delta) — generalize it. (Parent: #642; depends on #A for data.)

## Scope
Extend the metric model + saved-view analytics with the full benchmark panel, a peer-stats layer (percentile/z-score/trend), and a Green/Yellow/Red health scorecard.

## Non-Goals
- No holdings/portfolio analytics (issues C/D).
- Do NOT fabricate fee peer data — CEM is access-restricted; surface fees only where the plan self-publishes, else mark as a known gap.
- No UI rebuild; expose results through the existing saved-view/return shapes.

## Tasks
- [ ] Extend `query/saved_views/models.py` + `service.py` with: funded ratio **AVA & MVA**, AAL/UAAL + trend, **assumed_return/discount_rate**, inflation, payroll growth, amortization method+period, mortality table, **ADC vs actual contributions**, % of payroll, 1/3/5/10-yr net returns, cash-flow-maturity measures (net external CF %, support ratio, benefit %, assets/payroll).
- [ ] Add a peer-stats view: for each metric, percentile/quartile rank, z-score `(plan−μ)/σ`, time-trend vs peer-median, and signed "vs assumed return"/"vs policy benchmark" gaps. Support broad-universe AND a tight 5-15 cohort.
- [ ] Implement the **9-dimension health scorecard** (R4) with documented Green/Yellow/Red thresholds (funded ratio, assumed-return reasonableness, contribution sufficiency/tread-water, amortization, cash-flow maturity, GASB crossover, mortality currency, return-vs-assumed, trend).
- [ ] Apply the finite/bounds discipline from #636 to every new numeric field.

## Acceptance Criteria
- [ ] For a subject `ppd_id`, the panel returns each metric with peer percentile + z-score + trend.
- [ ] The scorecard emits a per-dimension Green/Yellow/Red with the numeric basis shown (no opaque scores).
- [ ] AVA and MVA funded ratios are both reported; assumed-return gap is explicit.
- [ ] New unit tests cover percentile/z-score math and each scorecard threshold boundary.

## Test gate
Gate: `tests/query/test_benchmark_panel.py` + `test_health_scorecard.py` with a small synthetic peer set asserting percentile/z-score values and each Green/Yellow/Red boundary (incl. a NaN/edge input → handled, ties to #636). Deliberate-break: shift a scorecard threshold → boundary test fails → revert.

## Implementation Notes
- Spec: `2026-06-28-ANALYTICS_DESIGN.md` §5 + `2026-06-28-R1-benchmarking-universe.md` §B/§C + `2026-06-28-R4-actuarial-analytics.md` (scorecard + tread-water `NC + i×UAAL`, discount-rate sensitivity).
- NASRA peer assumed-return median = 7.0% (load the distribution for the reasonableness dimension).



</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
<!-- meta:issue:646 -->
> **Source:** Issue #646

Closes #646

<!-- pr-preamble:end -->