### PR TITLE
Close bitemporal verifier overlap gaps

### DIFF
--- a/src/pension_data/db/migrations/20260302_001_core_fact_staging.sql
+++ b/src/pension_data/db/migrations/20260302_001_core_fact_staging.sql
@@ -28,6 +28,44 @@ CREATE TABLE IF NOT EXISTS staging_core_metrics (
   source_document_id TEXT NOT NULL
 );
 
+CREATE INDEX IF NOT EXISTS idx_staging_core_metrics_bitemporal
+  ON staging_core_metrics(plan_id, metric_family, metric_name, valid_from, asserted_at, superseded_at);
+
+CREATE TRIGGER IF NOT EXISTS trg_staging_core_metrics_no_active_overlap_insert
+BEFORE INSERT ON staging_core_metrics
+WHEN NEW.superseded_at IS NULL OR TRIM(NEW.superseded_at) = ''
+BEGIN
+  SELECT RAISE(ABORT, 'active valid-time overlap for staging_core_metrics')
+  WHERE EXISTS (
+    SELECT 1
+    FROM staging_core_metrics existing
+    WHERE existing.plan_id = NEW.plan_id
+      AND existing.metric_family = NEW.metric_family
+      AND existing.metric_name = NEW.metric_name
+      AND (existing.superseded_at IS NULL OR TRIM(existing.superseded_at) = '')
+      AND COALESCE(existing.valid_to, '9999-12-31T23:59:59Z') > NEW.valid_from
+      AND COALESCE(NEW.valid_to, '9999-12-31T23:59:59Z') > existing.valid_from
+  );
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_staging_core_metrics_no_active_overlap_update
+BEFORE UPDATE ON staging_core_metrics
+WHEN NEW.superseded_at IS NULL OR TRIM(NEW.superseded_at) = ''
+BEGIN
+  SELECT RAISE(ABORT, 'active valid-time overlap for staging_core_metrics')
+  WHERE EXISTS (
+    SELECT 1
+    FROM staging_core_metrics existing
+    WHERE existing.rowid != OLD.rowid
+      AND existing.plan_id = NEW.plan_id
+      AND existing.metric_family = NEW.metric_family
+      AND existing.metric_name = NEW.metric_name
+      AND (existing.superseded_at IS NULL OR TRIM(existing.superseded_at) = '')
+      AND COALESCE(existing.valid_to, '9999-12-31T23:59:59Z') > NEW.valid_from
+      AND COALESCE(NEW.valid_to, '9999-12-31T23:59:59Z') > existing.valid_from
+  );
+END;
+
 CREATE TABLE IF NOT EXISTS staging_cash_flows (
   cash_flow_id TEXT PRIMARY KEY,
   plan_id TEXT NOT NULL,

--- a/src/pension_data/db/migrations/20260302_001_core_fact_staging.sql
+++ b/src/pension_data/db/migrations/20260302_001_core_fact_staging.sql
@@ -39,9 +39,14 @@ BEGIN
   WHERE EXISTS (
     SELECT 1
     FROM staging_core_metrics existing
-    WHERE existing.plan_id = NEW.plan_id
+    WHERE existing.fact_id != NEW.fact_id
+      AND existing.plan_id = NEW.plan_id
       AND existing.metric_family = NEW.metric_family
       AND existing.metric_name = NEW.metric_name
+      AND existing.manager_name IS NEW.manager_name
+      AND existing.fund_name IS NEW.fund_name
+      AND existing.vehicle_name IS NEW.vehicle_name
+      AND existing.relationship_completeness IS NEW.relationship_completeness
       AND (existing.superseded_at IS NULL OR TRIM(existing.superseded_at) = '')
       AND COALESCE(existing.valid_to, '9999-12-31T23:59:59Z') > NEW.valid_from
       AND COALESCE(NEW.valid_to, '9999-12-31T23:59:59Z') > existing.valid_from
@@ -60,6 +65,10 @@ BEGIN
       AND existing.plan_id = NEW.plan_id
       AND existing.metric_family = NEW.metric_family
       AND existing.metric_name = NEW.metric_name
+      AND existing.manager_name IS NEW.manager_name
+      AND existing.fund_name IS NEW.fund_name
+      AND existing.vehicle_name IS NEW.vehicle_name
+      AND existing.relationship_completeness IS NEW.relationship_completeness
       AND (existing.superseded_at IS NULL OR TRIM(existing.superseded_at) = '')
       AND COALESCE(existing.valid_to, '9999-12-31T23:59:59Z') > NEW.valid_from
       AND COALESCE(NEW.valid_to, '9999-12-31T23:59:59Z') > existing.valid_from

--- a/src/pension_data/db/migrations/20260303_101_pg_core_fact_staging.sql
+++ b/src/pension_data/db/migrations/20260303_101_pg_core_fact_staging.sql
@@ -28,6 +28,41 @@ CREATE TABLE IF NOT EXISTS staging_core_metrics (
   source_document_id TEXT NOT NULL
 );
 
+CREATE INDEX IF NOT EXISTS idx_staging_core_metrics_bitemporal
+  ON staging_core_metrics(plan_id, metric_family, metric_name, valid_from, asserted_at, superseded_at);
+
+CREATE OR REPLACE FUNCTION reject_staging_core_metrics_active_overlap()
+RETURNS trigger AS $$
+BEGIN
+  IF NEW.superseded_at IS NULL AND EXISTS (
+    SELECT 1
+    FROM staging_core_metrics existing
+    WHERE existing.fact_id <> NEW.fact_id
+      AND existing.plan_id = NEW.plan_id
+      AND existing.metric_family = NEW.metric_family
+      AND existing.metric_name = NEW.metric_name
+      AND existing.superseded_at IS NULL
+      AND COALESCE(existing.valid_to, TIMESTAMPTZ '9999-12-31 23:59:59+00') > NEW.valid_from
+      AND COALESCE(NEW.valid_to, TIMESTAMPTZ '9999-12-31 23:59:59+00') > existing.valid_from
+  ) THEN
+    RAISE EXCEPTION 'active valid-time overlap for staging_core_metrics';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_staging_core_metrics_no_active_overlap_insert
+  ON staging_core_metrics;
+CREATE TRIGGER trg_staging_core_metrics_no_active_overlap_insert
+BEFORE INSERT ON staging_core_metrics
+FOR EACH ROW EXECUTE FUNCTION reject_staging_core_metrics_active_overlap();
+
+DROP TRIGGER IF EXISTS trg_staging_core_metrics_no_active_overlap_update
+  ON staging_core_metrics;
+CREATE TRIGGER trg_staging_core_metrics_no_active_overlap_update
+BEFORE UPDATE ON staging_core_metrics
+FOR EACH ROW EXECUTE FUNCTION reject_staging_core_metrics_active_overlap();
+
 CREATE TABLE IF NOT EXISTS staging_cash_flows (
   cash_flow_id TEXT PRIMARY KEY,
   plan_id TEXT NOT NULL,

--- a/src/pension_data/db/migrations/20260303_101_pg_core_fact_staging.sql
+++ b/src/pension_data/db/migrations/20260303_101_pg_core_fact_staging.sql
@@ -39,6 +39,10 @@ ALTER TABLE staging_core_metrics
     plan_id WITH =,
     metric_family WITH =,
     metric_name WITH =,
+    (COALESCE(manager_name, '')) WITH =,
+    (COALESCE(fund_name, '')) WITH =,
+    (COALESCE(vehicle_name, '')) WITH =,
+    (COALESCE(relationship_completeness, '')) WITH =,
     tstzrange(valid_from, COALESCE(valid_to, TIMESTAMPTZ 'infinity'), '[)') WITH &&
   )
   WHERE (superseded_at IS NULL);

--- a/src/pension_data/db/migrations/20260303_101_pg_core_fact_staging.sql
+++ b/src/pension_data/db/migrations/20260303_101_pg_core_fact_staging.sql
@@ -31,37 +31,17 @@ CREATE TABLE IF NOT EXISTS staging_core_metrics (
 CREATE INDEX IF NOT EXISTS idx_staging_core_metrics_bitemporal
   ON staging_core_metrics(plan_id, metric_family, metric_name, valid_from, asserted_at, superseded_at);
 
-CREATE OR REPLACE FUNCTION reject_staging_core_metrics_active_overlap()
-RETURNS trigger AS $$
-BEGIN
-  IF NEW.superseded_at IS NULL AND EXISTS (
-    SELECT 1
-    FROM staging_core_metrics existing
-    WHERE existing.fact_id <> NEW.fact_id
-      AND existing.plan_id = NEW.plan_id
-      AND existing.metric_family = NEW.metric_family
-      AND existing.metric_name = NEW.metric_name
-      AND existing.superseded_at IS NULL
-      AND COALESCE(existing.valid_to, TIMESTAMPTZ '9999-12-31 23:59:59+00') > NEW.valid_from
-      AND COALESCE(NEW.valid_to, TIMESTAMPTZ '9999-12-31 23:59:59+00') > existing.valid_from
-  ) THEN
-    RAISE EXCEPTION 'active valid-time overlap for staging_core_metrics';
-  END IF;
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
+CREATE EXTENSION IF NOT EXISTS btree_gist;
 
-DROP TRIGGER IF EXISTS trg_staging_core_metrics_no_active_overlap_insert
-  ON staging_core_metrics;
-CREATE TRIGGER trg_staging_core_metrics_no_active_overlap_insert
-BEFORE INSERT ON staging_core_metrics
-FOR EACH ROW EXECUTE FUNCTION reject_staging_core_metrics_active_overlap();
-
-DROP TRIGGER IF EXISTS trg_staging_core_metrics_no_active_overlap_update
-  ON staging_core_metrics;
-CREATE TRIGGER trg_staging_core_metrics_no_active_overlap_update
-BEFORE UPDATE ON staging_core_metrics
-FOR EACH ROW EXECUTE FUNCTION reject_staging_core_metrics_active_overlap();
+ALTER TABLE staging_core_metrics
+  ADD CONSTRAINT staging_core_metrics_no_active_overlap
+  EXCLUDE USING gist (
+    plan_id WITH =,
+    metric_family WITH =,
+    metric_name WITH =,
+    tstzrange(valid_from, COALESCE(valid_to, TIMESTAMPTZ 'infinity'), '[)') WITH &&
+  )
+  WHERE (superseded_at IS NULL);
 
 CREATE TABLE IF NOT EXISTS staging_cash_flows (
   cash_flow_id TEXT PRIMARY KEY,

--- a/src/pension_data/db/models/bitemporal.py
+++ b/src/pension_data/db/models/bitemporal.py
@@ -32,11 +32,12 @@ class BitemporalAssertion:
     asserted_at: str
     source_document_id: str
     superseded_at: str | None = None
+    restated: bool = False
 
     @property
     def is_restated(self) -> bool:
-        """Whether a later assertion superseded this row."""
-        return self.superseded_at is not None
+        """Whether this row participates in a restatement chain."""
+        return self.restated or self.superseded_at is not None
 
 
 def _within_valid_window(row: BitemporalRow, valid_at: datetime) -> bool:
@@ -62,6 +63,15 @@ def _known_at(row: BitemporalRow, known_at: datetime) -> bool:
 def _copy_with_superseded_at[T: BitemporalRow](row: T, superseded_at: str) -> T:
     updated = copy(row)
     object.__setattr__(updated, "superseded_at", superseded_at)
+    if hasattr(updated, "restated"):
+        object.__setattr__(updated, "restated", True)
+    return updated
+
+
+def _copy_with_restated_flag[T: BitemporalRow](row: T) -> T:
+    updated = copy(row)
+    if hasattr(updated, "restated"):
+        object.__setattr__(updated, "restated", True)
     return updated
 
 
@@ -134,10 +144,19 @@ def supersede_assertions[T: BitemporalRow, K: object](
     _parse_iso_temporal(superseded_at, field_name="superseded_at")
     replacement_list = list(replacement_rows)
     replacement_keys = {key(row) for row in replacement_list}
+    active_existing_keys = {
+        key(row)
+        for row in existing_rows
+        if key(row) in replacement_keys and row.superseded_at is None
+    }
     updated_existing: list[T] = []
     for row in existing_rows:
         if key(row) in replacement_keys and row.superseded_at is None:
             updated_existing.append(_copy_with_superseded_at(row, superseded_at))
         else:
             updated_existing.append(row)
-    return [*updated_existing, *replacement_list]
+    updated_replacements = [
+        _copy_with_restated_flag(row) if key(row) in active_existing_keys else row
+        for row in replacement_list
+    ]
+    return [*updated_existing, *updated_replacements]

--- a/src/pension_data/db/models/bitemporal.py
+++ b/src/pension_data/db/models/bitemporal.py
@@ -144,11 +144,11 @@ def supersede_assertions[T: BitemporalRow, K: object](
     _parse_iso_temporal(superseded_at, field_name="superseded_at")
     replacement_list = list(replacement_rows)
     replacement_keys = {key(row) for row in replacement_list}
-    active_existing_keys = {
-        key(row)
-        for row in existing_rows
-        if key(row) in replacement_keys and row.superseded_at is None
-    }
+    active_existing_keys = set()
+    for row in existing_rows:
+        row_key = key(row)
+        if row_key in replacement_keys and row.superseded_at is None:
+            active_existing_keys.add(row_key)
     updated_existing: list[T] = []
     for row in existing_rows:
         if key(row) in replacement_keys and row.superseded_at is None:

--- a/src/pension_data/db/models/investment_positions.py
+++ b/src/pension_data/db/models/investment_positions.py
@@ -71,8 +71,8 @@ class PlanSecurityPosition:
 
     @property
     def is_restated(self) -> bool:
-        """Whether this position was superseded by a later amendment/assertion."""
-        return self.superseded_at is not None
+        """Whether this position participates in an amendment/restatement chain."""
+        return self.superseded_at is not None or self.amendment_accession is not None
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/db/test_bitemporal.py
+++ b/tests/db/test_bitemporal.py
@@ -148,6 +148,7 @@ def test_13f_amendment_supersedes_security_position_without_losing_history() -> 
     assert [row.market_value_usd for row in before_amendment] == [1_250_000.0]
     assert [row.market_value_usd for row in after_amendment] == [1_300_000.0]
     assert rows[0].is_restated
+    assert rows[1].is_restated
     assert rows[1].amendment_accession == "0000919079-25-000001/A"
     assert_no_active_valid_overlaps(
         rows,
@@ -269,3 +270,77 @@ def test_security_position_migration_rejects_active_overlaps() -> None:
             """,
             ("2025-04-15", "2025-05-15", "13f:next-quarter"),
         )
+
+
+def test_core_metric_migration_rejects_active_overlaps() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    connection = sqlite3.connect(":memory:")
+    connection.executescript(
+        (repo_root / "src/pension_data/db/migrations/20260302_001_core_fact_staging.sql").read_text(
+            encoding="utf-8"
+        )
+    )
+    base_row = {
+        "fact_id": "metric:v1",
+        "plan_id": "CA-PERS",
+        "plan_period": "FY2025",
+        "metric_family": "funded_status",
+        "metric_name": "funded_ratio",
+        "as_reported_value": 74.0,
+        "normalized_value": 0.74,
+        "as_reported_unit": "percent",
+        "normalized_unit": "ratio",
+        "manager_name": None,
+        "fund_name": None,
+        "vehicle_name": None,
+        "relationship_completeness": None,
+        "confidence": 0.9,
+        "evidence_refs": "[]",
+        "effective_date": "2024-06-30",
+        "ingestion_date": "2025-01-15T00:00:00Z",
+        "valid_from": "2024-06-30",
+        "valid_to": "2025-06-30",
+        "asserted_at": "2025-01-15T00:00:00Z",
+        "superseded_at": None,
+        "restated": 0,
+        "benchmark_version": "v1",
+        "source_document_id": "doc:original",
+    }
+    columns = tuple(base_row)
+    placeholders = ", ".join("?" for _ in columns)
+    connection.execute(
+        f"INSERT INTO staging_core_metrics ({', '.join(columns)}) VALUES ({placeholders})",
+        tuple(base_row.values()),
+    )
+
+    overlapping = dict(base_row)
+    overlapping["fact_id"] = "metric:overlap"
+    overlapping["source_document_id"] = "doc:overlap"
+    overlapping["valid_from"] = "2025-01-01"
+    overlapping["asserted_at"] = "2025-02-01T00:00:00Z"
+    with pytest.raises(sqlite3.IntegrityError, match="active valid-time overlap"):
+        connection.execute(
+            f"INSERT INTO staging_core_metrics ({', '.join(columns)}) VALUES ({placeholders})",
+            tuple(overlapping.values()),
+        )
+
+    superseded_overlap = dict(overlapping)
+    superseded_overlap["fact_id"] = "metric:superseded"
+    superseded_overlap["source_document_id"] = "doc:superseded"
+    superseded_overlap["superseded_at"] = "2025-03-01T00:00:00Z"
+    superseded_overlap["restated"] = 1
+    connection.execute(
+        f"INSERT INTO staging_core_metrics ({', '.join(columns)}) VALUES ({placeholders})",
+        tuple(superseded_overlap.values()),
+    )
+
+    next_period = dict(base_row)
+    next_period["fact_id"] = "metric:next-period"
+    next_period["source_document_id"] = "doc:next-period"
+    next_period["valid_from"] = "2025-06-30"
+    next_period["valid_to"] = "2026-06-30"
+    next_period["asserted_at"] = "2026-01-15T00:00:00Z"
+    connection.execute(
+        f"INSERT INTO staging_core_metrics ({', '.join(columns)}) VALUES ({placeholders})",
+        tuple(next_period.values()),
+    )

--- a/tests/db/test_bitemporal.py
+++ b/tests/db/test_bitemporal.py
@@ -344,3 +344,27 @@ def test_core_metric_migration_rejects_active_overlaps() -> None:
         f"INSERT INTO staging_core_metrics ({', '.join(columns)}) VALUES ({placeholders})",
         tuple(next_period.values()),
     )
+
+    different_manager = dict(overlapping)
+    different_manager["fact_id"] = "metric:manager-b"
+    different_manager["metric_family"] = "holding"
+    different_manager["metric_name"] = "market_value"
+    different_manager["manager_name"] = "Manager B"
+    different_manager["fund_name"] = "Fund B"
+    different_manager["vehicle_name"] = "Vehicle B"
+    different_manager["relationship_completeness"] = "complete"
+    different_manager["source_document_id"] = "doc:manager-b"
+    connection.execute(
+        f"INSERT INTO staging_core_metrics ({', '.join(columns)}) VALUES ({placeholders})",
+        tuple(different_manager.values()),
+    )
+
+    with pytest.raises(sqlite3.IntegrityError, match="active valid-time overlap"):
+        connection.execute(
+            """
+            UPDATE staging_core_metrics
+            SET valid_from = ?, valid_to = ?
+            WHERE fact_id = ?
+            """,
+            ("2025-01-01", "2025-12-31", "metric:next-period"),
+        )


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:649 -->
> **Source:** Issue #649

Closes #649

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Pension facts have two independent timelines: the **as-of date** of the figure (FY2024 measurement) and the **assertion time** (when a filing/restatement told us). Actuarial restatements and holdings refilings (13F amendments) are routine. Without bitemporal modeling you can't answer "what did we believe the FY2023 funded ratio / the Q1 holdings were, as of last March, vs now," and restatements silently overwrite history. (Parent: #642; underpins holdings-over-time and benchmarking trends.)

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#642](https://github.com/stranske/Pension-Data/issues/642)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add `valid_from`/`valid_to` (as-of) and `asserted_at`/`superseded_at` (transaction-time) to the core staged metric + holdings rows; never UPDATE-in-place — insert a new assertion and close the prior.
- [ ] Add non-overlapping-period constraints + an "as-of-as-known-at" query helper (time-travel).
- [ ] Wire restatement/amendment ingestion (e.g., 13F-HR/A) to supersede rather than overwrite.
- [ ] Surface "restated" flags in the analytics outputs.

#### Acceptance criteria
- [ ] A restated metric keeps both the original and corrected assertion; a query can reproduce the pre-restatement view.
- [ ] No period overlaps for a given (plan, metric, as-of) across assertions.
- [ ] Holdings amendments (13F/A) supersede prior filings without losing history.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger support for tracking restated records in bitemporal data.
  * Improved handling of amendment chains for security positions.

* **Bug Fixes**
  * Prevented overlapping active metric records from being saved.
  * Allowed overlapping records when they are properly superseded.
  * Improved consistency when replacing existing assertions so restated entries are marked correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->