### PR TITLE
Collect security-level holdings for plan coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
+    "defusedxml>=0.7.1",
     "fastapi>=0.116.0",
     "pypdf>=5.4.0",
     "uvicorn>=0.35.0",

--- a/requirements.lock
+++ b/requirements.lock
@@ -35,6 +35,8 @@ colorama==0.4.6 ; sys_platform == 'win32'
     #   tqdm
 coverage==7.14.3
     # via pytest-cov
+defusedxml==0.7.1
+    # via pension-data (pyproject.toml)
 distro==1.9.0
     # via
     #   anthropic

--- a/src/pension_data/db/migrations/20260702_001_security_positions.sql
+++ b/src/pension_data/db/migrations/20260702_001_security_positions.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS plan_security_positions (
+    plan_id TEXT NOT NULL,
+    plan_period TEXT NOT NULL,
+    security_id TEXT NOT NULL,
+    security_name TEXT,
+    cusip TEXT,
+    ticker TEXT,
+    shares REAL,
+    market_value_usd REAL,
+    asset_class TEXT NOT NULL,
+    source TEXT NOT NULL,
+    as_of TEXT NOT NULL,
+    disclosure_state TEXT NOT NULL,
+    provenance_ref TEXT NOT NULL,
+    manager_name TEXT,
+    fund_name TEXT,
+    confidence REAL NOT NULL DEFAULT 1.0,
+    PRIMARY KEY (plan_id, plan_period, security_id, source, as_of, provenance_ref)
+);
+
+CREATE INDEX IF NOT EXISTS idx_plan_security_positions_plan_period
+    ON plan_security_positions(plan_id, plan_period);
+
+CREATE INDEX IF NOT EXISTS idx_plan_security_positions_asset_class
+    ON plan_security_positions(plan_id, plan_period, asset_class);

--- a/src/pension_data/db/models/__init__.py
+++ b/src/pension_data/db/models/__init__.py
@@ -31,7 +31,11 @@ from pension_data.db.models.investment_allocations_fees import (
     InvestmentExtractionWarning,
     ManagerFeeObservation,
 )
-from pension_data.db.models.investment_positions import PlanManagerFundPosition
+from pension_data.db.models.investment_positions import (
+    HoldingsCoverageReport,
+    PlanManagerFundPosition,
+    PlanSecurityPosition,
+)
 from pension_data.db.models.manager_lifecycle import ManagerLifecycleEvent
 from pension_data.db.models.provenance import EvidenceReference, MetricEvidenceLink
 from pension_data.db.models.registry import PensionSystemRecord, V1CohortMembership
@@ -85,6 +89,7 @@ __all__ = [
     "FundedActuarialStagingFact",
     "FundedStatusFact",
     "HoldingFact",
+    "HoldingsCoverageReport",
     "IngestionRunMetrics",
     "InvestmentExtractionWarning",
     "ManagerFeeObservation",
@@ -95,6 +100,7 @@ __all__ = [
     "PlanConsultantEngagement",
     "PlanFinancialFlow",
     "PlanManagerFundPosition",
+    "PlanSecurityPosition",
     "RawArtifactRecord",
     "ReviewQueueAuditEntry",
     "RiskExposureObservation",

--- a/src/pension_data/db/models/investment_positions.py
+++ b/src/pension_data/db/models/investment_positions.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from typing import Literal
 
 PositionCompleteness = Literal["complete", "partial", "not_disclosed"]
+SecurityDisclosureState = Literal["disclosed", "not_disclosed", "known_not_invested"]
+SecurityPositionSource = Literal["13f", "own_holdings_file", "acfr", "ab2833", "manual"]
 PositionWarningCode = Literal["non_disclosure", "partial_disclosure", "ambiguous_naming"]
 LinkageStatus = Literal["resolved", "ambiguous", "not_disclosed"]
 
@@ -34,3 +36,44 @@ class PlanManagerFundPosition:
     def is_disclosed(self) -> bool:
         """Whether this position row contains a disclosed investment."""
         return self.completeness != "not_disclosed"
+
+
+@dataclass(frozen=True, slots=True)
+class PlanSecurityPosition:
+    """Security-level holding row for a single plan-period and source."""
+
+    plan_id: str
+    plan_period: str
+    security_id: str
+    security_name: str | None
+    cusip: str | None
+    ticker: str | None
+    shares: float | None
+    market_value_usd: float | None
+    asset_class: str
+    source: SecurityPositionSource
+    as_of: str
+    disclosure_state: SecurityDisclosureState
+    provenance_ref: str
+    manager_name: str | None = None
+    fund_name: str | None = None
+    confidence: float = 1.0
+
+    @property
+    def is_disclosed(self) -> bool:
+        """Whether this security row represents a disclosed holding."""
+        return self.disclosure_state == "disclosed"
+
+
+@dataclass(frozen=True, slots=True)
+class HoldingsCoverageReport:
+    """Coverage of collected security holdings against ACFR total-plan assets."""
+
+    plan_id: str
+    plan_period: str
+    total_plan_assets_usd: float
+    collected_market_value_usd: float
+    coverage_ratio: float
+    scope_label: str
+    by_asset_class: dict[str, float]
+    provenance_refs: tuple[str, ...]

--- a/src/pension_data/extract/investment/__init__.py
+++ b/src/pension_data/extract/investment/__init__.py
@@ -21,9 +21,18 @@ from pension_data.extract.investment.risk_disclosures import (
     SecuritiesLendingDisclosureInput,
     extract_risk_exposure_observations,
 )
+from pension_data.extract.investment.security_positions import (
+    AcfrAllocationInput,
+    SecurityPositionInput,
+    build_security_positions,
+    load_own_holdings_csv,
+    parse_13f_information_table_xml,
+    reconcile_holdings_to_acfr,
+)
 
 __all__ = [
     "AllocationDisclosureInput",
+    "AcfrAllocationInput",
     "DerivativesDisclosureInput",
     "FeeDisclosureInput",
     "ExplicitLifecycleSignal",
@@ -31,9 +40,14 @@ __all__ = [
     "ManagerFundDisclosureInput",
     "RiskExtractionDiagnostic",
     "SecuritiesLendingDisclosureInput",
+    "SecurityPositionInput",
     "build_manager_fund_positions",
+    "build_security_positions",
     "extract_asset_allocations",
     "extract_fee_observations",
     "extract_risk_exposure_observations",
     "infer_lifecycle_events",
+    "load_own_holdings_csv",
+    "parse_13f_information_table_xml",
+    "reconcile_holdings_to_acfr",
 ]

--- a/src/pension_data/extract/investment/security_positions.py
+++ b/src/pension_data/extract/investment/security_positions.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import csv
 import math
-import xml.etree.ElementTree as ET
 from collections import defaultdict
 from dataclasses import dataclass
 from io import StringIO
+
+from defusedxml import ElementTree  # type: ignore[import-untyped]
 
 from pension_data.db.models.investment_positions import (
     HoldingsCoverageReport,
@@ -15,6 +16,8 @@ from pension_data.db.models.investment_positions import (
     SecurityDisclosureState,
     SecurityPositionSource,
 )
+
+_TOTAL_PLAN_COVERAGE_THRESHOLD = 0.95
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,12 +48,12 @@ class AcfrAllocationInput:
     provenance_ref: str
 
 
-def _text(element: ET.Element, tag_name: str) -> str | None:
+def _text(element: ElementTree.Element, tag_name: str) -> str | None:
     for child in element.iter():
         if child.tag.rsplit("}", 1)[-1] == tag_name and child.text:
             value = child.text.strip()
             if value:
-                return value
+                return str(value)
     return None
 
 
@@ -83,7 +86,8 @@ def _security_id(*, cusip: str | None, ticker: str | None, security_name: str | 
         return f"ticker:{ticker.strip().upper()}"
     if security_name:
         return "name:" + " ".join(security_name.lower().split())
-    return "unknown:security"
+    msg = "security position requires cusip, ticker, or security_name"
+    raise ValueError(msg)
 
 
 def parse_13f_information_table_xml(
@@ -98,7 +102,7 @@ def parse_13f_information_table_xml(
     13F values are reported in thousands of dollars, so `market_value_usd`
     multiplies the XML `value` field by 1,000.
     """
-    root = ET.fromstring(xml_text)
+    root = ElementTree.fromstring(xml_text)
     rows: list[SecurityPositionInput] = []
     for info_table in root.iter():
         if info_table.tag.rsplit("}", 1)[-1] != "infoTable":
@@ -215,6 +219,7 @@ def reconcile_holdings_to_acfr(
         raise ValueError(msg)
 
     collected_by_asset_class: dict[str, float] = defaultdict(float)
+    scoped_provenance_refs: list[str] = []
     for position in positions:
         if (
             position.plan_id != plan_id
@@ -224,6 +229,8 @@ def reconcile_holdings_to_acfr(
         ):
             continue
         collected_by_asset_class[position.asset_class] += position.market_value_usd
+        if position.provenance_ref:
+            scoped_provenance_refs.append(position.provenance_ref)
 
     acfr_by_asset_class = {
         row.asset_class.strip().lower(): row.market_value_usd for row in acfr_allocations
@@ -233,13 +240,15 @@ def reconcile_holdings_to_acfr(
     provenance_refs = tuple(
         dict.fromkeys(
             [
-                *(position.provenance_ref for position in positions if position.provenance_ref),
+                *scoped_provenance_refs,
                 *(row.provenance_ref for row in acfr_allocations if row.provenance_ref),
             ]
         )
     )
     coverage_ratio = round(collected_total / total_plan_assets_usd, 6)
-    scope_label = "total-plan" if coverage_ratio >= 0.95 else "equity-sleeve"
+    scope_label = (
+        "total-plan" if coverage_ratio >= _TOTAL_PLAN_COVERAGE_THRESHOLD else "equity-sleeve"
+    )
 
     return HoldingsCoverageReport(
         plan_id=plan_id,

--- a/src/pension_data/extract/investment/security_positions.py
+++ b/src/pension_data/extract/investment/security_positions.py
@@ -1,0 +1,260 @@
+"""Security-level holdings extraction and CAFR coverage reconciliation."""
+
+from __future__ import annotations
+
+import csv
+import math
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from dataclasses import dataclass
+from io import StringIO
+
+from pension_data.db.models.investment_positions import (
+    HoldingsCoverageReport,
+    PlanSecurityPosition,
+    SecurityDisclosureState,
+    SecurityPositionSource,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SecurityPositionInput:
+    """Raw security-level holding from a public source."""
+
+    security_name: str | None
+    cusip: str | None
+    ticker: str | None
+    shares: float | None
+    market_value_usd: float | None
+    asset_class: str
+    source: SecurityPositionSource
+    as_of: str
+    provenance_ref: str
+    disclosure_state: SecurityDisclosureState = "disclosed"
+    manager_name: str | None = None
+    fund_name: str | None = None
+    confidence: float = 1.0
+
+
+@dataclass(frozen=True, slots=True)
+class AcfrAllocationInput:
+    """ACFR total-plan anchor row used to label holdings coverage."""
+
+    asset_class: str
+    market_value_usd: float
+    provenance_ref: str
+
+
+def _text(element: ET.Element, tag_name: str) -> str | None:
+    for child in element.iter():
+        if child.tag.rsplit("}", 1)[-1] == tag_name and child.text:
+            value = child.text.strip()
+            if value:
+                return value
+    return None
+
+
+def _float_or_none(value: str | None) -> float | None:
+    if value is None:
+        return None
+    cleaned = value.strip().replace(",", "")
+    if not cleaned:
+        return None
+    try:
+        parsed = float(cleaned)
+    except ValueError:
+        return None
+    if not math.isfinite(parsed):
+        return None
+    return parsed
+
+
+def _normalize_cusip(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = "".join(ch for ch in value.upper() if ch.isalnum())
+    return normalized or None
+
+
+def _security_id(*, cusip: str | None, ticker: str | None, security_name: str | None) -> str:
+    if cusip:
+        return f"cusip:{cusip}"
+    if ticker:
+        return f"ticker:{ticker.strip().upper()}"
+    if security_name:
+        return "name:" + " ".join(security_name.lower().split())
+    return "unknown:security"
+
+
+def parse_13f_information_table_xml(
+    xml_text: str,
+    *,
+    as_of: str,
+    provenance_ref: str,
+    asset_class: str = "public_equity",
+) -> list[SecurityPositionInput]:
+    """Parse an EDGAR 13F information table XML payload.
+
+    13F values are reported in thousands of dollars, so `market_value_usd`
+    multiplies the XML `value` field by 1,000.
+    """
+    root = ET.fromstring(xml_text)
+    rows: list[SecurityPositionInput] = []
+    for info_table in root.iter():
+        if info_table.tag.rsplit("}", 1)[-1] != "infoTable":
+            continue
+        security_name = _text(info_table, "nameOfIssuer")
+        cusip = _normalize_cusip(_text(info_table, "cusip"))
+        value_thousands = _float_or_none(_text(info_table, "value"))
+        shares = _float_or_none(_text(info_table, "sshPrnamt"))
+        rows.append(
+            SecurityPositionInput(
+                security_name=security_name,
+                cusip=cusip,
+                ticker=None,
+                shares=shares,
+                market_value_usd=(
+                    round(value_thousands * 1000.0, 6) if value_thousands is not None else None
+                ),
+                asset_class=asset_class,
+                source="13f",
+                as_of=as_of,
+                provenance_ref=provenance_ref,
+            )
+        )
+    return rows
+
+
+def load_own_holdings_csv(
+    csv_text: str,
+    *,
+    as_of: str,
+    provenance_ref: str,
+    default_asset_class: str = "unknown",
+) -> list[SecurityPositionInput]:
+    """Load a public own-holdings CSV export into normalized inputs."""
+    reader = csv.DictReader(StringIO(csv_text))
+    rows: list[SecurityPositionInput] = []
+    for row in reader:
+        security_name = row.get("security_name") or row.get("name")
+        cusip = _normalize_cusip(row.get("cusip"))
+        ticker = row.get("ticker")
+        rows.append(
+            SecurityPositionInput(
+                security_name=security_name.strip() if security_name else None,
+                cusip=cusip,
+                ticker=ticker.strip().upper() if ticker and ticker.strip() else None,
+                shares=_float_or_none(row.get("shares")),
+                market_value_usd=_float_or_none(row.get("market_value_usd")),
+                asset_class=(row.get("asset_class") or default_asset_class).strip().lower(),
+                source="own_holdings_file",
+                as_of=as_of,
+                provenance_ref=provenance_ref,
+                manager_name=(row.get("manager_name") or None),
+                fund_name=(row.get("fund_name") or None),
+            )
+        )
+    return rows
+
+
+def build_security_positions(
+    *,
+    plan_id: str,
+    plan_period: str,
+    rows: list[SecurityPositionInput],
+) -> list[PlanSecurityPosition]:
+    """Stage security-level positions with deterministic IDs and ordering."""
+    positions = [
+        PlanSecurityPosition(
+            plan_id=plan_id,
+            plan_period=plan_period,
+            security_id=_security_id(
+                cusip=row.cusip,
+                ticker=row.ticker,
+                security_name=row.security_name,
+            ),
+            security_name=row.security_name.strip() if row.security_name else None,
+            cusip=row.cusip,
+            ticker=row.ticker.strip().upper() if row.ticker else None,
+            shares=row.shares,
+            market_value_usd=row.market_value_usd,
+            asset_class=row.asset_class.strip().lower(),
+            source=row.source,
+            as_of=row.as_of,
+            disclosure_state=row.disclosure_state,
+            provenance_ref=row.provenance_ref,
+            manager_name=row.manager_name.strip() if row.manager_name else None,
+            fund_name=row.fund_name.strip() if row.fund_name else None,
+            confidence=max(0.0, min(1.0, row.confidence)),
+        )
+        for row in rows
+    ]
+    return sorted(
+        positions,
+        key=lambda row: (
+            row.plan_id,
+            row.plan_period,
+            row.asset_class,
+            row.security_id,
+            row.provenance_ref,
+        ),
+    )
+
+
+def reconcile_holdings_to_acfr(
+    *,
+    plan_id: str,
+    plan_period: str,
+    positions: list[PlanSecurityPosition],
+    total_plan_assets_usd: float,
+    acfr_allocations: list[AcfrAllocationInput],
+) -> HoldingsCoverageReport:
+    """Compute holdings coverage against ACFR total-plan asset values."""
+    if total_plan_assets_usd <= 0.0 or not math.isfinite(total_plan_assets_usd):
+        msg = "total_plan_assets_usd must be a positive finite value"
+        raise ValueError(msg)
+
+    collected_by_asset_class: dict[str, float] = defaultdict(float)
+    for position in positions:
+        if (
+            position.plan_id != plan_id
+            or position.plan_period != plan_period
+            or position.disclosure_state != "disclosed"
+            or position.market_value_usd is None
+        ):
+            continue
+        collected_by_asset_class[position.asset_class] += position.market_value_usd
+
+    acfr_by_asset_class = {
+        row.asset_class.strip().lower(): row.market_value_usd for row in acfr_allocations
+    }
+    combined_classes = sorted(set(collected_by_asset_class) | set(acfr_by_asset_class))
+    collected_total = round(sum(collected_by_asset_class.values()), 6)
+    provenance_refs = tuple(
+        dict.fromkeys(
+            [
+                *(position.provenance_ref for position in positions if position.provenance_ref),
+                *(row.provenance_ref for row in acfr_allocations if row.provenance_ref),
+            ]
+        )
+    )
+    coverage_ratio = round(collected_total / total_plan_assets_usd, 6)
+    scope_label = "total-plan" if coverage_ratio >= 0.95 else "equity-sleeve"
+
+    return HoldingsCoverageReport(
+        plan_id=plan_id,
+        plan_period=plan_period,
+        total_plan_assets_usd=round(total_plan_assets_usd, 6),
+        collected_market_value_usd=collected_total,
+        coverage_ratio=coverage_ratio,
+        scope_label=scope_label,
+        by_asset_class={
+            asset_class: round(
+                collected_by_asset_class.get(asset_class, 0.0) / acfr_by_asset_class[asset_class],
+                6,
+            )
+            for asset_class in combined_classes
+            if acfr_by_asset_class.get(asset_class, 0.0) > 0.0
+        },
+        provenance_refs=provenance_refs,
+    )

--- a/tests/ingest/test_13f_parse.py
+++ b/tests/ingest/test_13f_parse.py
@@ -1,0 +1,58 @@
+"""Tests for public 13F security-position ingestion."""
+
+from __future__ import annotations
+
+from pension_data.extract.investment.security_positions import (
+    build_security_positions,
+    parse_13f_information_table_xml,
+)
+
+NAMESPACED_13F_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<informationTable xmlns="http://www.sec.gov/edgar/document/thirteenf/informationtable">
+  <infoTable>
+    <nameOfIssuer>APPLE INC</nameOfIssuer>
+    <titleOfClass>COM</titleOfClass>
+    <cusip>037833100</cusip>
+    <value>1250</value>
+    <shrsOrPrnAmt>
+      <sshPrnamt>2500</sshPrnamt>
+      <sshPrnamtType>SH</sshPrnamtType>
+    </shrsOrPrnAmt>
+  </infoTable>
+  <infoTable>
+    <nameOfIssuer>MICROSOFT CORP</nameOfIssuer>
+    <titleOfClass>COM</titleOfClass>
+    <cusip>594918104</cusip>
+    <value>2750</value>
+    <shrsOrPrnAmt>
+      <sshPrnamt>3000</sshPrnamt>
+      <sshPrnamtType>SH</sshPrnamtType>
+    </shrsOrPrnAmt>
+  </infoTable>
+</informationTable>
+"""
+
+
+def test_13f_information_table_parses_namespaced_xml_and_value_units() -> None:
+    inputs = parse_13f_information_table_xml(
+        NAMESPACED_13F_XML,
+        as_of="2025-03-31",
+        provenance_ref="edgar:calpers:2025q1",
+    )
+
+    positions = build_security_positions(
+        plan_id="CA-PERS",
+        plan_period="FY2025",
+        rows=inputs,
+    )
+
+    assert len(positions) == 2
+    assert [position.security_id for position in positions] == [
+        "cusip:037833100",
+        "cusip:594918104",
+    ]
+    assert sum(position.market_value_usd or 0.0 for position in positions) == 4_000_000.0
+    assert positions[0].shares == 2500.0
+    assert positions[0].source == "13f"
+    assert positions[0].asset_class == "public_equity"
+    assert positions[0].provenance_ref == "edgar:calpers:2025q1"

--- a/tests/ingest/test_13f_parse.py
+++ b/tests/ingest/test_13f_parse.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import pytest
+
 from pension_data.extract.investment.security_positions import (
+    AcfrAllocationInput,
+    SecurityPositionInput,
     build_security_positions,
     parse_13f_information_table_xml,
+    reconcile_holdings_to_acfr,
 )
 
 NAMESPACED_13F_XML = """<?xml version="1.0" encoding="UTF-8"?>
@@ -56,3 +61,76 @@ def test_13f_information_table_parses_namespaced_xml_and_value_units() -> None:
     assert positions[0].source == "13f"
     assert positions[0].asset_class == "public_equity"
     assert positions[0].provenance_ref == "edgar:calpers:2025q1"
+
+
+def test_security_positions_require_stable_identifier() -> None:
+    rows = [
+        SecurityPositionInput(
+            security_name=None,
+            cusip=None,
+            ticker=None,
+            shares=10.0,
+            market_value_usd=100.0,
+            asset_class="public_equity",
+            source="own_holdings_file",
+            as_of="2025-03-31",
+            provenance_ref="own:missing-id",
+        )
+    ]
+
+    with pytest.raises(ValueError, match="requires cusip, ticker, or security_name"):
+        build_security_positions(plan_id="CA-PERS", plan_period="FY2025", rows=rows)
+
+
+def test_holdings_coverage_provenance_refs_match_scoped_positions() -> None:
+    matching = build_security_positions(
+        plan_id="CA-PERS",
+        plan_period="FY2025",
+        rows=[
+            SecurityPositionInput(
+                security_name="APPLE INC",
+                cusip="037833100",
+                ticker=None,
+                shares=10.0,
+                market_value_usd=90.0,
+                asset_class="public_equity",
+                source="13f",
+                as_of="2025-03-31",
+                provenance_ref="edgar:ca",
+            )
+        ],
+    )
+    unrelated = build_security_positions(
+        plan_id="NY-ERS",
+        plan_period="FY2024",
+        rows=[
+            SecurityPositionInput(
+                security_name="MICROSOFT CORP",
+                cusip="594918104",
+                ticker=None,
+                shares=5.0,
+                market_value_usd=10.0,
+                asset_class="public_equity",
+                source="13f",
+                as_of="2024-03-31",
+                provenance_ref="edgar:ny",
+            )
+        ],
+    )
+
+    report = reconcile_holdings_to_acfr(
+        plan_id="CA-PERS",
+        plan_period="FY2025",
+        positions=[*matching, *unrelated],
+        total_plan_assets_usd=100.0,
+        acfr_allocations=[
+            AcfrAllocationInput(
+                asset_class="public_equity",
+                market_value_usd=100.0,
+                provenance_ref="acfr:ca",
+            )
+        ],
+    )
+
+    assert report.provenance_refs == ("edgar:ca", "acfr:ca")
+    assert report.scope_label == "equity-sleeve"

--- a/tests/ingest/test_cafr_reconcile.py
+++ b/tests/ingest/test_cafr_reconcile.py
@@ -1,0 +1,79 @@
+"""Tests for CAFR-anchored holdings coverage reconciliation."""
+
+from __future__ import annotations
+
+import pytest
+
+from pension_data.extract.investment.security_positions import (
+    AcfrAllocationInput,
+    build_security_positions,
+    load_own_holdings_csv,
+    parse_13f_information_table_xml,
+    reconcile_holdings_to_acfr,
+)
+
+
+def test_security_holdings_reconcile_to_cafr_total_assets_and_asset_classes() -> None:
+    own_holdings = load_own_holdings_csv(
+        """security_name,cusip,ticker,shares,market_value_usd,asset_class
+Apple Inc,037833100,AAPL,100,2500000,public_equity
+US Treasury 10Y,91282CJL6,,50,1500000,fixed_income
+""",
+        as_of="2025-06-30",
+        provenance_ref="calpers:own-holdings:fy2025",
+    )
+    thirteen_f = parse_13f_information_table_xml(
+        """<informationTable xmlns="http://www.sec.gov/edgar/document/thirteenf/informationtable">
+  <infoTable>
+    <nameOfIssuer>MICROSOFT CORP</nameOfIssuer>
+    <cusip>594918104</cusip>
+    <value>1000</value>
+    <shrsOrPrnAmt><sshPrnamt>1200</sshPrnamt></shrsOrPrnAmt>
+  </infoTable>
+</informationTable>
+""",
+        as_of="2025-03-31",
+        provenance_ref="edgar:calpers:2025q1",
+    )
+    positions = build_security_positions(
+        plan_id="CA-PERS",
+        plan_period="FY2025",
+        rows=[*own_holdings, *thirteen_f],
+    )
+
+    report = reconcile_holdings_to_acfr(
+        plan_id="CA-PERS",
+        plan_period="FY2025",
+        positions=positions,
+        total_plan_assets_usd=20_000_000.0,
+        acfr_allocations=[
+            AcfrAllocationInput("public_equity", 10_000_000.0, "acfr:fy2025:p52"),
+            AcfrAllocationInput("fixed_income", 5_000_000.0, "acfr:fy2025:p53"),
+            AcfrAllocationInput("private_equity", 5_000_000.0, "acfr:fy2025:p54"),
+        ],
+    )
+
+    assert report.collected_market_value_usd == 5_000_000.0
+    assert report.coverage_ratio == 0.25
+    assert report.scope_label == "equity-sleeve"
+    assert report.by_asset_class["public_equity"] == 0.35
+    assert report.by_asset_class["fixed_income"] == 0.3
+    assert report.by_asset_class["private_equity"] == 0.0
+    assert report.provenance_refs == (
+        "calpers:own-holdings:fy2025",
+        "edgar:calpers:2025q1",
+        "acfr:fy2025:p52",
+        "acfr:fy2025:p53",
+        "acfr:fy2025:p54",
+    )
+
+
+def test_cafr_reconcile_rejects_non_positive_total_assets() -> None:
+    with pytest.raises(ValueError, match="positive finite"):
+        reconcile_holdings_to_acfr(
+            plan_id="CA-PERS",
+            plan_period="FY2025",
+            positions=[],
+            total_plan_assets_usd=0.0,
+            acfr_allocations=[],
+        )


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:647 -->
> **Source:** Issue #647

Closes #647

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
To analyze a specific plan's actual portfolio we need real holdings. No single SEC filing is complete — 13F is an **equity-only sleeve (~25-46% of a plan)**, so total-plan figures must be **CAFR-anchored**. The richest source is usually the plan's **own published holdings file** (CalSTRS gold standard). The repo's `manager_fund_positions` already models positions with a `disclosed/not_disclosed/known_not_invested` tri-state — extend it down to security level. (Parent: #642; pairs with #D.)

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#642](https://github.com/stranske/Pension-Data/issues/642)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add a security-level positions table/dataclass beneath `manager_fund_positions`: cusip/ticker, name, shares, market_value, asset_class, source, as_of, `disclosure_state`, provenance ref.
- [ ] **13F ingestion** via EDGAR `https://data.sec.gov/submissions/CIK{10-digit}.json` → latest `13F-HR` → parse the INFORMATION TABLE XML (User-Agent header required). Verify the target plan's CIK (e.g. CalPERS 0000919079, NY Common 0000810265, Texas TRS 0000796848) — confirm per plan, some outsource and barely file.
- [ ] **Own-holdings-file** loader (CSV/XLS) when the plan publishes one (primary source, highest coverage).
- [ ] **ACFR allocation** capture (authoritative total-plan asset-class weights) as the anchor; **AB 2833**-style fee/alts disclosure capture where available.
- [ ] **Reconciliation**: compute and store the coverage gap (Σ holdings market_value vs CAFR total assets) and label each analysis's scope (equity-sleeve vs total-plan).

#### Acceptance criteria
- [ ] For one target plan, the pipeline produces security-level equity positions (13F) + asset-class totals (CAFR), with provenance and as_of on every row.
- [ ] A coverage report states what % of total plan assets the collected holdings represent, by asset class.
- [ ] `holdings_overlap` runs against the real security-level data.

<!-- auto-status-summary:end -->