### PR TITLE
Add bitemporal assertion history helpers

### DIFF
--- a/src/pension_data/db/migrations/20260702_002_security_positions_bitemporal.sql
+++ b/src/pension_data/db/migrations/20260702_002_security_positions_bitemporal.sql
@@ -1,0 +1,25 @@
+ALTER TABLE plan_security_positions
+    ADD COLUMN valid_from TEXT;
+
+ALTER TABLE plan_security_positions
+    ADD COLUMN valid_to TEXT;
+
+ALTER TABLE plan_security_positions
+    ADD COLUMN asserted_at TEXT;
+
+ALTER TABLE plan_security_positions
+    ADD COLUMN superseded_at TEXT;
+
+ALTER TABLE plan_security_positions
+    ADD COLUMN amendment_accession TEXT;
+
+UPDATE plan_security_positions
+SET valid_from = as_of
+WHERE valid_from IS NULL;
+
+UPDATE plan_security_positions
+SET asserted_at = as_of
+WHERE asserted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_plan_security_positions_bitemporal
+    ON plan_security_positions(plan_id, security_id, valid_from, asserted_at, superseded_at);

--- a/src/pension_data/db/models/__init__.py
+++ b/src/pension_data/db/models/__init__.py
@@ -2,6 +2,12 @@
 
 from pension_data.db.models.api_keys import APIKeyRecord
 from pension_data.db.models.artifacts import IngestionRunMetrics, RawArtifactRecord
+from pension_data.db.models.bitemporal import (
+    BitemporalAssertion,
+    assert_no_active_valid_overlaps,
+    query_as_known_at,
+    supersede_assertions,
+)
 from pension_data.db.models.consultant_attribution import ConsultantAttributionObservation
 from pension_data.db.models.consultants import (
     ConsultantEntity,
@@ -68,6 +74,7 @@ __all__ = [
     "AllocationFact",
     "AnnualReportCoverageRecord",
     "AssetAllocationObservation",
+    "BitemporalAssertion",
     "BitemporalFactContext",
     "CanonicalEntityRecord",
     "CashFlowFact",
@@ -107,4 +114,7 @@ __all__ = [
     "UnresolvedEntityCandidate",
     "V1CohortMembership",
     "query_bitemporal_as_of",
+    "assert_no_active_valid_overlaps",
+    "query_as_known_at",
+    "supersede_assertions",
 ]

--- a/src/pension_data/db/models/bitemporal.py
+++ b/src/pension_data/db/models/bitemporal.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Sequence
-from dataclasses import dataclass, replace
+from copy import copy
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Protocol
 
@@ -56,6 +57,12 @@ def _known_at(row: BitemporalRow, known_at: datetime) -> bool:
         return True
     superseded_at = _parse_iso_temporal(row.superseded_at, field_name="superseded_at")
     return known_at < superseded_at
+
+
+def _copy_with_superseded_at[T: BitemporalRow](row: T, superseded_at: str) -> T:
+    updated = copy(row)
+    object.__setattr__(updated, "superseded_at", superseded_at)
+    return updated
 
 
 def query_as_known_at[T: BitemporalRow, K: object](
@@ -129,7 +136,7 @@ def supersede_assertions[T: BitemporalRow, K: object](
     updated_existing: list[T] = []
     for row in existing_rows:
         if key(row) in replacement_keys and row.superseded_at is None:
-            updated_existing.append(replace(row, superseded_at=superseded_at))
+            updated_existing.append(_copy_with_superseded_at(row, superseded_at))
         else:
             updated_existing.append(row)
     return [*updated_existing, *replacement_list]

--- a/src/pension_data/db/models/bitemporal.py
+++ b/src/pension_data/db/models/bitemporal.py
@@ -1,0 +1,135 @@
+"""Bitemporal assertion helpers for additive metric and holdings history."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass, replace
+from datetime import datetime
+from typing import Protocol
+
+from pension_data.db.models.core_facts import _parse_iso_temporal
+
+
+class BitemporalRow(Protocol):
+    """Row shape needed for valid-time + assertion-time filtering."""
+
+    valid_from: str
+    valid_to: str | None
+    asserted_at: str
+    superseded_at: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class BitemporalAssertion:
+    """Generic bitemporal value assertion for staged metrics or facts."""
+
+    entity_id: str
+    fact_name: str
+    value: float | str | None
+    valid_from: str
+    valid_to: str | None
+    asserted_at: str
+    source_document_id: str
+    superseded_at: str | None = None
+
+    @property
+    def is_restated(self) -> bool:
+        """Whether a later assertion superseded this row."""
+        return self.superseded_at is not None
+
+
+def _within_valid_window(row: BitemporalRow, valid_at: datetime) -> bool:
+    valid_from = _parse_iso_temporal(row.valid_from, field_name="valid_from")
+    if valid_from > valid_at:
+        return False
+    if row.valid_to is None:
+        return True
+    valid_to = _parse_iso_temporal(row.valid_to, field_name="valid_to")
+    return valid_at < valid_to
+
+
+def _known_at(row: BitemporalRow, known_at: datetime) -> bool:
+    asserted_at = _parse_iso_temporal(row.asserted_at, field_name="asserted_at")
+    if asserted_at > known_at:
+        return False
+    if row.superseded_at is None:
+        return True
+    superseded_at = _parse_iso_temporal(row.superseded_at, field_name="superseded_at")
+    return known_at < superseded_at
+
+
+def query_as_known_at[T: BitemporalRow, K: object](
+    rows: Sequence[T],
+    *,
+    valid_at: str,
+    known_at: str,
+    key: Callable[[T], K],
+) -> list[T]:
+    """Return the latest active assertion per key for an as-of/as-known-at view."""
+    valid_dt = _parse_iso_temporal(valid_at, field_name="valid_at")
+    known_dt = _parse_iso_temporal(known_at, field_name="known_at")
+
+    latest_by_key: dict[K, T] = {}
+    for row in rows:
+        if not _within_valid_window(row, valid_dt) or not _known_at(row, known_dt):
+            continue
+        row_key = key(row)
+        current = latest_by_key.get(row_key)
+        if current is None or _parse_iso_temporal(
+            row.asserted_at,
+            field_name="asserted_at",
+        ) > _parse_iso_temporal(current.asserted_at, field_name="asserted_at"):
+            latest_by_key[row_key] = row
+
+    return sorted(latest_by_key.values(), key=lambda row: (str(key(row)), row.asserted_at))
+
+
+def assert_no_active_valid_overlaps[T: BitemporalRow, K: object](
+    rows: Sequence[T],
+    *,
+    key: Callable[[T], K],
+) -> None:
+    """Raise when two active rows overlap for the same valid-time key."""
+    active_rows = [row for row in rows if row.superseded_at is None]
+    rows_by_key: dict[K, list[T]] = {}
+    for row in active_rows:
+        rows_by_key.setdefault(key(row), []).append(row)
+
+    for row_key, keyed_rows in rows_by_key.items():
+        ordered = sorted(
+            keyed_rows,
+            key=lambda row: _parse_iso_temporal(row.valid_from, field_name="valid_from"),
+        )
+        previous: T | None = None
+        for row in ordered:
+            if previous is None:
+                previous = row
+                continue
+            previous_end = (
+                _parse_iso_temporal(previous.valid_to, field_name="valid_to")
+                if previous.valid_to is not None
+                else None
+            )
+            row_start = _parse_iso_temporal(row.valid_from, field_name="valid_from")
+            if previous_end is None or row_start < previous_end:
+                raise ValueError(f"active valid-time overlap for {row_key!r}")
+            previous = row
+
+
+def supersede_assertions[T: BitemporalRow, K: object](
+    existing_rows: Sequence[T],
+    replacement_rows: Iterable[T],
+    *,
+    key: Callable[[T], K],
+    superseded_at: str,
+) -> list[T]:
+    """Return additive rows where matching active assertions are closed, not overwritten."""
+    replacement_list = list(replacement_rows)
+    replacement_keys = {key(row) for row in replacement_list}
+    updated_existing: list[T] = []
+    for row in existing_rows:
+        if key(row) in replacement_keys and row.superseded_at is None:
+            updated_existing.append(replace(row, superseded_at=superseded_at))
+        else:
+            updated_existing.append(row)
+    return [*updated_existing, *replacement_list]

--- a/src/pension_data/db/models/bitemporal.py
+++ b/src/pension_data/db/models/bitemporal.py
@@ -131,6 +131,7 @@ def supersede_assertions[T: BitemporalRow, K: object](
     superseded_at: str,
 ) -> list[T]:
     """Return additive rows where matching active assertions are closed, not overwritten."""
+    _parse_iso_temporal(superseded_at, field_name="superseded_at")
     replacement_list = list(replacement_rows)
     replacement_keys = {key(row) for row in replacement_list}
     updated_existing: list[T] = []

--- a/src/pension_data/db/models/investment_positions.py
+++ b/src/pension_data/db/models/investment_positions.py
@@ -58,11 +58,21 @@ class PlanSecurityPosition:
     manager_name: str | None = None
     fund_name: str | None = None
     confidence: float = 1.0
+    valid_from: str | None = None
+    valid_to: str | None = None
+    asserted_at: str | None = None
+    superseded_at: str | None = None
+    amendment_accession: str | None = None
 
     @property
     def is_disclosed(self) -> bool:
         """Whether this security row represents a disclosed holding."""
         return self.disclosure_state == "disclosed"
+
+    @property
+    def is_restated(self) -> bool:
+        """Whether this position was superseded by a later amendment/assertion."""
+        return self.superseded_at is not None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/pension_data/db/models/investment_positions.py
+++ b/src/pension_data/db/models/investment_positions.py
@@ -55,12 +55,12 @@ class PlanSecurityPosition:
     as_of: str
     disclosure_state: SecurityDisclosureState
     provenance_ref: str
+    valid_from: str
+    asserted_at: str
     manager_name: str | None = None
     fund_name: str | None = None
     confidence: float = 1.0
-    valid_from: str | None = None
     valid_to: str | None = None
-    asserted_at: str | None = None
     superseded_at: str | None = None
     amendment_accession: str | None = None
 

--- a/src/pension_data/extract/investment/security_positions.py
+++ b/src/pension_data/extract/investment/security_positions.py
@@ -37,6 +37,10 @@ class SecurityPositionInput:
     manager_name: str | None = None
     fund_name: str | None = None
     confidence: float = 1.0
+    valid_from: str | None = None
+    valid_to: str | None = None
+    asserted_at: str | None = None
+    amendment_accession: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -190,6 +194,10 @@ def build_security_positions(
             manager_name=row.manager_name.strip() if row.manager_name else None,
             fund_name=row.fund_name.strip() if row.fund_name else None,
             confidence=max(0.0, min(1.0, row.confidence)),
+            valid_from=row.valid_from or row.as_of,
+            valid_to=row.valid_to,
+            asserted_at=row.asserted_at or row.as_of,
+            amendment_accession=row.amendment_accession,
         )
         for row in rows
     ]

--- a/tests/db/test_bitemporal.py
+++ b/tests/db/test_bitemporal.py
@@ -150,3 +150,35 @@ def test_13f_amendment_supersedes_security_position_without_losing_history() -> 
         rows,
         key=lambda row: (row.plan_id, row.security_id, row.source),
     )
+
+
+def test_supersede_assertions_rejects_invalid_superseded_at() -> None:
+    rows = [
+        BitemporalAssertion(
+            entity_id="CA-PERS",
+            fact_name="funded_ratio",
+            value=0.74,
+            valid_from="2023-06-30",
+            valid_to="2024-06-30",
+            asserted_at="2024-02-01T00:00:00Z",
+            source_document_id="doc:fy2023-original",
+        )
+    ]
+
+    with pytest.raises(ValueError, match="superseded_at"):
+        supersede_assertions(
+            rows,
+            [
+                BitemporalAssertion(
+                    entity_id="CA-PERS",
+                    fact_name="funded_ratio",
+                    value=0.78,
+                    valid_from="2023-06-30",
+                    valid_to="2024-06-30",
+                    asserted_at="2025-03-01T00:00:00Z",
+                    source_document_id="doc:fy2023-restated",
+                )
+            ],
+            key=lambda row: (row.entity_id, row.fact_name),
+            superseded_at="not-a-date",
+        )

--- a/tests/db/test_bitemporal.py
+++ b/tests/db/test_bitemporal.py
@@ -1,0 +1,152 @@
+"""Tests for bitemporal metric and holdings assertions."""
+
+from __future__ import annotations
+
+import pytest
+
+from pension_data.db.models.bitemporal import (
+    BitemporalAssertion,
+    assert_no_active_valid_overlaps,
+    query_as_known_at,
+    supersede_assertions,
+)
+from pension_data.extract.investment.security_positions import (
+    SecurityPositionInput,
+    build_security_positions,
+)
+
+
+def test_metric_restatement_keeps_original_and_reproduces_known_at_views() -> None:
+    original = BitemporalAssertion(
+        entity_id="CA-PERS",
+        fact_name="funded_ratio",
+        value=0.74,
+        valid_from="2023-06-30",
+        valid_to="2024-06-30",
+        asserted_at="2024-02-01T00:00:00Z",
+        superseded_at="2025-03-01T00:00:00Z",
+        source_document_id="doc:fy2023-original",
+    )
+    restated = BitemporalAssertion(
+        entity_id="CA-PERS",
+        fact_name="funded_ratio",
+        value=0.78,
+        valid_from="2023-06-30",
+        valid_to="2024-06-30",
+        asserted_at="2025-03-01T00:00:00Z",
+        source_document_id="doc:fy2023-restated",
+    )
+    rows = [original, restated]
+
+    as_known_then = query_as_known_at(
+        rows,
+        valid_at="2023-12-31",
+        known_at="2024-12-31",
+        key=lambda row: (row.entity_id, row.fact_name),
+    )
+    as_known_now = query_as_known_at(
+        rows,
+        valid_at="2023-12-31",
+        known_at="2025-03-02",
+        key=lambda row: (row.entity_id, row.fact_name),
+    )
+
+    assert [row.value for row in as_known_then] == [0.74]
+    assert [row.value for row in as_known_now] == [0.78]
+    assert original.is_restated
+    assert not restated.is_restated
+    assert_no_active_valid_overlaps(rows, key=lambda row: (row.entity_id, row.fact_name))
+
+
+def test_active_overlap_guard_rejects_two_current_assertions_for_same_period() -> None:
+    rows = [
+        BitemporalAssertion(
+            entity_id="CA-PERS",
+            fact_name="funded_ratio",
+            value=0.74,
+            valid_from="2023-01-01",
+            valid_to="2024-01-01",
+            asserted_at="2024-02-01",
+            source_document_id="doc:a",
+        ),
+        BitemporalAssertion(
+            entity_id="CA-PERS",
+            fact_name="funded_ratio",
+            value=0.75,
+            valid_from="2023-06-30",
+            valid_to="2024-06-30",
+            asserted_at="2024-02-02",
+            source_document_id="doc:b",
+        ),
+    ]
+
+    with pytest.raises(ValueError, match="active valid-time overlap"):
+        assert_no_active_valid_overlaps(rows, key=lambda row: (row.entity_id, row.fact_name))
+
+
+def test_13f_amendment_supersedes_security_position_without_losing_history() -> None:
+    original = build_security_positions(
+        plan_id="CA-PERS",
+        plan_period="FY2025",
+        rows=[
+            SecurityPositionInput(
+                security_name="APPLE INC",
+                cusip="037833100",
+                ticker=None,
+                shares=2500.0,
+                market_value_usd=1_250_000.0,
+                asset_class="public_equity",
+                source="13f",
+                as_of="2025-03-31",
+                provenance_ref="13f:original",
+                asserted_at="2025-05-15T00:00:00Z",
+            )
+        ],
+    )
+    amendment = build_security_positions(
+        plan_id="CA-PERS",
+        plan_period="FY2025",
+        rows=[
+            SecurityPositionInput(
+                security_name="APPLE INC",
+                cusip="037833100",
+                ticker=None,
+                shares=2600.0,
+                market_value_usd=1_300_000.0,
+                asset_class="public_equity",
+                source="13f",
+                as_of="2025-03-31",
+                provenance_ref="13f:amendment",
+                asserted_at="2025-06-01T00:00:00Z",
+                amendment_accession="0000919079-25-000001/A",
+            )
+        ],
+    )
+    rows = supersede_assertions(
+        original,
+        amendment,
+        key=lambda row: (row.plan_id, row.security_id, row.source, row.as_of),
+        superseded_at="2025-06-01T00:00:00Z",
+    )
+
+    before_amendment = query_as_known_at(
+        rows,
+        valid_at="2025-03-31",
+        known_at="2025-05-20",
+        key=lambda row: (row.plan_id, row.security_id, row.source),
+    )
+    after_amendment = query_as_known_at(
+        rows,
+        valid_at="2025-03-31",
+        known_at="2025-06-02",
+        key=lambda row: (row.plan_id, row.security_id, row.source),
+    )
+
+    assert [row.market_value_usd for row in before_amendment] == [1_250_000.0]
+    assert [row.market_value_usd for row in after_amendment] == [1_300_000.0]
+    assert rows[0].is_restated
+    assert rows[1].amendment_accession == "0000919079-25-000001/A"
+    assert_no_active_valid_overlaps(
+        rows,
+        key=lambda row: (row.plan_id, row.security_id, row.source),
+    )


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:649 -->
> **Source:** Issue #649

Closes #649

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Pension facts have two independent timelines: the **as-of date** of the figure (FY2024 measurement) and the **assertion time** (when a filing/restatement told us). Actuarial restatements and holdings refilings (13F amendments) are routine. Without bitemporal modeling you can't answer "what did we believe the FY2023 funded ratio / the Q1 holdings were, as of last March, vs now," and restatements silently overwrite history. (Parent: #642; underpins holdings-over-time and benchmarking trends.)

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#642](https://github.com/stranske/Pension-Data/issues/642)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add `valid_from`/`valid_to` (as-of) and `asserted_at`/`superseded_at` (transaction-time) to the core staged metric + holdings rows; never UPDATE-in-place — insert a new assertion and close the prior.
- [ ] Add non-overlapping-period constraints + an "as-of-as-known-at" query helper (time-travel).
- [ ] Wire restatement/amendment ingestion (e.g., 13F-HR/A) to supersede rather than overwrite.
- [ ] Surface "restated" flags in the analytics outputs.

#### Acceptance criteria
- [ ] A restated metric keeps both the original and corrected assertion; a query can reproduce the pre-restatement view.
- [ ] No period overlaps for a given (plan, metric, as-of) across assertions.
- [ ] Holdings amendments (13F/A) supersede prior filings without losing history.

<!-- auto-status-summary:end -->