### PR TITLE
Add bitemporal versioning for pension facts and holdings

### DIFF
--- a/agents/codex-649.md
+++ b/agents/codex-649.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #649 -->

--- a/src/pension_data/db/migrations/20260302_001_core_fact_staging.sql
+++ b/src/pension_data/db/migrations/20260302_001_core_fact_staging.sql
@@ -19,6 +19,11 @@ CREATE TABLE IF NOT EXISTS staging_core_metrics (
   evidence_refs TEXT,
   effective_date TEXT NOT NULL,
   ingestion_date TEXT NOT NULL,
+  valid_from TEXT NOT NULL,
+  valid_to TEXT,
+  asserted_at TEXT NOT NULL,
+  superseded_at TEXT,
+  restated INTEGER NOT NULL DEFAULT 0,
   benchmark_version TEXT NOT NULL,
   source_document_id TEXT NOT NULL
 );
@@ -103,6 +108,11 @@ SELECT
   vehicle_name,
   effective_date,
   ingestion_date,
+  valid_from,
+  valid_to,
+  asserted_at,
+  superseded_at,
+  restated,
   benchmark_version,
   source_document_id
 FROM staging_core_metrics

--- a/src/pension_data/db/migrations/20260302_002_seed_backfill_compat.sql
+++ b/src/pension_data/db/migrations/20260302_002_seed_backfill_compat.sql
@@ -7,7 +7,11 @@ SET
   benchmark_version = COALESCE(NULLIF(benchmark_version, ''), 'v1'),
   ingestion_date = COALESCE(NULLIF(ingestion_date, ''), effective_date),
   valid_from = COALESCE(NULLIF(valid_from, ''), effective_date),
-  asserted_at = COALESCE(NULLIF(asserted_at, ''), ingestion_date, effective_date),
+  asserted_at = COALESCE(
+    NULLIF(asserted_at, ''),
+    NULLIF(ingestion_date, ''),
+    effective_date
+  ),
   restated = CASE WHEN superseded_at IS NULL OR TRIM(superseded_at) = '' THEN 0 ELSE 1 END
 WHERE
   plan_period IS NULL
@@ -19,7 +23,12 @@ WHERE
   OR valid_from IS NULL
   OR valid_from = ''
   OR asserted_at IS NULL
-  OR asserted_at = '';
+  OR asserted_at = ''
+  OR (
+    superseded_at IS NOT NULL
+    AND TRIM(superseded_at) <> ''
+    AND COALESCE(restated, 0) = 0
+  );
 
 UPDATE staging_cash_flows
 SET

--- a/src/pension_data/db/migrations/20260302_002_seed_backfill_compat.sql
+++ b/src/pension_data/db/migrations/20260302_002_seed_backfill_compat.sql
@@ -5,14 +5,21 @@ UPDATE staging_core_metrics
 SET
   plan_period = COALESCE(NULLIF(plan_period, ''), 'UNKNOWN'),
   benchmark_version = COALESCE(NULLIF(benchmark_version, ''), 'v1'),
-  ingestion_date = COALESCE(NULLIF(ingestion_date, ''), effective_date)
+  ingestion_date = COALESCE(NULLIF(ingestion_date, ''), effective_date),
+  valid_from = COALESCE(NULLIF(valid_from, ''), effective_date),
+  asserted_at = COALESCE(NULLIF(asserted_at, ''), ingestion_date, effective_date),
+  restated = CASE WHEN superseded_at IS NULL OR TRIM(superseded_at) = '' THEN 0 ELSE 1 END
 WHERE
   plan_period IS NULL
   OR plan_period = ''
   OR benchmark_version IS NULL
   OR benchmark_version = ''
   OR ingestion_date IS NULL
-  OR ingestion_date = '';
+  OR ingestion_date = ''
+  OR valid_from IS NULL
+  OR valid_from = ''
+  OR asserted_at IS NULL
+  OR asserted_at = '';
 
 UPDATE staging_cash_flows
 SET

--- a/src/pension_data/db/migrations/20260303_101_pg_core_fact_staging.sql
+++ b/src/pension_data/db/migrations/20260303_101_pg_core_fact_staging.sql
@@ -19,6 +19,11 @@ CREATE TABLE IF NOT EXISTS staging_core_metrics (
   evidence_refs JSONB,
   effective_date TIMESTAMPTZ NOT NULL,
   ingestion_date TIMESTAMPTZ NOT NULL,
+  valid_from TIMESTAMPTZ NOT NULL,
+  valid_to TIMESTAMPTZ,
+  asserted_at TIMESTAMPTZ NOT NULL,
+  superseded_at TIMESTAMPTZ,
+  restated BOOLEAN NOT NULL DEFAULT FALSE,
   benchmark_version TEXT NOT NULL,
   source_document_id TEXT NOT NULL
 );
@@ -103,6 +108,11 @@ SELECT
   vehicle_name,
   effective_date,
   ingestion_date,
+  valid_from,
+  valid_to,
+  asserted_at,
+  superseded_at,
+  restated,
   benchmark_version,
   source_document_id
 FROM staging_core_metrics

--- a/src/pension_data/db/migrations/20260303_102_pg_seed_backfill_compat.sql
+++ b/src/pension_data/db/migrations/20260303_102_pg_seed_backfill_compat.sql
@@ -5,13 +5,9 @@ UPDATE staging_core_metrics
 SET
   plan_period = COALESCE(NULLIF(plan_period, ''), 'UNKNOWN'),
   benchmark_version = COALESCE(NULLIF(benchmark_version, ''), 'v1'),
-  ingestion_date = COALESCE(NULLIF(ingestion_date, ''), effective_date),
-  valid_from = COALESCE(NULLIF(valid_from, ''), effective_date),
-  asserted_at = COALESCE(
-    NULLIF(asserted_at, ''),
-    NULLIF(ingestion_date, ''),
-    effective_date
-  ),
+  ingestion_date = COALESCE(ingestion_date, effective_date),
+  valid_from = COALESCE(valid_from, effective_date),
+  asserted_at = COALESCE(asserted_at, ingestion_date, effective_date),
   restated = superseded_at IS NOT NULL
 WHERE
   plan_period IS NULL
@@ -19,11 +15,8 @@ WHERE
   OR benchmark_version IS NULL
   OR benchmark_version = ''
   OR ingestion_date IS NULL
-  OR ingestion_date = ''
   OR valid_from IS NULL
-  OR valid_from = ''
   OR asserted_at IS NULL
-  OR asserted_at = ''
   OR (
     superseded_at IS NOT NULL
     AND restated IS DISTINCT FROM TRUE

--- a/src/pension_data/db/migrations/20260303_102_pg_seed_backfill_compat.sql
+++ b/src/pension_data/db/migrations/20260303_102_pg_seed_backfill_compat.sql
@@ -5,9 +5,13 @@ UPDATE staging_core_metrics
 SET
   plan_period = COALESCE(NULLIF(plan_period, ''), 'UNKNOWN'),
   benchmark_version = COALESCE(NULLIF(benchmark_version, ''), 'v1'),
-  ingestion_date = COALESCE(ingestion_date, effective_date),
-  valid_from = COALESCE(valid_from, effective_date),
-  asserted_at = COALESCE(asserted_at, ingestion_date, effective_date),
+  ingestion_date = COALESCE(NULLIF(ingestion_date, ''), effective_date),
+  valid_from = COALESCE(NULLIF(valid_from, ''), effective_date),
+  asserted_at = COALESCE(
+    NULLIF(asserted_at, ''),
+    NULLIF(ingestion_date, ''),
+    effective_date
+  ),
   restated = superseded_at IS NOT NULL
 WHERE
   plan_period IS NULL
@@ -15,8 +19,15 @@ WHERE
   OR benchmark_version IS NULL
   OR benchmark_version = ''
   OR ingestion_date IS NULL
+  OR ingestion_date = ''
   OR valid_from IS NULL
-  OR asserted_at IS NULL;
+  OR valid_from = ''
+  OR asserted_at IS NULL
+  OR asserted_at = ''
+  OR (
+    superseded_at IS NOT NULL
+    AND restated IS DISTINCT FROM TRUE
+  );
 
 UPDATE staging_cash_flows
 SET

--- a/src/pension_data/db/migrations/20260303_102_pg_seed_backfill_compat.sql
+++ b/src/pension_data/db/migrations/20260303_102_pg_seed_backfill_compat.sql
@@ -5,13 +5,18 @@ UPDATE staging_core_metrics
 SET
   plan_period = COALESCE(NULLIF(plan_period, ''), 'UNKNOWN'),
   benchmark_version = COALESCE(NULLIF(benchmark_version, ''), 'v1'),
-  ingestion_date = COALESCE(ingestion_date, effective_date)
+  ingestion_date = COALESCE(ingestion_date, effective_date),
+  valid_from = COALESCE(valid_from, effective_date),
+  asserted_at = COALESCE(asserted_at, ingestion_date, effective_date),
+  restated = superseded_at IS NOT NULL
 WHERE
   plan_period IS NULL
   OR plan_period = ''
   OR benchmark_version IS NULL
   OR benchmark_version = ''
-  OR ingestion_date IS NULL;
+  OR ingestion_date IS NULL
+  OR valid_from IS NULL
+  OR asserted_at IS NULL;
 
 UPDATE staging_cash_flows
 SET

--- a/src/pension_data/db/migrations/20260702_002_security_positions_bitemporal.sql
+++ b/src/pension_data/db/migrations/20260702_002_security_positions_bitemporal.sql
@@ -23,3 +23,38 @@ WHERE asserted_at IS NULL;
 
 CREATE INDEX IF NOT EXISTS idx_plan_security_positions_bitemporal
     ON plan_security_positions(plan_id, security_id, valid_from, asserted_at, superseded_at);
+
+CREATE TRIGGER IF NOT EXISTS trg_plan_security_positions_no_active_overlap_insert
+BEFORE INSERT ON plan_security_positions
+WHEN NEW.superseded_at IS NULL
+BEGIN
+    SELECT RAISE(ABORT, 'active valid-time overlap for plan_security_positions')
+    WHERE EXISTS (
+        SELECT 1
+        FROM plan_security_positions existing
+        WHERE existing.plan_id = NEW.plan_id
+          AND existing.security_id = NEW.security_id
+          AND existing.source = NEW.source
+          AND existing.superseded_at IS NULL
+          AND COALESCE(existing.valid_to, '9999-12-31T23:59:59Z') > NEW.valid_from
+          AND COALESCE(NEW.valid_to, '9999-12-31T23:59:59Z') > existing.valid_from
+    );
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_plan_security_positions_no_active_overlap_update
+BEFORE UPDATE ON plan_security_positions
+WHEN NEW.superseded_at IS NULL
+BEGIN
+    SELECT RAISE(ABORT, 'active valid-time overlap for plan_security_positions')
+    WHERE EXISTS (
+        SELECT 1
+        FROM plan_security_positions existing
+        WHERE existing.rowid != OLD.rowid
+          AND existing.plan_id = NEW.plan_id
+          AND existing.security_id = NEW.security_id
+          AND existing.source = NEW.source
+          AND existing.superseded_at IS NULL
+          AND COALESCE(existing.valid_to, '9999-12-31T23:59:59Z') > NEW.valid_from
+          AND COALESCE(NEW.valid_to, '9999-12-31T23:59:59Z') > existing.valid_from
+    );
+END;

--- a/src/pension_data/db/models/core_facts.py
+++ b/src/pension_data/db/models/core_facts.py
@@ -72,7 +72,7 @@ class BitemporalFactContext:
     @property
     def is_restated(self) -> bool:
         """Whether this fact row has been superseded by a later assertion."""
-        return self.superseded_at is not None
+        return bool(self.superseded_at and self.superseded_at.strip())
 
 
 class _HasBitemporalContext(Protocol):
@@ -93,6 +93,13 @@ def _parse_iso_temporal(value: str, *, field_name: str) -> datetime:
     if parsed.tzinfo is None or parsed.tzinfo.utcoffset(parsed) is None:
         return parsed.replace(tzinfo=UTC)
     return parsed.astimezone(UTC)
+
+
+def _nonblank(value: str | None) -> str | None:
+    if value is None:
+        return None
+    candidate = value.strip()
+    return candidate or None
 
 
 @dataclass(frozen=True, slots=True)
@@ -220,19 +227,21 @@ def query_bitemporal_as_of[TFact: _HasBitemporalContext](
         )
         if row_effective > as_of_effective or row_ingestion > as_of_ingestion:
             continue
+        valid_to = _nonblank(row.context.valid_to)
         if (
-            row.context.valid_to is not None
+            valid_to is not None
             and _parse_iso_temporal(
-                row.context.valid_to,
+                valid_to,
                 field_name="row.context.valid_to",
             )
             <= as_of_effective
         ):
             continue
+        superseded_at = _nonblank(row.context.superseded_at)
         if (
-            row.context.superseded_at is not None
+            superseded_at is not None
             and _parse_iso_temporal(
-                row.context.superseded_at,
+                superseded_at,
                 field_name="row.context.superseded_at",
             )
             <= as_of_ingestion

--- a/src/pension_data/db/models/core_facts.py
+++ b/src/pension_data/db/models/core_facts.py
@@ -54,6 +54,25 @@ class BitemporalFactContext:
     ingestion_date: str
     benchmark_version: str
     source_document_id: str
+    valid_from: str | None = None
+    valid_to: str | None = None
+    asserted_at: str | None = None
+    superseded_at: str | None = None
+
+    @property
+    def resolved_valid_from(self) -> str:
+        """Valid-time start, defaulting to the effective date for legacy rows."""
+        return self.valid_from or self.effective_date
+
+    @property
+    def resolved_asserted_at(self) -> str:
+        """Assertion-time start, defaulting to the ingestion date for legacy rows."""
+        return self.asserted_at or self.ingestion_date
+
+    @property
+    def is_restated(self) -> bool:
+        """Whether this fact row has been superseded by a later assertion."""
+        return self.superseded_at is not None
 
 
 class _HasBitemporalContext(Protocol):
@@ -192,15 +211,34 @@ def query_bitemporal_as_of[TFact: _HasBitemporalContext](
     eligible_rows: list[TFact] = []
     for row in facts:
         row_effective = _parse_iso_temporal(
-            row.context.effective_date,
-            field_name="row.context.effective_date",
+            row.context.resolved_valid_from,
+            field_name="row.context.valid_from",
         )
         row_ingestion = _parse_iso_temporal(
-            row.context.ingestion_date,
-            field_name="row.context.ingestion_date",
+            row.context.resolved_asserted_at,
+            field_name="row.context.asserted_at",
         )
-        if row_effective <= as_of_effective and row_ingestion <= as_of_ingestion:
-            eligible_rows.append(row)
+        if row_effective > as_of_effective or row_ingestion > as_of_ingestion:
+            continue
+        if (
+            row.context.valid_to is not None
+            and _parse_iso_temporal(
+                row.context.valid_to,
+                field_name="row.context.valid_to",
+            )
+            <= as_of_effective
+        ):
+            continue
+        if (
+            row.context.superseded_at is not None
+            and _parse_iso_temporal(
+                row.context.superseded_at,
+                field_name="row.context.superseded_at",
+            )
+            <= as_of_ingestion
+        ):
+            continue
+        eligible_rows.append(row)
 
     return sorted(
         eligible_rows,

--- a/src/pension_data/db/staging_persistence.py
+++ b/src/pension_data/db/staging_persistence.py
@@ -58,7 +58,7 @@ def _row_values(row: Mapping[str, object]) -> tuple[object, ...]:
         elif column == "asserted_at":
             values.append(raw_value or row.get("ingestion_date"))
         elif column == "restated":
-            values.append(int(bool(raw_value or row.get("superseded_at"))))
+            values.append(bool(raw_value or row.get("superseded_at")))
         else:
             values.append(raw_value)
     return tuple(values)

--- a/src/pension_data/db/staging_persistence.py
+++ b/src/pension_data/db/staging_persistence.py
@@ -26,6 +26,11 @@ _STAGING_CORE_METRIC_COLUMNS: tuple[str, ...] = (
     "evidence_refs",
     "effective_date",
     "ingestion_date",
+    "valid_from",
+    "valid_to",
+    "asserted_at",
+    "superseded_at",
+    "restated",
     "benchmark_version",
     "source_document_id",
 )
@@ -48,6 +53,12 @@ def _row_values(row: Mapping[str, object]) -> tuple[object, ...]:
         raw_value = row.get(column)
         if column == "evidence_refs":
             values.append(_serialize_evidence_refs(raw_value))
+        elif column == "valid_from":
+            values.append(raw_value or row.get("effective_date"))
+        elif column == "asserted_at":
+            values.append(raw_value or row.get("ingestion_date"))
+        elif column == "restated":
+            values.append(int(bool(raw_value or row.get("superseded_at"))))
         else:
             values.append(raw_value)
     return tuple(values)

--- a/src/pension_data/extract/persistence.py
+++ b/src/pension_data/extract/persistence.py
@@ -53,6 +53,11 @@ STAGING_CORE_METRICS_COLUMNS: tuple[str, ...] = (
     "evidence_refs",
     "effective_date",
     "ingestion_date",
+    "valid_from",
+    "valid_to",
+    "asserted_at",
+    "superseded_at",
+    "restated",
     "benchmark_version",
     "source_document_id",
 )

--- a/src/pension_data/query/metric_history_service.py
+++ b/src/pension_data/query/metric_history_service.py
@@ -52,6 +52,11 @@ class MetricHistoryRow:
     report_id: str
     source_document_id: str
     provenance_refs: tuple[MetricHistoryProvenanceRef, ...]
+    valid_from: str = ""
+    asserted_at: str = ""
+    valid_to: str | None = None
+    superseded_at: str | None = None
+    is_restated: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -148,6 +153,11 @@ def build_metric_history_rows(
                     source_document_id=funded_fact.context.source_document_id,
                     evidence_refs=funded_fact.evidence_refs,
                 ),
+                valid_from=funded_fact.context.resolved_valid_from,
+                valid_to=funded_fact.context.valid_to,
+                asserted_at=funded_fact.context.resolved_asserted_at,
+                superseded_at=funded_fact.context.superseded_at,
+                is_restated=funded_fact.context.is_restated,
             )
         )
 
@@ -173,6 +183,11 @@ def build_metric_history_rows(
                     source_document_id=actuarial_fact.context.source_document_id,
                     evidence_refs=actuarial_fact.evidence_refs,
                 ),
+                valid_from=actuarial_fact.context.resolved_valid_from,
+                valid_to=actuarial_fact.context.valid_to,
+                asserted_at=actuarial_fact.context.resolved_asserted_at,
+                superseded_at=actuarial_fact.context.superseded_at,
+                is_restated=actuarial_fact.context.is_restated,
             )
         )
 
@@ -198,6 +213,11 @@ def build_metric_history_rows(
                     source_document_id=allocation_fact.context.source_document_id,
                     evidence_refs=allocation_fact.evidence_refs,
                 ),
+                valid_from=allocation_fact.context.resolved_valid_from,
+                valid_to=allocation_fact.context.valid_to,
+                asserted_at=allocation_fact.context.resolved_asserted_at,
+                superseded_at=allocation_fact.context.superseded_at,
+                is_restated=allocation_fact.context.is_restated,
             )
         )
 
@@ -223,6 +243,11 @@ def build_metric_history_rows(
                     source_document_id=holding_fact.context.source_document_id,
                     evidence_refs=holding_fact.evidence_refs,
                 ),
+                valid_from=holding_fact.context.resolved_valid_from,
+                valid_to=holding_fact.context.valid_to,
+                asserted_at=holding_fact.context.resolved_asserted_at,
+                superseded_at=holding_fact.context.superseded_at,
+                is_restated=holding_fact.context.is_restated,
             )
         )
 
@@ -248,6 +273,11 @@ def build_metric_history_rows(
                     source_document_id=fee_fact.context.source_document_id,
                     evidence_refs=fee_fact.evidence_refs,
                 ),
+                valid_from=fee_fact.context.resolved_valid_from,
+                valid_to=fee_fact.context.valid_to,
+                asserted_at=fee_fact.context.resolved_asserted_at,
+                superseded_at=fee_fact.context.superseded_at,
+                is_restated=fee_fact.context.is_restated,
             )
         )
 

--- a/tests/db/test_bitemporal.py
+++ b/tests/db/test_bitemporal.py
@@ -241,3 +241,31 @@ def test_security_position_migration_rejects_active_overlaps() -> None:
             f"INSERT INTO plan_security_positions ({', '.join(columns)}) VALUES ({placeholders})",
             tuple(overlapping.values()),
         )
+
+    superseded_overlap = dict(overlapping)
+    superseded_overlap["provenance_ref"] = "13f:superseded"
+    superseded_overlap["superseded_at"] = "2025-05-20T00:00:00Z"
+    connection.execute(
+        f"INSERT INTO plan_security_positions ({', '.join(columns)}) VALUES ({placeholders})",
+        tuple(superseded_overlap.values()),
+    )
+
+    non_overlapping = dict(base_row)
+    non_overlapping["provenance_ref"] = "13f:next-quarter"
+    non_overlapping["valid_from"] = "2025-07-01"
+    non_overlapping["valid_to"] = "2025-09-30"
+    non_overlapping["asserted_at"] = "2025-08-15T00:00:00Z"
+    connection.execute(
+        f"INSERT INTO plan_security_positions ({', '.join(columns)}) VALUES ({placeholders})",
+        tuple(non_overlapping.values()),
+    )
+
+    with pytest.raises(sqlite3.IntegrityError, match="active valid-time overlap"):
+        connection.execute(
+            """
+            UPDATE plan_security_positions
+            SET valid_from = ?, valid_to = ?
+            WHERE provenance_ref = ?
+            """,
+            ("2025-04-15", "2025-05-15", "13f:next-quarter"),
+        )

--- a/tests/db/test_bitemporal.py
+++ b/tests/db/test_bitemporal.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import sqlite3
+from pathlib import Path
+
 import pytest
 
 from pension_data.db.models.bitemporal import (
@@ -181,4 +184,60 @@ def test_supersede_assertions_rejects_invalid_superseded_at() -> None:
             ],
             key=lambda row: (row.entity_id, row.fact_name),
             superseded_at="not-a-date",
+        )
+
+
+def test_security_position_migration_rejects_active_overlaps() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    connection = sqlite3.connect(":memory:")
+    connection.executescript(
+        (
+            repo_root / "src/pension_data/db/migrations/20260702_001_security_positions.sql"
+        ).read_text(encoding="utf-8")
+    )
+    connection.executescript(
+        (
+            repo_root
+            / "src/pension_data/db/migrations/20260702_002_security_positions_bitemporal.sql"
+        ).read_text(encoding="utf-8")
+    )
+    base_row = {
+        "plan_id": "CA-PERS",
+        "plan_period": "FY2025",
+        "security_id": "cusip:037833100",
+        "security_name": "APPLE INC",
+        "cusip": "037833100",
+        "ticker": None,
+        "shares": 2500.0,
+        "market_value_usd": 1_250_000.0,
+        "asset_class": "public_equity",
+        "source": "13f",
+        "as_of": "2025-03-31",
+        "disclosure_state": "disclosed",
+        "provenance_ref": "13f:original",
+        "manager_name": None,
+        "fund_name": None,
+        "confidence": 1.0,
+        "valid_from": "2025-03-31",
+        "valid_to": "2025-06-30",
+        "asserted_at": "2025-05-15T00:00:00Z",
+        "superseded_at": None,
+        "amendment_accession": None,
+    }
+    columns = tuple(base_row)
+    placeholders = ", ".join("?" for _ in columns)
+    connection.execute(
+        f"INSERT INTO plan_security_positions ({', '.join(columns)}) VALUES ({placeholders})",
+        tuple(base_row.values()),
+    )
+
+    overlapping = dict(base_row)
+    overlapping["provenance_ref"] = "13f:amendment"
+    overlapping["valid_from"] = "2025-04-01"
+    overlapping["valid_to"] = "2025-05-01"
+    overlapping["asserted_at"] = "2025-05-16T00:00:00Z"
+    with pytest.raises(sqlite3.IntegrityError, match="active valid-time overlap"):
+        connection.execute(
+            f"INSERT INTO plan_security_positions ({', '.join(columns)}) VALUES ({placeholders})",
+            tuple(overlapping.values()),
         )

--- a/tests/query/test_metric_history.py
+++ b/tests/query/test_metric_history.py
@@ -152,6 +152,43 @@ def _seed_history_rows() -> list[MetricHistoryRow]:
     return build_metric_history_rows(funded_facts=funded_facts, actuarial_facts=actuarial_facts)
 
 
+def test_metric_history_exposes_core_fact_restatement_metadata() -> None:
+    rows = build_metric_history_rows(
+        funded_facts=(
+            FundedStatusFact(
+                context=BitemporalFactContext(
+                    plan_id="CA-PERS",
+                    plan_period="FY2024",
+                    effective_date="2024-06-30",
+                    ingestion_date="2025-01-15T00:00:00Z",
+                    valid_from="2024-06-30",
+                    valid_to="2025-06-30",
+                    asserted_at="2025-01-15T00:00:00Z",
+                    superseded_at="2025-03-01T00:00:00Z",
+                    benchmark_version="v1",
+                    source_document_id="doc:ca:2024:funded",
+                ),
+                metric_name="funded_ratio",
+                metric_value=_value(
+                    as_reported_value=79.5,
+                    normalized_value=0.795,
+                    as_reported_unit="percent",
+                    normalized_unit="ratio",
+                ),
+                confidence=0.95,
+                evidence_refs=("p.45",),
+            ),
+        )
+    )
+
+    row = rows[0]
+    assert row.valid_from == "2024-06-30"
+    assert row.valid_to == "2025-06-30"
+    assert row.asserted_at == "2025-01-15T00:00:00Z"
+    assert row.superseded_at == "2025-03-01T00:00:00Z"
+    assert row.is_restated
+
+
 def test_metric_history_returns_ordered_series_with_provenance_and_dual_values() -> None:
     rows = _seed_history_rows()
     response = query_metric_history(


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Pension facts have two independent timelines: the **as-of date** of the figure (FY2024 measurement) and the **assertion time** (when a filing/restatement told us). Actuarial restatements and holdings refilings (13F amendments) are routine. Without bitemporal modeling you can't answer "what did we believe the FY2023 funded ratio / the Q1 holdings were, as of last March, vs now," and restatements silently overwrite history. (Parent: #642; underpins holdings-over-time and benchmarking trends.)

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#642](https://github.com/stranske/Pension-Data/issues/642)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add `valid_from`/`valid_to` (as-of) and `asserted_at`/`superseded_at` (transaction-time) to the core staged metric + holdings rows; never UPDATE-in-place — insert a new assertion and close the prior.
- [ ] Add non-overlapping-period constraints + an "as-of-as-known-at" query helper (time-travel).
- [ ] Wire restatement/amendment ingestion (e.g., 13F-HR/A) to supersede rather than overwrite.
- [ ] Surface "restated" flags in the analytics outputs.

#### Acceptance criteria
- [ ] A restated metric keeps both the original and corrected assertion; a query can reproduce the pre-restatement view.
- [ ] No period overlaps for a given (plan, metric, as-of) across assertions.
- [ ] Holdings amendments (13F/A) supersede prior filings without losing history.

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why
Pension facts have two independent timelines: the **as-of date** of the figure (FY2024 measurement) and the **assertion time** (when a filing/restatement told us). Actuarial restatements and holdings refilings (13F amendments) are routine. Without bitemporal modeling you can't answer "what did we believe the FY2023 funded ratio / the Q1 holdings were, as of last March, vs now," and restatements silently overwrite history. (Parent: #642; underpins holdings-over-time and benchmarking trends.)

## Scope
Add valid-time (as-of) + transaction-time (asserted-at) to the staged fact + holdings tables, with time-travel queries.

## Non-Goals
- Do NOT retro-rewrite existing facts destructively — additive only.
- No general temporal framework; the minimal bitemporal columns + query helpers.

## Tasks
- [ ] Add `valid_from`/`valid_to` (as-of) and `asserted_at`/`superseded_at` (transaction-time) to the core staged metric + holdings rows; never UPDATE-in-place — insert a new assertion and close the prior.
- [ ] Add non-overlapping-period constraints + an "as-of-as-known-at" query helper (time-travel).
- [ ] Wire restatement/amendment ingestion (e.g., 13F-HR/A) to supersede rather than overwrite.
- [ ] Surface "restated" flags in the analytics outputs.

## Acceptance Criteria
- [ ] A restated metric keeps both the original and corrected assertion; a query can reproduce the pre-restatement view.
- [ ] No period overlaps for a given (plan, metric, as-of) across assertions.
- [ ] Holdings amendments (13F/A) supersede prior filings without losing history.

## Test gate
Gate: `tests/db/test_bitemporal.py` — insert v1, restate to v2, assert (a) as-of-then view = v1, (b) as-of-now view = v2, (c) no overlap. Deliberate-break: allow in-place UPDATE → the "as-of-then" test fails → revert.

## Implementation Notes
- Design `2026-06-28-ANALYTICS_DESIGN.md` §3/§8-E. Pattern: bitemporal (valid-time + transaction-time) modeling; ties to GASB restatement handling and 13F/A amendments noted in R2/R4.



</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
<!-- meta:issue:649 -->
> **Source:** Issue #649

Closes #649

<!-- pr-preamble:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an issue-tracking header to the agent note.
* **New Features**
  * Extended core metric staging and query outputs with bitemporal/provenance fields (validity range, assertion timestamps, and restatement status).
* **Bug Fixes**
  * Prevented overlapping “active” valid-time intervals for security position records during insert/update.
* **Tests**
  * Added database and metric-history tests to verify restatement metadata is surfaced and overlap rules are enforced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->