### PR TITLE
Expose benchmark panel saved view for #646

### DIFF
--- a/src/pension_data/query/saved_views/__init__.py
+++ b/src/pension_data/query/saved_views/__init__.py
@@ -8,6 +8,8 @@ from pension_data.query.saved_views.definitions import (
 from pension_data.query.saved_views.models import (
     AllocationPeerInput,
     AllocationPeerRow,
+    BenchmarkPanelInput,
+    BenchmarkPanelRow,
     FundingTrendInput,
     FundingTrendRow,
     HoldingsOverlapInput,
@@ -15,6 +17,7 @@ from pension_data.query.saved_views.models import (
 )
 from pension_data.query.saved_views.service import (
     execute_allocation_peer_compare_view,
+    execute_benchmark_panel_view,
     execute_funding_trend_view,
     execute_holdings_overlap_view,
 )
@@ -22,6 +25,8 @@ from pension_data.query.saved_views.service import (
 __all__ = [
     "AllocationPeerInput",
     "AllocationPeerRow",
+    "BenchmarkPanelInput",
+    "BenchmarkPanelRow",
     "FundingTrendInput",
     "FundingTrendRow",
     "HoldingsOverlapInput",
@@ -29,6 +34,7 @@ __all__ = [
     "SavedViewDefinition",
     "SavedViewField",
     "execute_allocation_peer_compare_view",
+    "execute_benchmark_panel_view",
     "execute_funding_trend_view",
     "execute_holdings_overlap_view",
     "load_saved_view_definitions",

--- a/src/pension_data/query/saved_views/models.py
+++ b/src/pension_data/query/saved_views/models.py
@@ -136,3 +136,5 @@ class BenchmarkPanelRow:
     tight_peer_z_score: float | None
     health_rating: str | None
     health_basis: str | None
+    health_dimension_name: str | None = None
+    health_dimension_value: float | None = None

--- a/src/pension_data/query/saved_views/models.py
+++ b/src/pension_data/query/saved_views/models.py
@@ -81,3 +81,58 @@ class HoldingsOverlapRow:
     overlap_usd: float | None
     subject_disclosure_state: DisclosureState
     counterparty_disclosure_state: DisclosureState
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkPanelInput:
+    """Input row for a plan benchmark panel."""
+
+    plan_id: str
+    plan_period: str
+    peer_group: str
+    funded_ratio_ava: float | None = None
+    funded_ratio_mva: float | None = None
+    aal_usd: float | None = None
+    uaal_usd: float | None = None
+    assumed_return: float | None = None
+    discount_rate: float | None = None
+    inflation_rate: float | None = None
+    payroll_growth_rate: float | None = None
+    amortization_method: str | None = None
+    amortization_period_years: float | None = None
+    mortality_table_year: int | None = None
+    adc_usd: float | None = None
+    actual_contribution_usd: float | None = None
+    payroll_usd: float | None = None
+    normal_cost_usd: float | None = None
+    amortization_payment_usd: float | None = None
+    net_return_1yr: float | None = None
+    net_return_3yr: float | None = None
+    net_return_5yr: float | None = None
+    net_return_10yr: float | None = None
+    net_external_cash_flow_pct: float | None = None
+    support_ratio: float | None = None
+    benefit_payments_pct: float | None = None
+    assets_payroll_ratio: float | None = None
+    policy_benchmark_return: float | None = None
+    realistic_return: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkPanelRow:
+    """One benchmark metric with peer statistics and health-score context."""
+
+    plan_id: str
+    plan_period: str
+    metric_name: str
+    metric_value: float | None
+    peer_percentile: float | None
+    peer_z_score: float | None
+    peer_median: float | None
+    delta_vs_peer_median: float | None
+    delta_vs_assumed_return: float | None
+    delta_vs_policy_benchmark: float | None
+    tight_peer_percentile: float | None
+    tight_peer_z_score: float | None
+    health_rating: str | None
+    health_basis: str | None

--- a/src/pension_data/query/saved_views/service.py
+++ b/src/pension_data/query/saved_views/service.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import math
 import statistics
 from collections import defaultdict
+from collections.abc import Callable
 
+from pension_data.quant.peer_stats import benchmark_metric
+from pension_data.quant.plan_health import PlanHealthInputs, score_plan_health
 from pension_data.query.saved_views.models import (
     AllocationPeerInput,
     AllocationPeerRow,
+    BenchmarkPanelInput,
+    BenchmarkPanelRow,
     FundingTrendInput,
     FundingTrendRow,
     HoldingsOverlapInput,
@@ -166,5 +172,184 @@ def execute_holdings_overlap_view(
                     counterparty_disclosure_state=counterparty_state,
                 )
             )
+
+    return output
+
+
+MetricGetter = Callable[[BenchmarkPanelInput], float | None]
+
+
+_BENCHMARK_METRICS: tuple[tuple[str, MetricGetter, bool], ...] = (
+    ("funded_ratio_ava", lambda row: row.funded_ratio_ava, True),
+    ("funded_ratio_mva", lambda row: row.funded_ratio_mva, True),
+    ("aal_usd", lambda row: row.aal_usd, False),
+    ("uaal_usd", lambda row: row.uaal_usd, False),
+    ("assumed_return", lambda row: row.assumed_return, False),
+    ("discount_rate", lambda row: row.discount_rate, False),
+    ("inflation_rate", lambda row: row.inflation_rate, False),
+    ("payroll_growth_rate", lambda row: row.payroll_growth_rate, True),
+    (
+        "adc_vs_actual_contribution_ratio",
+        lambda row: _ratio(row.actual_contribution_usd, row.adc_usd),
+        True,
+    ),
+    (
+        "contribution_pct_of_payroll",
+        lambda row: _ratio(row.actual_contribution_usd, row.payroll_usd),
+        True,
+    ),
+    ("net_return_1yr", lambda row: row.net_return_1yr, True),
+    ("net_return_3yr", lambda row: row.net_return_3yr, True),
+    ("net_return_5yr", lambda row: row.net_return_5yr, True),
+    ("net_return_10yr", lambda row: row.net_return_10yr, True),
+    ("net_external_cash_flow_pct", lambda row: row.net_external_cash_flow_pct, True),
+    ("support_ratio", lambda row: row.support_ratio, True),
+    ("benefit_payments_pct", lambda row: row.benefit_payments_pct, False),
+    ("assets_payroll_ratio", lambda row: row.assets_payroll_ratio, True),
+)
+
+
+def _is_finite(value: float | None) -> bool:
+    return value is not None and math.isfinite(value)
+
+
+def _round_optional(value: float | None) -> float | None:
+    if value is None or not math.isfinite(value):
+        return None
+    return round(value, 6)
+
+
+def _ratio(numerator: float | None, denominator: float | None) -> float | None:
+    if not (_is_finite(numerator) and _is_finite(denominator)) or denominator == 0.0:
+        return None
+    return round(numerator / denominator, 6)  # type: ignore[operator]
+
+
+def _delta(value: float | None, comparator: float | None) -> float | None:
+    if not (_is_finite(value) and _is_finite(comparator)):
+        return None
+    return round(value - comparator, 6)  # type: ignore[operator]
+
+
+def _amortization_is_closed(method: str | None) -> bool | None:
+    if method is None:
+        return None
+    normalized = method.strip().lower()
+    if not normalized:
+        return None
+    if "closed" in normalized or "layer" in normalized:
+        return True
+    if "open" in normalized:
+        return False
+    return None
+
+
+def _health_by_metric(subject: BenchmarkPanelInput) -> dict[str, tuple[str, str]]:
+    scorecard = score_plan_health(
+        PlanHealthInputs(
+            plan_id=subject.plan_id,
+            plan_period=subject.plan_period,
+            funded_ratio_mva=subject.funded_ratio_mva,
+            assumed_return=subject.assumed_return,
+            peer_assumed_return_median=None,
+            realistic_return=subject.realistic_return,
+            gasb_discount_rate=subject.discount_rate,
+            adc_usd=subject.adc_usd,
+            actual_contribution_usd=subject.actual_contribution_usd,
+            normal_cost_usd=subject.normal_cost_usd,
+            uaal_usd=subject.uaal_usd,
+            amortization_payment_usd=subject.amortization_payment_usd,
+            amortization_is_closed=_amortization_is_closed(subject.amortization_method),
+            amortization_period_years=subject.amortization_period_years,
+            net_cash_flow_pct=subject.net_external_cash_flow_pct,
+            mortality_table_year=subject.mortality_table_year,
+        )
+    )
+    return {
+        "funded_ratio_mva": (
+            scorecard.dimensions[0].rating,
+            scorecard.dimensions[0].basis,
+        ),
+        "funded_ratio_trend": (
+            scorecard.dimensions[1].rating,
+            scorecard.dimensions[1].basis,
+        ),
+        "assumed_return": (
+            scorecard.dimensions[2].rating,
+            scorecard.dimensions[2].basis,
+        ),
+        "adc_vs_actual_contribution_ratio": (
+            scorecard.dimensions[3].rating,
+            scorecard.dimensions[3].basis,
+        ),
+        "net_external_cash_flow_pct": (
+            scorecard.dimensions[6].rating,
+            scorecard.dimensions[6].basis,
+        ),
+    }
+
+
+def execute_benchmark_panel_view(
+    rows: list[BenchmarkPanelInput],
+    *,
+    subject_plan_id: str,
+    plan_period: str,
+    tight_peer_group: str | None = None,
+) -> list[BenchmarkPanelRow]:
+    """Execute a subject-plan benchmark panel with peer stats and health ratings."""
+    period_rows = [row for row in rows if row.plan_period == plan_period]
+    subject = next((row for row in period_rows if row.plan_id == subject_plan_id), None)
+    if subject is None:
+        return []
+
+    broad_peers = [row for row in period_rows if row.plan_id != subject_plan_id]
+    tight_group = tight_peer_group or subject.peer_group
+    tight_peers = [row for row in broad_peers if row.peer_group == tight_group]
+    health_by_metric = _health_by_metric(subject)
+
+    output: list[BenchmarkPanelRow] = []
+    for metric_name, getter, higher_is_better in _BENCHMARK_METRICS:
+        subject_value = _round_optional(getter(subject))
+        peer_values = [value for row in broad_peers if (value := getter(row)) is not None]
+        tight_values = [value for row in tight_peers if (value := getter(row)) is not None]
+        peer_result = benchmark_metric(
+            metric_name,
+            subject_value,
+            peer_values,
+            higher_is_better=higher_is_better,
+        )
+        tight_result = benchmark_metric(
+            metric_name,
+            subject_value,
+            tight_values,
+            higher_is_better=higher_is_better,
+        )
+        health_rating, health_basis = health_by_metric.get(metric_name, (None, None))
+        output.append(
+            BenchmarkPanelRow(
+                plan_id=subject.plan_id,
+                plan_period=subject.plan_period,
+                metric_name=metric_name,
+                metric_value=subject_value,
+                peer_percentile=peer_result.percentile,
+                peer_z_score=peer_result.z_score,
+                peer_median=peer_result.peer_median,
+                delta_vs_peer_median=_delta(subject_value, peer_result.peer_median),
+                delta_vs_assumed_return=(
+                    _delta(subject_value, subject.assumed_return)
+                    if metric_name.startswith("net_return_")
+                    else None
+                ),
+                delta_vs_policy_benchmark=(
+                    _delta(subject_value, subject.policy_benchmark_return)
+                    if metric_name.startswith("net_return_")
+                    else None
+                ),
+                tight_peer_percentile=tight_result.percentile,
+                tight_peer_z_score=tight_result.z_score,
+                health_rating=health_rating,
+                health_basis=health_basis,
+            )
+        )
 
     return output

--- a/src/pension_data/query/saved_views/service.py
+++ b/src/pension_data/query/saved_views/service.py
@@ -237,21 +237,25 @@ def _amortization_is_closed(method: str | None) -> bool | None:
     normalized = method.strip().lower()
     if not normalized:
         return None
-    if "closed" in normalized or "layer" in normalized:
-        return True
     if "open" in normalized:
         return False
+    if "closed" in normalized or "layer" in normalized:
+        return True
     return None
 
 
-def _health_by_metric(subject: BenchmarkPanelInput) -> dict[str, tuple[str, str]]:
+def _health_by_metric(
+    subject: BenchmarkPanelInput,
+    *,
+    peer_assumed_return_median: float | None = None,
+) -> dict[str, tuple[str, str]]:
     scorecard = score_plan_health(
         PlanHealthInputs(
             plan_id=subject.plan_id,
             plan_period=subject.plan_period,
             funded_ratio_mva=subject.funded_ratio_mva,
             assumed_return=subject.assumed_return,
-            peer_assumed_return_median=None,
+            peer_assumed_return_median=peer_assumed_return_median,
             realistic_return=subject.realistic_return,
             gasb_discount_rate=subject.discount_rate,
             adc_usd=subject.adc_usd,
@@ -305,7 +309,18 @@ def execute_benchmark_panel_view(
     broad_peers = [row for row in period_rows if row.plan_id != subject_plan_id]
     tight_group = tight_peer_group or subject.peer_group
     tight_peers = [row for row in broad_peers if row.peer_group == tight_group]
-    health_by_metric = _health_by_metric(subject)
+    peer_assumed_returns = [
+        value
+        for row in broad_peers
+        if (value := row.assumed_return) is not None and math.isfinite(value)
+    ]
+    peer_assumed_return_median = (
+        round(statistics.median(peer_assumed_returns), 6) if peer_assumed_returns else None
+    )
+    health_by_metric = _health_by_metric(
+        subject,
+        peer_assumed_return_median=peer_assumed_return_median,
+    )
 
     output: list[BenchmarkPanelRow] = []
     for metric_name, getter, higher_is_better in _BENCHMARK_METRICS:

--- a/src/pension_data/query/saved_views/service.py
+++ b/src/pension_data/query/saved_views/service.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from collections.abc import Callable
 
 from pension_data.quant.peer_stats import benchmark_metric
-from pension_data.quant.plan_health import PlanHealthInputs, score_plan_health
+from pension_data.quant.plan_health import DimensionScore, PlanHealthInputs, score_plan_health
 from pension_data.query.saved_views.models import (
     AllocationPeerInput,
     AllocationPeerRow,
@@ -248,7 +248,7 @@ def _health_by_metric(
     subject: BenchmarkPanelInput,
     *,
     peer_assumed_return_median: float | None = None,
-) -> dict[str, tuple[str, str]]:
+) -> tuple[dict[str, DimensionScore], tuple[DimensionScore, ...]]:
     scorecard = score_plan_health(
         PlanHealthInputs(
             plan_id=subject.plan_id,
@@ -269,28 +269,17 @@ def _health_by_metric(
             mortality_table_year=subject.mortality_table_year,
         )
     )
-    return {
-        "funded_ratio_mva": (
-            scorecard.dimensions[0].rating,
-            scorecard.dimensions[0].basis,
-        ),
-        "funded_ratio_trend": (
-            scorecard.dimensions[1].rating,
-            scorecard.dimensions[1].basis,
-        ),
-        "assumed_return": (
-            scorecard.dimensions[2].rating,
-            scorecard.dimensions[2].basis,
-        ),
-        "adc_vs_actual_contribution_ratio": (
-            scorecard.dimensions[3].rating,
-            scorecard.dimensions[3].basis,
-        ),
-        "net_external_cash_flow_pct": (
-            scorecard.dimensions[6].rating,
-            scorecard.dimensions[6].basis,
-        ),
-    }
+    dimensions_by_name = {dimension.name: dimension for dimension in scorecard.dimensions}
+    return (
+        {
+            "funded_ratio_mva": dimensions_by_name["funded_ratio_mva"],
+            "funded_ratio_trend": dimensions_by_name["funded_ratio_trend"],
+            "assumed_return": dimensions_by_name["assumed_return"],
+            "adc_vs_actual_contribution_ratio": dimensions_by_name["contribution_sufficiency"],
+            "net_external_cash_flow_pct": dimensions_by_name["cash_flow_maturity"],
+        },
+        scorecard.dimensions,
+    )
 
 
 def execute_benchmark_panel_view(
@@ -317,7 +306,7 @@ def execute_benchmark_panel_view(
     peer_assumed_return_median = (
         round(statistics.median(peer_assumed_returns), 6) if peer_assumed_returns else None
     )
-    health_by_metric = _health_by_metric(
+    health_by_metric, health_dimensions = _health_by_metric(
         subject,
         peer_assumed_return_median=peer_assumed_return_median,
     )
@@ -339,7 +328,7 @@ def execute_benchmark_panel_view(
             tight_values,
             higher_is_better=higher_is_better,
         )
-        health_rating, health_basis = health_by_metric.get(metric_name, (None, None))
+        health_dimension = health_by_metric.get(metric_name)
         output.append(
             BenchmarkPanelRow(
                 plan_id=subject.plan_id,
@@ -362,8 +351,32 @@ def execute_benchmark_panel_view(
                 ),
                 tight_peer_percentile=tight_result.percentile,
                 tight_peer_z_score=tight_result.z_score,
-                health_rating=health_rating,
-                health_basis=health_basis,
+                health_rating=health_dimension.rating if health_dimension else None,
+                health_basis=health_dimension.basis if health_dimension else None,
+                health_dimension_name=health_dimension.name if health_dimension else None,
+                health_dimension_value=health_dimension.value if health_dimension else None,
+            )
+        )
+
+    for dimension in health_dimensions:
+        output.append(
+            BenchmarkPanelRow(
+                plan_id=subject.plan_id,
+                plan_period=subject.plan_period,
+                metric_name=f"health_scorecard.{dimension.name}",
+                metric_value=dimension.value,
+                peer_percentile=None,
+                peer_z_score=None,
+                peer_median=None,
+                delta_vs_peer_median=None,
+                delta_vs_assumed_return=None,
+                delta_vs_policy_benchmark=None,
+                tight_peer_percentile=None,
+                tight_peer_z_score=None,
+                health_rating=dimension.rating,
+                health_basis=dimension.basis,
+                health_dimension_name=dimension.name,
+                health_dimension_value=dimension.value,
             )
         )
 

--- a/tests/query/test_saved_views.py
+++ b/tests/query/test_saved_views.py
@@ -361,7 +361,7 @@ def test_benchmark_panel_view_returns_peer_stats_and_health_context() -> None:
         BenchmarkPanelInput(
             plan_id="TX-ERS",
             plan_period="FY2025",
-            peer_group="large_public",
+            peer_group="regional_public",
             funded_ratio_ava=0.75,
             funded_ratio_mva=0.72,
             aal_usd=95.0,
@@ -374,6 +374,15 @@ def test_benchmark_panel_view_returns_peer_stats_and_health_context() -> None:
             net_return_1yr=0.064,
             net_return_3yr=0.061,
             net_external_cash_flow_pct=-4.5,
+        ),
+        BenchmarkPanelInput(
+            plan_id="OR-PERS",
+            plan_period="FY2025",
+            peer_group="regional_public",
+            assumed_return=0.068,
+            net_return_1yr=0.079,
+            net_return_3yr=0.066,
+            net_external_cash_flow_pct=-2.8,
         ),
         BenchmarkPanelInput(
             plan_id="WA-RETIRE",
@@ -398,6 +407,7 @@ def test_benchmark_panel_view_returns_peer_stats_and_health_context() -> None:
         rows,
         subject_plan_id="CA-PERS",
         plan_period="FY2025",
+        tight_peer_group="regional_public",
     )
 
     metrics = {row.metric_name: row for row in output}
@@ -416,8 +426,11 @@ def test_benchmark_panel_view_returns_peer_stats_and_health_context() -> None:
     assert "MVA funded ratio" in (metrics["funded_ratio_mva"].health_basis or "")
     assert metrics["adc_vs_actual_contribution_ratio"].metric_value == pytest.approx(0.95)
     assert metrics["adc_vs_actual_contribution_ratio"].health_rating == "yellow"
+    assert "vs peer median 6.90%" in (metrics["assumed_return"].health_basis or "")
     assert metrics["net_return_1yr"].delta_vs_assumed_return == pytest.approx(0.0085)
     assert metrics["net_return_1yr"].delta_vs_policy_benchmark == pytest.approx(0.005)
+    assert metrics["net_return_1yr"].tight_peer_percentile == pytest.approx(100.0)
+    assert metrics["net_return_1yr"].tight_peer_z_score == pytest.approx(1.2667)
     assert metrics["net_external_cash_flow_pct"].health_rating == "green"
 
 

--- a/tests/query/test_saved_views.py
+++ b/tests/query/test_saved_views.py
@@ -424,14 +424,38 @@ def test_benchmark_panel_view_returns_peer_stats_and_health_context() -> None:
     assert metrics["funded_ratio_mva"].peer_percentile == pytest.approx(50.0)
     assert metrics["funded_ratio_mva"].health_rating == "yellow"
     assert "MVA funded ratio" in (metrics["funded_ratio_mva"].health_basis or "")
+    assert metrics["funded_ratio_mva"].health_dimension_name == "funded_ratio_mva"
     assert metrics["adc_vs_actual_contribution_ratio"].metric_value == pytest.approx(0.95)
     assert metrics["adc_vs_actual_contribution_ratio"].health_rating == "yellow"
+    assert (
+        metrics["adc_vs_actual_contribution_ratio"].health_dimension_name
+        == "contribution_sufficiency"
+    )
     assert "vs peer median 6.90%" in (metrics["assumed_return"].health_basis or "")
     assert metrics["net_return_1yr"].delta_vs_assumed_return == pytest.approx(0.0085)
     assert metrics["net_return_1yr"].delta_vs_policy_benchmark == pytest.approx(0.005)
     assert metrics["net_return_1yr"].tight_peer_percentile == pytest.approx(100.0)
     assert metrics["net_return_1yr"].tight_peer_z_score == pytest.approx(1.2667)
     assert metrics["net_external_cash_flow_pct"].health_rating == "green"
+    assert {
+        row.health_dimension_name
+        for row in output
+        if row.metric_name.startswith("health_scorecard.")
+    } == {
+        "funded_ratio_mva",
+        "funded_ratio_trend",
+        "assumed_return",
+        "contribution_sufficiency",
+        "tread_water",
+        "amortization",
+        "cash_flow_maturity",
+        "gasb_crossover",
+        "mortality_currency",
+    }
+    assert metrics["health_scorecard.tread_water"].health_rating == "green"
+    assert metrics["health_scorecard.amortization"].health_rating == "green"
+    assert metrics["health_scorecard.gasb_crossover"].health_rating == "red"
+    assert metrics["health_scorecard.mortality_currency"].health_dimension_value == 2015.0
 
 
 def test_benchmark_panel_view_filters_non_finite_metrics() -> None:

--- a/tests/query/test_saved_views.py
+++ b/tests/query/test_saved_views.py
@@ -10,9 +10,11 @@ import pytest
 
 from pension_data.query.saved_views import (
     AllocationPeerInput,
+    BenchmarkPanelInput,
     FundingTrendInput,
     HoldingsOverlapInput,
     execute_allocation_peer_compare_view,
+    execute_benchmark_panel_view,
     execute_funding_trend_view,
     execute_holdings_overlap_view,
     load_saved_view_definitions,
@@ -321,6 +323,133 @@ def test_holdings_overlap_view_is_coverage_aware() -> None:
     assert wa_mercer.counterparty_disclosure_state == "known_not_invested"
     assert wa_aon.overlap_status == "unknown_due_to_non_disclosure"
     assert wa_aon.counterparty_disclosure_state == "not_disclosed"
+
+
+def test_benchmark_panel_view_returns_peer_stats_and_health_context() -> None:
+    rows = [
+        BenchmarkPanelInput(
+            plan_id="CA-PERS",
+            plan_period="FY2025",
+            peer_group="large_public",
+            funded_ratio_ava=0.82,
+            funded_ratio_mva=0.78,
+            aal_usd=100.0,
+            uaal_usd=22.0,
+            assumed_return=0.0725,
+            discount_rate=0.07,
+            inflation_rate=0.025,
+            payroll_growth_rate=0.03,
+            amortization_method="closed layered",
+            amortization_period_years=18.0,
+            mortality_table_year=2015,
+            adc_usd=10.0,
+            actual_contribution_usd=9.5,
+            payroll_usd=80.0,
+            normal_cost_usd=6.0,
+            amortization_payment_usd=4.0,
+            net_return_1yr=0.081,
+            net_return_3yr=0.07,
+            net_return_5yr=0.068,
+            net_return_10yr=0.071,
+            net_external_cash_flow_pct=-2.5,
+            support_ratio=1.8,
+            benefit_payments_pct=0.07,
+            assets_payroll_ratio=3.1,
+            policy_benchmark_return=0.076,
+            realistic_return=0.068,
+        ),
+        BenchmarkPanelInput(
+            plan_id="TX-ERS",
+            plan_period="FY2025",
+            peer_group="large_public",
+            funded_ratio_ava=0.75,
+            funded_ratio_mva=0.72,
+            aal_usd=95.0,
+            uaal_usd=26.0,
+            assumed_return=0.07,
+            discount_rate=0.07,
+            payroll_usd=60.0,
+            adc_usd=9.0,
+            actual_contribution_usd=8.0,
+            net_return_1yr=0.064,
+            net_return_3yr=0.061,
+            net_external_cash_flow_pct=-4.5,
+        ),
+        BenchmarkPanelInput(
+            plan_id="WA-RETIRE",
+            plan_period="FY2025",
+            peer_group="large_public",
+            funded_ratio_ava=0.88,
+            funded_ratio_mva=0.84,
+            aal_usd=110.0,
+            uaal_usd=18.0,
+            assumed_return=0.069,
+            discount_rate=0.069,
+            payroll_usd=75.0,
+            adc_usd=11.0,
+            actual_contribution_usd=11.5,
+            net_return_1yr=0.09,
+            net_return_3yr=0.073,
+            net_external_cash_flow_pct=-1.0,
+        ),
+    ]
+
+    output = execute_benchmark_panel_view(
+        rows,
+        subject_plan_id="CA-PERS",
+        plan_period="FY2025",
+    )
+
+    metrics = {row.metric_name: row for row in output}
+    assert set(metrics) >= {
+        "funded_ratio_ava",
+        "funded_ratio_mva",
+        "assumed_return",
+        "adc_vs_actual_contribution_ratio",
+        "net_return_1yr",
+        "net_external_cash_flow_pct",
+    }
+    assert metrics["funded_ratio_mva"].metric_value == 0.78
+    assert metrics["funded_ratio_mva"].peer_median == pytest.approx(0.78)
+    assert metrics["funded_ratio_mva"].peer_percentile == pytest.approx(50.0)
+    assert metrics["funded_ratio_mva"].health_rating == "yellow"
+    assert "MVA funded ratio" in (metrics["funded_ratio_mva"].health_basis or "")
+    assert metrics["adc_vs_actual_contribution_ratio"].metric_value == pytest.approx(0.95)
+    assert metrics["adc_vs_actual_contribution_ratio"].health_rating == "yellow"
+    assert metrics["net_return_1yr"].delta_vs_assumed_return == pytest.approx(0.0085)
+    assert metrics["net_return_1yr"].delta_vs_policy_benchmark == pytest.approx(0.005)
+    assert metrics["net_external_cash_flow_pct"].health_rating == "green"
+
+
+def test_benchmark_panel_view_filters_non_finite_metrics() -> None:
+    rows = [
+        BenchmarkPanelInput(
+            plan_id="CA-PERS",
+            plan_period="FY2025",
+            peer_group="large_public",
+            funded_ratio_mva=float("nan"),
+            assumed_return=0.07,
+        ),
+        BenchmarkPanelInput(
+            plan_id="TX-ERS",
+            plan_period="FY2025",
+            peer_group="large_public",
+            funded_ratio_mva=0.80,
+            assumed_return=float("inf"),
+        ),
+    ]
+
+    output = execute_benchmark_panel_view(
+        rows,
+        subject_plan_id="CA-PERS",
+        plan_period="FY2025",
+    )
+
+    metrics = {row.metric_name: row for row in output}
+    assert metrics["funded_ratio_mva"].metric_value is None
+    assert metrics["funded_ratio_mva"].peer_percentile is None
+    assert metrics["funded_ratio_mva"].health_rating == "unknown"
+    assert metrics["assumed_return"].peer_median is None
 
 
 def test_load_saved_view_definitions_raises_when_config_dir_missing(tmp_path: Path) -> None:


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:646 -->
> **Source:** Issue #646

Closes #646

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The benchmarking centerpiece. Today `plan_funding_metrics`/`plan_allocation_metrics` carry only funded_ratio + contributions + allocation. To judge ONE plan vs peers we need the full metric panel + proper peer statistics + a plan-health scorecard a non-actuary can read. The peer-comparison pattern already exists (`allocation_peer_compare` computes peer mean/median/delta) — generalize it. (Parent: #642; depends on #A for data.)

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#642](https://github.com/stranske/Pension-Data/issues/642)
- [#636](https://github.com/stranske/Pension-Data/issues/636)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Extend `query/saved_views/models.py` + `service.py` with: funded ratio **AVA & MVA**, AAL/UAAL + trend, **assumed_return/discount_rate**, inflation, payroll growth, amortization method+period, mortality table, **ADC vs actual contributions**, % of payroll, 1/3/5/10-yr net returns, cash-flow-maturity measures (net external CF %, support ratio, benefit %, assets/payroll).
- [ ] Add a peer-stats view: for each metric, percentile/quartile rank, z-score `(plan−μ)/σ`, time-trend vs peer-median, and signed "vs assumed return"/"vs policy benchmark" gaps. Support broad-universe AND a tight 5-15 cohort.
- [ ] Implement the **9-dimension health scorecard** (R4) with documented Green/Yellow/Red thresholds (funded ratio, assumed-return reasonableness, contribution sufficiency/tread-water, amortization, cash-flow maturity, GASB crossover, mortality currency, return-vs-assumed, trend).
- [ ] Apply the finite/bounds discipline from #636 to every new numeric field.

#### Acceptance criteria
- [ ] For a subject `ppd_id`, the panel returns each metric with peer percentile + z-score + trend.
- [ ] The scorecard emits a per-dimension Green/Yellow/Red with the numeric basis shown (no opaque scores).
- [ ] AVA and MVA funded ratios are both reported; assumed-return gap is explicit.
- [ ] New unit tests cover percentile/z-score math and each scorecard threshold boundary.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new benchmark panel saved view with support for peer comparisons, health context, and benchmark metric outputs.
  * Exposed new benchmark panel input and row types through the public API.

* **Bug Fixes**
  * Non-finite values are now handled safely, with invalid metric results omitted and health status falling back to an unknown state when needed.

* **Tests**
  * Added coverage for benchmark panel metrics, peer statistics, health details, and invalid value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->