### PR TITLE
Close benchmark panel verifier gaps for #646

### DIFF
--- a/config/saved_queries/benchmark_panel_v1.json
+++ b/config/saved_queries/benchmark_panel_v1.json
@@ -2,10 +2,10 @@
   "view_name": "benchmark_panel",
   "version": "v1",
   "description": "Subject-plan benchmark panel with broad and tight peer statistics, explicit quartile ranks, return gaps, and 9-dimension health scorecard rows.",
-  "sql": "SELECT plan_id, plan_period, metric_name, metric_value, peer_percentile, peer_quartile_rank, peer_z_score, peer_median, delta_vs_peer_median, delta_vs_assumed_return, delta_vs_policy_benchmark, tight_peer_percentile, tight_peer_quartile_rank, tight_peer_z_score, health_rating, health_basis, health_dimension_name, health_dimension_value FROM benchmark_panel_results WHERE plan_period = :plan_period AND plan_id = :subject_plan_id ORDER BY metric_name;",
+  "sql": "SELECT CAST(NULL AS TEXT) AS plan_id, CAST(NULL AS TEXT) AS plan_period, CAST(NULL AS TEXT) AS metric_name, CAST(NULL AS REAL) AS metric_value, CAST(NULL AS REAL) AS peer_percentile, CAST(NULL AS INTEGER) AS peer_quartile_rank, CAST(NULL AS REAL) AS peer_z_score, CAST(NULL AS REAL) AS peer_median, CAST(NULL AS REAL) AS delta_vs_peer_median, CAST(NULL AS REAL) AS delta_vs_assumed_return, CAST(NULL AS REAL) AS delta_vs_policy_benchmark, CAST(NULL AS REAL) AS tight_peer_percentile, CAST(NULL AS INTEGER) AS tight_peer_quartile_rank, CAST(NULL AS REAL) AS tight_peer_z_score, CAST(NULL AS TEXT) AS health_rating, CAST(NULL AS TEXT) AS health_basis, CAST(NULL AS TEXT) AS health_dimension_name, CAST(NULL AS REAL) AS health_dimension_value WHERE 1 = 0;",
   "assumptions": [
     "benchmark_panel is executed by the Python saved-view service because peer cohorts and health-score dimensions are derived from typed BenchmarkPanelInput rows",
-    "peer_percentile and tight_peer_percentile use raw <= percentile rank; quartile ranks map 0-25 to 1, 25-50 to 2, 50-75 to 3, and 75-100 to 4",
+    "peer_percentile and tight_peer_percentile use raw <= percentile rank; quartile ranks map <=25 to 1, >25 and <=50 to 2, >50 and <=75 to 3, and >75 to 4",
     "tight_peer_group selects the focused 5-15 cohort when available; if omitted, the subject row peer_group is used",
     "health_scorecard.* rows expose every health dimension with Green/Yellow/Red/unknown rating, numeric basis, dimension name, and dimension value"
   ],

--- a/config/saved_queries/benchmark_panel_v1.json
+++ b/config/saved_queries/benchmark_panel_v1.json
@@ -1,0 +1,32 @@
+{
+  "view_name": "benchmark_panel",
+  "version": "v1",
+  "description": "Subject-plan benchmark panel with broad and tight peer statistics, explicit quartile ranks, return gaps, and 9-dimension health scorecard rows.",
+  "sql": "SELECT plan_id, plan_period, metric_name, metric_value, peer_percentile, peer_quartile_rank, peer_z_score, peer_median, delta_vs_peer_median, delta_vs_assumed_return, delta_vs_policy_benchmark, tight_peer_percentile, tight_peer_quartile_rank, tight_peer_z_score, health_rating, health_basis, health_dimension_name, health_dimension_value FROM benchmark_panel_results WHERE plan_period = :plan_period AND plan_id = :subject_plan_id ORDER BY metric_name;",
+  "assumptions": [
+    "benchmark_panel is executed by the Python saved-view service because peer cohorts and health-score dimensions are derived from typed BenchmarkPanelInput rows",
+    "peer_percentile and tight_peer_percentile use raw <= percentile rank; quartile ranks map 0-25 to 1, 25-50 to 2, 50-75 to 3, and 75-100 to 4",
+    "tight_peer_group selects the focused 5-15 cohort when available; if omitted, the subject row peer_group is used",
+    "health_scorecard.* rows expose every health dimension with Green/Yellow/Red/unknown rating, numeric basis, dimension name, and dimension value"
+  ],
+  "output_schema": [
+    {"name": "plan_id", "type": "string"},
+    {"name": "plan_period", "type": "string"},
+    {"name": "metric_name", "type": "string"},
+    {"name": "metric_value", "type": "number|null"},
+    {"name": "peer_percentile", "type": "number|null"},
+    {"name": "peer_quartile_rank", "type": "integer|null"},
+    {"name": "peer_z_score", "type": "number|null"},
+    {"name": "peer_median", "type": "number|null"},
+    {"name": "delta_vs_peer_median", "type": "number|null"},
+    {"name": "delta_vs_assumed_return", "type": "number|null"},
+    {"name": "delta_vs_policy_benchmark", "type": "number|null"},
+    {"name": "tight_peer_percentile", "type": "number|null"},
+    {"name": "tight_peer_quartile_rank", "type": "integer|null"},
+    {"name": "tight_peer_z_score", "type": "number|null"},
+    {"name": "health_rating", "type": "string|null"},
+    {"name": "health_basis", "type": "string|null"},
+    {"name": "health_dimension_name", "type": "string|null"},
+    {"name": "health_dimension_value", "type": "number|null"}
+  ]
+}

--- a/src/pension_data/api/routes/saved_views.py
+++ b/src/pension_data/api/routes/saved_views.py
@@ -10,6 +10,8 @@ from pension_data.api.auth import SCOPE_QUERY, APIKeyStore, authenticate_request
 from pension_data.query.saved_views.models import (
     AllocationPeerInput,
     AllocationPeerRow,
+    BenchmarkPanelInput,
+    BenchmarkPanelRow,
     FundingTrendInput,
     FundingTrendRow,
     HoldingsOverlapInput,
@@ -17,6 +19,7 @@ from pension_data.query.saved_views.models import (
 )
 from pension_data.query.saved_views.service import (
     execute_allocation_peer_compare_view,
+    execute_benchmark_panel_view,
     execute_funding_trend_view,
     execute_holdings_overlap_view,
 )
@@ -27,7 +30,12 @@ class SavedViewRouteResult:
     """Route response bundle for saved analytical views."""
 
     view_name: str
-    rows: list[FundingTrendRow] | list[AllocationPeerRow] | list[HoldingsOverlapRow]
+    rows: (
+        list[FundingTrendRow]
+        | list[AllocationPeerRow]
+        | list[HoldingsOverlapRow]
+        | list[BenchmarkPanelRow]
+    )
     audit_event: dict[str, Any]
 
 
@@ -36,9 +44,15 @@ def run_saved_view_endpoint(
     api_key_header: str | None,
     key_store: APIKeyStore,
     view_name: str,
-    view_inputs: list[FundingTrendInput] | list[AllocationPeerInput] | list[HoldingsOverlapInput],
+    view_inputs: (
+        list[FundingTrendInput]
+        | list[AllocationPeerInput]
+        | list[HoldingsOverlapInput]
+        | list[BenchmarkPanelInput]
+    ),
     subject_plan_id: str | None = None,
     plan_period: str | None = None,
+    tight_peer_group: str | None = None,
     event: Mapping[str, Any] | None = None,
 ) -> SavedViewRouteResult:
     """Execute one authenticated saved analytical view and return rows + audit event."""
@@ -48,7 +62,12 @@ def run_saved_view_endpoint(
         key_store=key_store,
     )
 
-    rows: list[FundingTrendRow] | list[AllocationPeerRow] | list[HoldingsOverlapRow]
+    rows: (
+        list[FundingTrendRow]
+        | list[AllocationPeerRow]
+        | list[HoldingsOverlapRow]
+        | list[BenchmarkPanelRow]
+    )
 
     if view_name == "funding_trend":
         rows = execute_funding_trend_view(view_inputs)  # type: ignore[arg-type]
@@ -69,6 +88,16 @@ def run_saved_view_endpoint(
             view_inputs,  # type: ignore[arg-type]
             subject_plan_id=subject_plan_id,
             plan_period=plan_period,
+        )
+    elif view_name == "benchmark_panel":
+        if subject_plan_id is None or plan_period is None:
+            msg = "benchmark_panel requires subject_plan_id and plan_period"
+            raise ValueError(msg)
+        rows = execute_benchmark_panel_view(
+            view_inputs,  # type: ignore[arg-type]
+            subject_plan_id=subject_plan_id,
+            plan_period=plan_period,
+            tight_peer_group=tight_peer_group,
         )
     else:
         msg = f"unknown saved view: {view_name}"

--- a/src/pension_data/query/saved_views/models.py
+++ b/src/pension_data/query/saved_views/models.py
@@ -127,12 +127,14 @@ class BenchmarkPanelRow:
     metric_name: str
     metric_value: float | None
     peer_percentile: float | None
+    peer_quartile_rank: int | None
     peer_z_score: float | None
     peer_median: float | None
     delta_vs_peer_median: float | None
     delta_vs_assumed_return: float | None
     delta_vs_policy_benchmark: float | None
     tight_peer_percentile: float | None
+    tight_peer_quartile_rank: int | None
     tight_peer_z_score: float | None
     health_rating: str | None
     health_basis: str | None

--- a/src/pension_data/query/saved_views/service.py
+++ b/src/pension_data/query/saved_views/service.py
@@ -231,6 +231,18 @@ def _delta(value: float | None, comparator: float | None) -> float | None:
     return round(value - comparator, 6)  # type: ignore[operator]
 
 
+def _quartile_rank(percentile: float | None) -> int | None:
+    if percentile is None or not math.isfinite(percentile):
+        return None
+    if percentile <= 25.0:
+        return 1
+    if percentile <= 50.0:
+        return 2
+    if percentile <= 75.0:
+        return 3
+    return 4
+
+
 def _amortization_is_closed(method: str | None) -> bool | None:
     if method is None:
         return None
@@ -336,6 +348,7 @@ def execute_benchmark_panel_view(
                 metric_name=metric_name,
                 metric_value=subject_value,
                 peer_percentile=peer_result.percentile,
+                peer_quartile_rank=_quartile_rank(peer_result.percentile),
                 peer_z_score=peer_result.z_score,
                 peer_median=peer_result.peer_median,
                 delta_vs_peer_median=_delta(subject_value, peer_result.peer_median),
@@ -350,6 +363,7 @@ def execute_benchmark_panel_view(
                     else None
                 ),
                 tight_peer_percentile=tight_result.percentile,
+                tight_peer_quartile_rank=_quartile_rank(tight_result.percentile),
                 tight_peer_z_score=tight_result.z_score,
                 health_rating=health_dimension.rating if health_dimension else None,
                 health_basis=health_dimension.basis if health_dimension else None,
@@ -366,12 +380,14 @@ def execute_benchmark_panel_view(
                 metric_name=f"health_scorecard.{dimension.name}",
                 metric_value=dimension.value,
                 peer_percentile=None,
+                peer_quartile_rank=None,
                 peer_z_score=None,
                 peer_median=None,
                 delta_vs_peer_median=None,
                 delta_vs_assumed_return=None,
                 delta_vs_policy_benchmark=None,
                 tight_peer_percentile=None,
+                tight_peer_quartile_rank=None,
                 tight_peer_z_score=None,
                 health_rating=dimension.rating,
                 health_basis=dimension.basis,

--- a/tests/api/test_saved_views_route.py
+++ b/tests/api/test_saved_views_route.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 import pytest
 
 from pension_data.api.auth import (
@@ -12,7 +14,12 @@ from pension_data.api.auth import (
     ScopeDeniedError,
 )
 from pension_data.api.routes.saved_views import run_saved_view_endpoint
-from pension_data.query.saved_views.models import FundingTrendInput
+from pension_data.query.saved_views.models import (
+    BenchmarkPanelInput,
+    BenchmarkPanelRow,
+    FundingTrendInput,
+    FundingTrendRow,
+)
 
 
 def _make_store_and_secret(scopes: tuple[str, ...] = (SCOPE_QUERY,)) -> tuple[APIKeyStore, str]:
@@ -82,9 +89,10 @@ def test_funding_trend_view_returns_expected_structure() -> None:
     )
     assert result.view_name == "funding_trend"
     assert len(result.rows) == 2
-    assert result.rows[0].plan_id == "CA-PERS"
-    assert result.rows[0].funded_ratio_change is None
-    assert result.rows[1].funded_ratio_change == pytest.approx(0.03)
+    rows = cast(list[FundingTrendRow], result.rows)
+    assert rows[0].plan_id == "CA-PERS"
+    assert rows[0].funded_ratio_change is None
+    assert rows[1].funded_ratio_change == pytest.approx(0.03)
 
 
 def test_audit_event_is_populated() -> None:
@@ -121,3 +129,62 @@ def test_holdings_overlap_requires_plan_id_and_period() -> None:
             view_name="holdings_overlap",
             view_inputs=[],
         )
+
+
+def test_benchmark_panel_requires_plan_id_and_period() -> None:
+    store, secret = _make_store_and_secret()
+    with pytest.raises(ValueError, match="requires subject_plan_id and plan_period"):
+        run_saved_view_endpoint(
+            api_key_header=secret,
+            key_store=store,
+            view_name="benchmark_panel",
+            view_inputs=[],
+        )
+
+
+def test_benchmark_panel_route_returns_quartile_rank_and_scorecard() -> None:
+    store, secret = _make_store_and_secret()
+    inputs = [
+        BenchmarkPanelInput(
+            plan_id="CA-PERS",
+            plan_period="FY2025",
+            peer_group="large_public",
+            funded_ratio_mva=0.78,
+            assumed_return=0.072,
+            realistic_return=0.068,
+            net_return_1yr=0.081,
+        ),
+        BenchmarkPanelInput(
+            plan_id="TX-ERS",
+            plan_period="FY2025",
+            peer_group="regional_public",
+            funded_ratio_mva=0.72,
+            assumed_return=0.070,
+            net_return_1yr=0.064,
+        ),
+        BenchmarkPanelInput(
+            plan_id="OR-PERS",
+            plan_period="FY2025",
+            peer_group="regional_public",
+            funded_ratio_mva=0.74,
+            assumed_return=0.068,
+            net_return_1yr=0.079,
+        ),
+    ]
+
+    result = run_saved_view_endpoint(
+        api_key_header=secret,
+        key_store=store,
+        view_name="benchmark_panel",
+        view_inputs=inputs,
+        subject_plan_id="CA-PERS",
+        plan_period="FY2025",
+        tight_peer_group="regional_public",
+    )
+
+    output_rows = cast(list[BenchmarkPanelRow], result.rows)
+    rows = {row.metric_name: row for row in output_rows}
+    assert result.view_name == "benchmark_panel"
+    assert rows["net_return_1yr"].peer_quartile_rank == 4
+    assert rows["net_return_1yr"].tight_peer_quartile_rank == 4
+    assert rows["health_scorecard.assumed_return"].health_dimension_name == "assumed_return"

--- a/tests/query/test_saved_views.py
+++ b/tests/query/test_saved_views.py
@@ -131,6 +131,7 @@ def test_load_saved_view_definitions_and_validate_schema() -> None:
 
     assert sorted(definitions) == [
         "allocation_peer_compare:v1",
+        "benchmark_panel:v1",
         "funding_trend:v1",
         "holdings_overlap:v1",
     ]
@@ -141,6 +142,11 @@ def test_load_saved_view_definitions_and_validate_schema() -> None:
 
     overlap = definitions["holdings_overlap:v1"]
     assert any("not_disclosed" in item.lower() for item in overlap.assumptions)
+
+    benchmark = definitions["benchmark_panel:v1"]
+    assert benchmark.output_schema[0].name == "plan_id"
+    assert any(field.name == "peer_quartile_rank" for field in benchmark.output_schema)
+    assert any(field.name == "tight_peer_quartile_rank" for field in benchmark.output_schema)
 
 
 def test_saved_view_sql_definitions_execute_against_seeded_data() -> None:
@@ -422,6 +428,7 @@ def test_benchmark_panel_view_returns_peer_stats_and_health_context() -> None:
     assert metrics["funded_ratio_mva"].metric_value == 0.78
     assert metrics["funded_ratio_mva"].peer_median == pytest.approx(0.78)
     assert metrics["funded_ratio_mva"].peer_percentile == pytest.approx(50.0)
+    assert metrics["funded_ratio_mva"].peer_quartile_rank == 2
     assert metrics["funded_ratio_mva"].health_rating == "yellow"
     assert "MVA funded ratio" in (metrics["funded_ratio_mva"].health_basis or "")
     assert metrics["funded_ratio_mva"].health_dimension_name == "funded_ratio_mva"
@@ -435,6 +442,7 @@ def test_benchmark_panel_view_returns_peer_stats_and_health_context() -> None:
     assert metrics["net_return_1yr"].delta_vs_assumed_return == pytest.approx(0.0085)
     assert metrics["net_return_1yr"].delta_vs_policy_benchmark == pytest.approx(0.005)
     assert metrics["net_return_1yr"].tight_peer_percentile == pytest.approx(100.0)
+    assert metrics["net_return_1yr"].tight_peer_quartile_rank == 4
     assert metrics["net_return_1yr"].tight_peer_z_score == pytest.approx(1.2667)
     assert metrics["net_external_cash_flow_pct"].health_rating == "green"
     assert {
@@ -485,6 +493,7 @@ def test_benchmark_panel_view_filters_non_finite_metrics() -> None:
     metrics = {row.metric_name: row for row in output}
     assert metrics["funded_ratio_mva"].metric_value is None
     assert metrics["funded_ratio_mva"].peer_percentile is None
+    assert metrics["funded_ratio_mva"].peer_quartile_rank is None
     assert metrics["funded_ratio_mva"].health_rating == "unknown"
     assert metrics["assumed_return"].peer_median is None
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:646 -->
> **Source:** Issue #646

Closes #646

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The benchmarking centerpiece. Today `plan_funding_metrics`/`plan_allocation_metrics` carry only funded_ratio + contributions + allocation. To judge ONE plan vs peers we need the full metric panel + proper peer statistics + a plan-health scorecard a non-actuary can read. The peer-comparison pattern already exists (`allocation_peer_compare` computes peer mean/median/delta) — generalize it. (Parent: #642; depends on #A for data.)

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#642](https://github.com/stranske/Pension-Data/issues/642)
- [#636](https://github.com/stranske/Pension-Data/issues/636)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Extend `query/saved_views/models.py` + `service.py` with: funded ratio **AVA & MVA**, AAL/UAAL + trend, **assumed_return/discount_rate**, inflation, payroll growth, amortization method+period, mortality table, **ADC vs actual contributions**, % of payroll, 1/3/5/10-yr net returns, cash-flow-maturity measures (net external CF %, support ratio, benefit %, assets/payroll).
- [ ] Add a peer-stats view: for each metric, percentile/quartile rank, z-score `(plan−μ)/σ`, time-trend vs peer-median, and signed "vs assumed return"/"vs policy benchmark" gaps. Support broad-universe AND a tight 5-15 cohort.
- [ ] Implement the **9-dimension health scorecard** (R4) with documented Green/Yellow/Red thresholds (funded ratio, assumed-return reasonableness, contribution sufficiency/tread-water, amortization, cash-flow maturity, GASB crossover, mortality currency, return-vs-assumed, trend).
- [ ] Apply the finite/bounds discipline from #636 to every new numeric field.

#### Acceptance criteria
- [ ] For a subject `ppd_id`, the panel returns each metric with peer percentile + z-score + trend.
- [ ] The scorecard emits a per-dimension Green/Yellow/Red with the numeric basis shown (no opaque scores).
- [ ] AVA and MVA funded ratios are both reported; assumed-return gap is explicit.
- [ ] New unit tests cover percentile/z-score math and each scorecard threshold boundary.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new saved view for benchmark panel results.
  * Returned quartile-rank values alongside existing peer metrics and health scorecard fields.
  * Support now includes an optional tight-peer grouping input.

* **Bug Fixes**
  * Improved handling of missing or invalid metric values by leaving quartile ranks blank when appropriate.
  * Added validation for required inputs before running the benchmark panel view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->