### PR TITLE
Preserve corrected core metric assertions

### DIFF
--- a/src/pension_data/db/staging_persistence.py
+++ b/src/pension_data/db/staging_persistence.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping, Sequence
+from hashlib import sha1
 from typing import Any
 
 from pension_data.db.strategy import DatabaseDialect
@@ -64,6 +65,34 @@ def _row_values(row: Mapping[str, object]) -> tuple[object, ...]:
     return tuple(values)
 
 
+def _placeholder(dialect: DatabaseDialect) -> str:
+    return "%s" if dialect == "postgresql" else "?"
+
+
+def _replacement_fact_id(row: Mapping[str, object]) -> str:
+    asserted_at = row.get("asserted_at") or row.get("ingestion_date") or ""
+    digest_payload = json.dumps(
+        {key: row.get(key) for key in _STAGING_CORE_METRIC_COLUMNS if key != "fact_id"},
+        default=str,
+        sort_keys=True,
+    )
+    digest = sha1(digest_payload.encode("utf-8")).hexdigest()[:12]
+    return f"{row['fact_id']}@{asserted_at}:{digest}"
+
+
+def _same_assertion(existing: Any, candidate_values: tuple[object, ...]) -> bool:
+    return all(existing[index] == candidate for index, candidate in enumerate(candidate_values))
+
+
+def _same_assertion_source(existing: Any, candidate_values: tuple[object, ...]) -> bool:
+    asserted_at_index = _STAGING_CORE_METRIC_COLUMNS.index("asserted_at")
+    source_document_id_index = _STAGING_CORE_METRIC_COLUMNS.index("source_document_id")
+    return bool(
+        existing[asserted_at_index] == candidate_values[asserted_at_index]
+        and existing[source_document_id_index] == candidate_values[source_document_id_index]
+    )
+
+
 def persist_staging_core_metrics(
     connection: Any,
     *,
@@ -74,18 +103,53 @@ def persist_staging_core_metrics(
     if not rows:
         return 0
 
-    placeholders = ", ".join(
-        "%s" if dialect == "postgresql" else "?" for _ in _STAGING_CORE_METRIC_COLUMNS
-    )
+    placeholder = _placeholder(dialect)
+    placeholders = ", ".join(placeholder for _ in _STAGING_CORE_METRIC_COLUMNS)
     columns = ", ".join(_STAGING_CORE_METRIC_COLUMNS)
     sql = (
         f"INSERT INTO staging_core_metrics ({columns}) VALUES ({placeholders}) "
         "ON CONFLICT (fact_id) DO NOTHING"
     )
+    select_sql = f"SELECT {columns} FROM staging_core_metrics WHERE fact_id = {placeholder}"
+    update_sql = (
+        "UPDATE staging_core_metrics "
+        f"SET superseded_at = {placeholder}, restated = {placeholder} "
+        f"WHERE fact_id = {placeholder} AND (superseded_at IS NULL OR TRIM(CAST(superseded_at AS TEXT)) = '')"
+    )
 
     inserted = 0
     for row in rows:
-        cursor = connection.execute(sql, _row_values(row))
-        inserted += max(cursor.rowcount, 0)
+        candidate_values = _row_values(row)
+        existing = connection.execute(select_sql, (row["fact_id"],)).fetchone()
+        if existing is not None:
+            if _same_assertion(existing, candidate_values) or _same_assertion_source(
+                existing,
+                candidate_values,
+            ):
+                continue
+
+            replacement = dict(row)
+            replacement["fact_id"] = _replacement_fact_id(row)
+            replacement["restated"] = True
+            replacement_values = _row_values(replacement)
+            existing_replacement = connection.execute(
+                select_sql,
+                (replacement["fact_id"],),
+            ).fetchone()
+            if existing_replacement is not None:
+                if _same_assertion(existing_replacement, replacement_values):
+                    continue
+                raise ValueError(f"conflicting assertion already exists for {row['fact_id']!r}")
+
+            asserted_at_index = _STAGING_CORE_METRIC_COLUMNS.index("asserted_at")
+            superseded_at = candidate_values[asserted_at_index]
+            connection.execute(update_sql, (superseded_at, True, row["fact_id"]))
+            replacement_cursor = connection.execute(sql, replacement_values)
+            inserted += max(replacement_cursor.rowcount, 0)
+            continue
+
+        cursor = connection.execute(sql, candidate_values)
+        rowcount = max(cursor.rowcount, 0)
+        inserted += rowcount
     connection.commit()
     return inserted

--- a/src/pension_data/db/staging_persistence.py
+++ b/src/pension_data/db/staging_persistence.py
@@ -110,28 +110,42 @@ def persist_staging_core_metrics(
         f"INSERT INTO staging_core_metrics ({columns}) VALUES ({placeholders}) "
         "ON CONFLICT (fact_id) DO NOTHING"
     )
+    active_clause = "(superseded_at IS NULL OR TRIM(CAST(superseded_at AS TEXT)) = '')"
     select_sql = f"SELECT {columns} FROM staging_core_metrics WHERE fact_id = {placeholder}"
+    select_active_sql = (
+        f"SELECT {columns} FROM staging_core_metrics "
+        f"WHERE (fact_id = {placeholder} OR fact_id LIKE {placeholder}) AND {active_clause} "
+        f"ORDER BY CASE WHEN fact_id = {placeholder} THEN 0 ELSE 1 END, asserted_at DESC, fact_id DESC "
+        "LIMIT 1"
+    )
     update_sql = (
         "UPDATE staging_core_metrics "
         f"SET superseded_at = {placeholder}, restated = {placeholder} "
-        f"WHERE fact_id = {placeholder} AND (superseded_at IS NULL OR TRIM(CAST(superseded_at AS TEXT)) = '')"
+        f"WHERE (fact_id = {placeholder} OR fact_id LIKE {placeholder}) AND {active_clause}"
     )
 
     inserted = 0
     for row in rows:
         candidate_values = _row_values(row)
-        existing = connection.execute(select_sql, (row["fact_id"],)).fetchone()
+        fact_id = str(row["fact_id"])
+        fact_id_pattern = f"{fact_id}@%"
+        existing = connection.execute(
+            select_active_sql,
+            (fact_id, fact_id_pattern, fact_id),
+        ).fetchone()
         if existing is not None:
-            if _same_assertion(existing, candidate_values) or _same_assertion_source(
-                existing,
-                candidate_values,
-            ):
-                continue
-
             replacement = dict(row)
             replacement["fact_id"] = _replacement_fact_id(row)
             replacement["restated"] = True
             replacement_values = _row_values(replacement)
+            if _same_assertion(existing, candidate_values) or _same_assertion(
+                existing,
+                replacement_values,
+            ):
+                continue
+            if _same_assertion_source(existing, candidate_values):
+                raise ValueError(f"conflicting assertion source for {fact_id!r}")
+
             existing_replacement = connection.execute(
                 select_sql,
                 (replacement["fact_id"],),
@@ -143,7 +157,7 @@ def persist_staging_core_metrics(
 
             asserted_at_index = _STAGING_CORE_METRIC_COLUMNS.index("asserted_at")
             superseded_at = candidate_values[asserted_at_index]
-            connection.execute(update_sql, (superseded_at, True, row["fact_id"]))
+            connection.execute(update_sql, (superseded_at, True, fact_id, fact_id_pattern))
             replacement_cursor = connection.execute(sql, replacement_values)
             inserted += max(replacement_cursor.rowcount, 0)
             continue

--- a/src/pension_data/db/staging_persistence.py
+++ b/src/pension_data/db/staging_persistence.py
@@ -125,45 +125,49 @@ def persist_staging_core_metrics(
     )
 
     inserted = 0
-    for row in rows:
-        candidate_values = _row_values(row)
-        fact_id = str(row["fact_id"])
-        fact_id_pattern = f"{fact_id}@%"
-        existing = connection.execute(
-            select_active_sql,
-            (fact_id, fact_id_pattern, fact_id),
-        ).fetchone()
-        if existing is not None:
-            replacement = dict(row)
-            replacement["fact_id"] = _replacement_fact_id(row)
-            replacement["restated"] = True
-            replacement_values = _row_values(replacement)
-            if _same_assertion(existing, candidate_values) or _same_assertion(
-                existing,
-                replacement_values,
-            ):
-                continue
-            if _same_assertion_source(existing, candidate_values):
-                raise ValueError(f"conflicting assertion source for {fact_id!r}")
-
-            existing_replacement = connection.execute(
-                select_sql,
-                (replacement["fact_id"],),
+    try:
+        for row in rows:
+            candidate_values = _row_values(row)
+            fact_id = str(row["fact_id"])
+            fact_id_pattern = f"{fact_id}@%"
+            existing = connection.execute(
+                select_active_sql,
+                (fact_id, fact_id_pattern, fact_id),
             ).fetchone()
-            if existing_replacement is not None:
-                if _same_assertion(existing_replacement, replacement_values):
+            if existing is not None:
+                replacement = dict(row)
+                replacement["fact_id"] = _replacement_fact_id(row)
+                replacement["restated"] = True
+                replacement_values = _row_values(replacement)
+                if _same_assertion(existing, candidate_values) or _same_assertion(
+                    existing,
+                    replacement_values,
+                ):
                     continue
-                raise ValueError(f"conflicting assertion already exists for {row['fact_id']!r}")
+                if _same_assertion_source(existing, candidate_values):
+                    raise ValueError(f"conflicting assertion source for {fact_id!r}")
 
-            asserted_at_index = _STAGING_CORE_METRIC_COLUMNS.index("asserted_at")
-            superseded_at = candidate_values[asserted_at_index]
-            connection.execute(update_sql, (superseded_at, True, fact_id, fact_id_pattern))
-            replacement_cursor = connection.execute(sql, replacement_values)
-            inserted += max(replacement_cursor.rowcount, 0)
-            continue
+                existing_replacement = connection.execute(
+                    select_sql,
+                    (replacement["fact_id"],),
+                ).fetchone()
+                if existing_replacement is not None:
+                    if _same_assertion(existing_replacement, replacement_values):
+                        continue
+                    raise ValueError(f"conflicting assertion already exists for {row['fact_id']!r}")
 
-        cursor = connection.execute(sql, candidate_values)
-        rowcount = max(cursor.rowcount, 0)
-        inserted += rowcount
+                asserted_at_index = _STAGING_CORE_METRIC_COLUMNS.index("asserted_at")
+                superseded_at = candidate_values[asserted_at_index]
+                connection.execute(update_sql, (superseded_at, True, fact_id, fact_id_pattern))
+                replacement_cursor = connection.execute(sql, replacement_values)
+                inserted += max(replacement_cursor.rowcount, 0)
+                continue
+
+            cursor = connection.execute(sql, candidate_values)
+            rowcount = max(cursor.rowcount, 0)
+            inserted += rowcount
+    except Exception:
+        connection.rollback()
+        raise
     connection.commit()
     return inserted

--- a/tests/db/test_staging_persistence.py
+++ b/tests/db/test_staging_persistence.py
@@ -84,6 +84,71 @@ def test_persist_staging_core_metrics_rejects_same_source_conflict_in_sqlite() -
     assert json.loads(row[1]) == ["p.40"]
 
 
+def test_persist_staging_core_metrics_rolls_back_batch_on_conflict_in_sqlite() -> None:
+    config = resolve_database_config(database_url="sqlite:///:memory:")
+    connection = connect_database(config)
+    existing_row = {
+        "fact_id": "fact:existing",
+        "plan_id": "CA-PERS",
+        "plan_period": "FY2024",
+        "metric_family": "funded",
+        "metric_name": "funded_ratio",
+        "as_reported_value": 78.4,
+        "normalized_value": 0.784,
+        "as_reported_unit": "percent",
+        "normalized_unit": "ratio",
+        "manager_name": None,
+        "fund_name": None,
+        "vehicle_name": None,
+        "relationship_completeness": "complete",
+        "confidence": 0.9,
+        "evidence_refs": ["p.40"],
+        "effective_date": "2024-06-30",
+        "ingestion_date": "2026-03-03",
+        "benchmark_version": "v1",
+        "source_document_id": "doc:ca:2024",
+    }
+    pending_row = {
+        **existing_row,
+        "fact_id": "fact:pending",
+        "plan_id": "CA-TEACHERS",
+        "source_document_id": "doc:ca:pending",
+    }
+    conflicting_row = {
+        **existing_row,
+        "as_reported_value": 79.0,
+        "normalized_value": 0.79,
+        "confidence": 0.92,
+        "evidence_refs": ["p.41"],
+    }
+    try:
+        apply_migrations(connection, dialect="sqlite")
+        persist_staging_core_metrics(
+            connection,
+            dialect="sqlite",
+            rows=[existing_row],
+        )
+        with pytest.raises(ValueError, match="conflicting assertion source"):
+            persist_staging_core_metrics(
+                connection,
+                dialect="sqlite",
+                rows=[pending_row, conflicting_row],
+            )
+        pending_count = connection.execute(
+            "SELECT COUNT(*) FROM staging_core_metrics WHERE fact_id = ?",
+            ("fact:pending",),
+        ).fetchone()[0]
+        existing_count = connection.execute(
+            "SELECT COUNT(*) FROM staging_core_metrics WHERE fact_id = ?",
+            ("fact:existing",),
+        ).fetchone()[0]
+    finally:
+        connection.close()
+
+    assert pending_count == 0
+    assert existing_count == 1
+
+
 def test_persist_staging_core_metrics_preserves_corrected_assertions_in_sqlite() -> None:
     config = resolve_database_config(database_url="sqlite:///:memory:")
     connection = connect_database(config)

--- a/tests/db/test_staging_persistence.py
+++ b/tests/db/test_staging_persistence.py
@@ -80,3 +80,79 @@ def test_persist_staging_core_metrics_keeps_existing_assertion_in_sqlite() -> No
     assert row is not None
     assert row[0] == 0.784
     assert json.loads(row[1]) == ["p.40"]
+
+
+def test_persist_staging_core_metrics_preserves_corrected_assertions_in_sqlite() -> None:
+    config = resolve_database_config(database_url="sqlite:///:memory:")
+    connection = connect_database(config)
+    base_row = {
+        "fact_id": "fact:restated",
+        "plan_id": "CA-PERS",
+        "plan_period": "FY2024",
+        "metric_family": "funded",
+        "metric_name": "funded_ratio",
+        "as_reported_value": 78.4,
+        "normalized_value": 0.784,
+        "as_reported_unit": "percent",
+        "normalized_unit": "ratio",
+        "manager_name": None,
+        "fund_name": None,
+        "vehicle_name": None,
+        "relationship_completeness": "complete",
+        "confidence": 0.9,
+        "evidence_refs": ["p.40"],
+        "effective_date": "2024-06-30",
+        "ingestion_date": "2026-03-03T00:00:00Z",
+        "benchmark_version": "v1",
+        "source_document_id": "doc:ca:2024-original",
+    }
+    corrected_row = {
+        **base_row,
+        "as_reported_value": 79.0,
+        "normalized_value": 0.79,
+        "confidence": 0.92,
+        "evidence_refs": ["p.41"],
+        "ingestion_date": "2026-04-01T00:00:00Z",
+        "source_document_id": "doc:ca:2024-restated",
+    }
+    try:
+        apply_migrations(connection, dialect="sqlite")
+        inserted = persist_staging_core_metrics(
+            connection,
+            dialect="sqlite",
+            rows=[base_row],
+        )
+        restated_inserted = persist_staging_core_metrics(
+            connection,
+            dialect="sqlite",
+            rows=[corrected_row],
+        )
+        retry_inserted = persist_staging_core_metrics(
+            connection,
+            dialect="sqlite",
+            rows=[corrected_row],
+        )
+        rows = connection.execute(
+            """
+            SELECT fact_id, normalized_value, asserted_at, superseded_at, restated, evidence_refs
+            FROM staging_core_metrics
+            ORDER BY asserted_at, fact_id
+            """,
+        ).fetchall()
+    finally:
+        connection.close()
+
+    assert inserted == 1
+    assert restated_inserted == 1
+    assert retry_inserted == 0
+    assert len(rows) == 2
+    assert rows[0][0] == "fact:restated"
+    assert rows[0][1] == 0.784
+    assert rows[0][3] == "2026-04-01T00:00:00Z"
+    assert rows[0][4] == 1
+    assert json.loads(rows[0][5]) == ["p.40"]
+    assert rows[1][0].startswith("fact:restated@2026-04-01T00:00:00Z:")
+    assert rows[1][1] == 0.79
+    assert rows[1][3] is None
+    assert rows[1][4] == 1
+    assert json.loads(rows[1][5]) == ["p.41"]

--- a/tests/db/test_staging_persistence.py
+++ b/tests/db/test_staging_persistence.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from pension_data.db.migrations_runner import apply_migrations
 from pension_data.db.staging_persistence import persist_staging_core_metrics
 from pension_data.db.strategy import connect_database, resolve_database_config
 
 
-def test_persist_staging_core_metrics_keeps_existing_assertion_in_sqlite() -> None:
+def test_persist_staging_core_metrics_rejects_same_source_conflict_in_sqlite() -> None:
     config = resolve_database_config(database_url="sqlite:///:memory:")
     connection = connect_database(config)
     try:
@@ -41,33 +43,34 @@ def test_persist_staging_core_metrics_keeps_existing_assertion_in_sqlite() -> No
                 }
             ],
         )
-        duplicate = persist_staging_core_metrics(
-            connection,
-            dialect="sqlite",
-            rows=[
-                {
-                    "fact_id": "fact:1",
-                    "plan_id": "CA-PERS",
-                    "plan_period": "FY2024",
-                    "metric_family": "funded",
-                    "metric_name": "funded_ratio",
-                    "as_reported_value": 79.0,
-                    "normalized_value": 0.79,
-                    "as_reported_unit": "percent",
-                    "normalized_unit": "ratio",
-                    "manager_name": None,
-                    "fund_name": None,
-                    "vehicle_name": None,
-                    "relationship_completeness": "complete",
-                    "confidence": 0.92,
-                    "evidence_refs": ["p.41"],
-                    "effective_date": "2024-06-30",
-                    "ingestion_date": "2026-03-03",
-                    "benchmark_version": "v1",
-                    "source_document_id": "doc:ca:2024",
-                }
-            ],
-        )
+        with pytest.raises(ValueError, match="conflicting assertion source"):
+            persist_staging_core_metrics(
+                connection,
+                dialect="sqlite",
+                rows=[
+                    {
+                        "fact_id": "fact:1",
+                        "plan_id": "CA-PERS",
+                        "plan_period": "FY2024",
+                        "metric_family": "funded",
+                        "metric_name": "funded_ratio",
+                        "as_reported_value": 79.0,
+                        "normalized_value": 0.79,
+                        "as_reported_unit": "percent",
+                        "normalized_unit": "ratio",
+                        "manager_name": None,
+                        "fund_name": None,
+                        "vehicle_name": None,
+                        "relationship_completeness": "complete",
+                        "confidence": 0.92,
+                        "evidence_refs": ["p.41"],
+                        "effective_date": "2024-06-30",
+                        "ingestion_date": "2026-03-03",
+                        "benchmark_version": "v1",
+                        "source_document_id": "doc:ca:2024",
+                    }
+                ],
+            )
         row = connection.execute(
             "SELECT normalized_value, evidence_refs FROM staging_core_metrics WHERE fact_id = ?",
             ("fact:1",),
@@ -76,7 +79,6 @@ def test_persist_staging_core_metrics_keeps_existing_assertion_in_sqlite() -> No
         connection.close()
 
     assert inserted == 1
-    assert duplicate == 0
     assert row is not None
     assert row[0] == 0.784
     assert json.loads(row[1]) == ["p.40"]
@@ -115,6 +117,15 @@ def test_persist_staging_core_metrics_preserves_corrected_assertions_in_sqlite()
         "ingestion_date": "2026-04-01T00:00:00Z",
         "source_document_id": "doc:ca:2024-restated",
     }
+    second_corrected_row = {
+        **base_row,
+        "as_reported_value": 80.0,
+        "normalized_value": 0.8,
+        "confidence": 0.94,
+        "evidence_refs": ["p.42"],
+        "ingestion_date": "2026-05-01T00:00:00Z",
+        "source_document_id": "doc:ca:2024-restated-2",
+    }
     try:
         apply_migrations(connection, dialect="sqlite")
         inserted = persist_staging_core_metrics(
@@ -132,6 +143,11 @@ def test_persist_staging_core_metrics_preserves_corrected_assertions_in_sqlite()
             dialect="sqlite",
             rows=[corrected_row],
         )
+        second_restated_inserted = persist_staging_core_metrics(
+            connection,
+            dialect="sqlite",
+            rows=[second_corrected_row],
+        )
         rows = connection.execute(
             """
             SELECT fact_id, normalized_value, asserted_at, superseded_at, restated, evidence_refs
@@ -145,7 +161,8 @@ def test_persist_staging_core_metrics_preserves_corrected_assertions_in_sqlite()
     assert inserted == 1
     assert restated_inserted == 1
     assert retry_inserted == 0
-    assert len(rows) == 2
+    assert second_restated_inserted == 1
+    assert len(rows) == 3
     assert rows[0][0] == "fact:restated"
     assert rows[0][1] == 0.784
     assert rows[0][3] == "2026-04-01T00:00:00Z"
@@ -153,6 +170,11 @@ def test_persist_staging_core_metrics_preserves_corrected_assertions_in_sqlite()
     assert json.loads(rows[0][5]) == ["p.40"]
     assert rows[1][0].startswith("fact:restated@2026-04-01T00:00:00Z:")
     assert rows[1][1] == 0.79
-    assert rows[1][3] is None
+    assert rows[1][3] == "2026-05-01T00:00:00Z"
     assert rows[1][4] == 1
     assert json.loads(rows[1][5]) == ["p.41"]
+    assert rows[2][0].startswith("fact:restated@2026-05-01T00:00:00Z:")
+    assert rows[2][1] == 0.8
+    assert rows[2][3] is None
+    assert rows[2][4] == 1
+    assert json.loads(rows[2][5]) == ["p.42"]


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:649 -->
> **Source:** Issue #649

Closes #649

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Pension facts have two independent timelines: the **as-of date** of the figure (FY2024 measurement) and the **assertion time** (when a filing/restatement told us). Actuarial restatements and holdings refilings (13F amendments) are routine. Without bitemporal modeling you can't answer "what did we believe the FY2023 funded ratio / the Q1 holdings were, as of last March, vs now," and restatements silently overwrite history. (Parent: #642; underpins holdings-over-time and benchmarking trends.)

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#642](https://github.com/stranske/Pension-Data/issues/642)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add `valid_from`/`valid_to` (as-of) and `asserted_at`/`superseded_at` (transaction-time) to the core staged metric + holdings rows; never UPDATE-in-place — insert a new assertion and close the prior.
- [ ] Add non-overlapping-period constraints + an "as-of-as-known-at" query helper (time-travel).
- [ ] Wire restatement/amendment ingestion (e.g., 13F-HR/A) to supersede rather than overwrite.
- [ ] Surface "restated" flags in the analytics outputs.

#### Acceptance criteria
- [ ] A restated metric keeps both the original and corrected assertion; a query can reproduce the pre-restatement view.
- [ ] No period overlaps for a given (plan, metric, as-of) across assertions.
- [ ] Holdings amendments (13F/A) supersede prior filings without losing history.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved staging persistence to deterministically de-duplicate assertions and correctly supersede/restore existing records while preserving prior history.
  * Added stronger conflict detection: same source + same assertion key with differing values is now rejected instead of being silently ignored.
  * Enhanced idempotency for repeated imports, including correct handling of “active” records.

* **Tests**
  * Updated and expanded SQLite test coverage to verify conflict rollback within a batch and validate supersession/restatement behavior and evidence fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->