### PR TITLE
Preserve additive core metric assertions

### DIFF
--- a/src/pension_data/db/staging_persistence.py
+++ b/src/pension_data/db/staging_persistence.py
@@ -78,14 +78,14 @@ def persist_staging_core_metrics(
         "%s" if dialect == "postgresql" else "?" for _ in _STAGING_CORE_METRIC_COLUMNS
     )
     columns = ", ".join(_STAGING_CORE_METRIC_COLUMNS)
-    update_columns = [column for column in _STAGING_CORE_METRIC_COLUMNS if column != "fact_id"]
-    update_clause = ", ".join(f"{column}=excluded.{column}" for column in update_columns)
     sql = (
         f"INSERT INTO staging_core_metrics ({columns}) VALUES ({placeholders}) "
-        f"ON CONFLICT (fact_id) DO UPDATE SET {update_clause}"
+        "ON CONFLICT (fact_id) DO NOTHING"
     )
 
+    inserted = 0
     for row in rows:
-        connection.execute(sql, _row_values(row))
+        cursor = connection.execute(sql, _row_values(row))
+        inserted += max(cursor.rowcount, 0)
     connection.commit()
-    return len(rows)
+    return inserted

--- a/tests/db/test_staging_persistence.py
+++ b/tests/db/test_staging_persistence.py
@@ -9,7 +9,7 @@ from pension_data.db.staging_persistence import persist_staging_core_metrics
 from pension_data.db.strategy import connect_database, resolve_database_config
 
 
-def test_persist_staging_core_metrics_upserts_rows_in_sqlite() -> None:
+def test_persist_staging_core_metrics_keeps_existing_assertion_in_sqlite() -> None:
     config = resolve_database_config(database_url="sqlite:///:memory:")
     connection = connect_database(config)
     try:
@@ -41,7 +41,7 @@ def test_persist_staging_core_metrics_upserts_rows_in_sqlite() -> None:
                 }
             ],
         )
-        _updated = persist_staging_core_metrics(
+        duplicate = persist_staging_core_metrics(
             connection,
             dialect="sqlite",
             rows=[
@@ -76,6 +76,7 @@ def test_persist_staging_core_metrics_upserts_rows_in_sqlite() -> None:
         connection.close()
 
     assert inserted == 1
+    assert duplicate == 0
     assert row is not None
-    assert row[0] == 0.79
-    assert json.loads(row[1]) == ["p.41"]
+    assert row[0] == 0.784
+    assert json.loads(row[1]) == ["p.40"]


### PR DESCRIPTION
Closes #649

## Summary
- keep `persist_staging_core_metrics()` additive by using `ON CONFLICT (fact_id) DO NOTHING` instead of updating existing assertion rows
- return the actual inserted row count so duplicate facts are visible to callers
- update the SQLite regression to prove duplicate `fact_id` writes leave the original assertion value/evidence intact

## Verifier disposition
Current-main audit after #679 showed most provider concerns are already satisfied: bitemporal/as-known-at helpers, holdings bitemporal columns/triggers, 13F amendment supersession tests, and metric-history restated output are present. The remaining bounded gap was the persistence helper still allowing an in-place conflict update by `fact_id`, contrary to the additive assertion requirement.

## Validation
- `PYTHONPYCACHEPREFIX=/tmp/pycache-pension-649-followup2 /opt/anaconda3/bin/python3.12 -m pytest tests/db/test_staging_persistence.py tests/db/test_bitemporal.py tests/query/test_metric_history.py -q` -> 14 passed
- `/opt/anaconda3/bin/python3.12 -m ruff check src/pension_data/db/staging_persistence.py tests/db/test_staging_persistence.py` -> passed
- `/opt/anaconda3/bin/python3.12 -m black --check --line-length 100 --target-version py312 --exclude '(\\.workflows-lib|node_modules)' src/pension_data/db/staging_persistence.py tests/db/test_staging_persistence.py` -> passed
- `PYTHONPYCACHEPREFIX=/tmp/pycache-pension-649-followup2-mypy /opt/anaconda3/bin/python3.12 -m mypy src/pension_data/db/staging_persistence.py tests/db/test_staging_persistence.py` -> success
- `git diff --check` -> passed

<!-- pr-preamble:start -->
<!-- meta:issue:649 -->
> **Source:** Issue #649

Closes #649

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Pension facts have two independent timelines: the **as-of date** of the figure (FY2024 measurement) and the **assertion time** (when a filing/restatement told us). Actuarial restatements and holdings refilings (13F amendments) are routine. Without bitemporal modeling you can't answer "what did we believe the FY2023 funded ratio / the Q1 holdings were, as of last March, vs now," and restatements silently overwrite history. (Parent: #642; underpins holdings-over-time and benchmarking trends.)

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#642](https://github.com/stranske/Pension-Data/issues/642)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add `valid_from`/`valid_to` (as-of) and `asserted_at`/`superseded_at` (transaction-time) to the core staged metric + holdings rows; never UPDATE-in-place — insert a new assertion and close the prior.
- [ ] Add non-overlapping-period constraints + an "as-of-as-known-at" query helper (time-travel).
- [ ] Wire restatement/amendment ingestion (e.g., 13F-HR/A) to supersede rather than overwrite.
- [ ] Surface "restated" flags in the analytics outputs.

#### Acceptance criteria
- [ ] A restated metric keeps both the original and corrected assertion; a query can reproduce the pre-restatement view.
- [ ] No period overlaps for a given (plan, metric, as-of) across assertions.
- [ ] Holdings amendments (13F/A) supersede prior filings without losing history.

<!-- auto-status-summary:end -->