### PR TITLE
Codex bootstrap for #650

### DIFF
--- a/agents/codex-650.md
+++ b/agents/codex-650.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #650 -->

--- a/src/pension_data/parser/pdf_pipeline.py
+++ b/src/pension_data/parser/pdf_pipeline.py
@@ -24,6 +24,12 @@ from pension_data.extract.orchestration.fallback import (
     run_fallback_chain,
 )
 from pension_data.normalize.financial_units import UnitScale
+from pension_data.parser.hybrid_backend import (
+    HybridBackendConfig,
+    HybridBackendResult,
+    ParserBackend,
+    run_hybrid_table_extraction,
+)
 
 _TEXT_TOKEN_PATTERN = re.compile(r"\((?P<token>(?:\\(?:\r\n|[\r\n]|.)|[^\\)])+)\)\s*Tj")
 _TEXT_ARRAY_PATTERN = re.compile(r"\[(?P<array>(?:\\.|[^\]])*)\]\s*TJ", re.DOTALL)
@@ -111,6 +117,8 @@ class PDFParserInput:
     default_money_unit_scale: UnitScale
     pdf_bytes: bytes
     ocr_extract: Callable[[bytes], Sequence[str]] | None = None
+    hybrid_config: HybridBackendConfig | None = None
+    docling_backend: ParserBackend | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -136,6 +144,7 @@ class PDFParserResult:
     missing_metrics: tuple[FundedActuarialMetricName, ...]
     actionable_flags: tuple[str, ...]
     provenance_refs: tuple[str, ...]
+    hybrid_result: HybridBackendResult | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -266,8 +275,13 @@ def _extract_table_rows(*, page_number: int, lines: Sequence[str]) -> list[dict[
         ]
         label = ""
         value = ""
+        year_columns = [column for column in columns[1:] if column.isdigit() and len(column) == 4]
         if len(columns) >= 2 and _looks_like_metric_label(columns[0]):
-            label, value = columns[0], columns[1]
+            label = columns[0]
+            if year_columns and len(columns) > len(year_columns) + 1:
+                value = columns[-1]
+            else:
+                value = columns[1]
         elif ":" in line:
             left, right = line.split(":", 1)
             if _looks_like_metric_label(left):
@@ -278,13 +292,19 @@ def _extract_table_rows(*, page_number: int, lines: Sequence[str]) -> list[dict[
                 label, value = metric_like_row
         if not label or not value:
             continue
-        rows.append(
-            {
-                "label": label,
-                "value": value,
-                "evidence_ref": f"p.{page_number}#table",
-            }
-        )
+        row = {
+            "label": label,
+            "value": value,
+            "evidence_ref": f"p.{page_number}#table",
+        }
+        if year_columns:
+            row["complex_table"] = "true"
+            row["header_depth"] = "2"
+            for index, year in enumerate(year_columns, start=1):
+                value_index = index + len(year_columns)
+                if value_index < len(columns):
+                    row[year] = columns[value_index]
+        rows.append(row)
     return rows
 
 
@@ -452,6 +472,24 @@ def _collect_provenance_refs(raw: RawFundedActuarialInput | None) -> tuple[str, 
     return _dedupe_non_empty(refs)
 
 
+def _run_optional_hybrid_backend(
+    *,
+    input_payload: PDFParserInput,
+    raw: RawFundedActuarialInput | None,
+) -> HybridBackendResult | None:
+    if raw is None or input_payload.hybrid_config is None:
+        return None
+    if not input_payload.hybrid_config.enable_docling:
+        return None
+    return run_hybrid_table_extraction(
+        plan_id=input_payload.source_document_id,
+        plan_period=input_payload.effective_date,
+        raw=raw,
+        config=input_payload.hybrid_config,
+        docling_backend=input_payload.docling_backend,
+    )
+
+
 def parse_pdf_to_funded_input(input_payload: PDFParserInput) -> PDFParserResult:
     """Parse pension PDF bytes into funded/actuarial extraction-ready structures."""
     stage_candidates: dict[str, _StageCandidate] = {}
@@ -483,6 +521,7 @@ def parse_pdf_to_funded_input(input_payload: PDFParserInput) -> PDFParserResult:
     selected = outcome.result if outcome.result is not None else _best_partial(stage_candidates)
     escalation = outcome.escalation
     selected_raw = selected.raw if selected is not None else None
+    hybrid_result = _run_optional_hybrid_backend(input_payload=input_payload, raw=selected_raw)
     return PDFParserResult(
         raw=selected_raw,
         stage_name=selected.stage_name if selected is not None else None,
@@ -499,4 +538,5 @@ def parse_pdf_to_funded_input(input_payload: PDFParserInput) -> PDFParserResult:
             partial=selected,
         ),
         provenance_refs=_collect_provenance_refs(selected_raw),
+        hybrid_result=hybrid_result,
     )

--- a/tests/parser/test_pdf_pipeline.py
+++ b/tests/parser/test_pdf_pipeline.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 
 from pension_data.extract.actuarial.metrics import extract_funded_and_actuarial_metrics
+from pension_data.parser.hybrid_backend import (
+    BackendMetricValue,
+    HybridBackendConfig,
+    SelfHostedDoclingBackend,
+)
 from pension_data.parser.pdf_pipeline import PDFParserInput, parse_pdf_to_funded_input
 
 FIXTURE_PATH = Path(__file__).parent / "fixtures" / "calpers_fy2024_excerpt.pdf"
@@ -44,6 +49,62 @@ def test_real_pension_pdf_fixture_parses_end_to_end_into_extraction_ready_input(
     assert len(facts) == 7
     assert all("%pdf" not in block.lower() for block in parser_result.raw.text_blocks)
     assert all("startxref" not in block.lower() for block in parser_result.raw.text_blocks)
+
+
+def test_hybrid_docling_routes_complex_multi_year_table_from_pipeline() -> None:
+    complex_table_pdf = (
+        b"%PDF-1.4\n%%Page: 1 1\n"
+        b"Funded ratio | 2023 | 2024 | 78.0% | 50.0%\n"
+        b"AAL | $410.0 million\n"
+        b"AVA | $333.7 million\n"
+        b"Discount rate | 6.75%\n"
+        b"Employer contribution rate | 11.1%\n"
+        b"Employee contribution rate | 7.1%\n"
+        b"Participant count | 112000\n"
+    )
+
+    def _docling_values(_: object) -> tuple[BackendMetricValue, ...]:
+        return (
+            BackendMetricValue(
+                metric_name="funded_ratio",
+                normalized_value=0.812,
+                as_reported_value=81.2,
+                normalized_unit="ratio",
+                as_reported_unit="percent",
+                confidence=0.91,
+                backend="docling",
+                evidence_refs=("p.1#docling-tableformer",),
+            ),
+        )
+
+    parser_result = parse_pdf_to_funded_input(
+        PDFParserInput(
+            source_document_id="doc:calpers:complex-actuarial",
+            source_url="file://fixtures/complex-multi-year-actuarial.pdf",
+            effective_date="2024-06-30",
+            ingestion_date="2026-07-04",
+            default_money_unit_scale="million_usd",
+            pdf_bytes=complex_table_pdf,
+            hybrid_config=HybridBackendConfig(enable_docling=True),
+            docling_backend=SelfHostedDoclingBackend(_docling_values),
+        )
+    )
+
+    assert parser_result.stage_name == "table_primary"
+    assert parser_result.raw is not None
+    assert any(row.get("complex_table") == "true" for row in parser_result.raw.table_rows)
+    assert parser_result.hybrid_result is not None
+    assert parser_result.hybrid_result.routed_to_docling is True
+    assert parser_result.hybrid_result.docling is not None
+    docling_by_metric = {
+        value.metric_name: value for value in parser_result.hybrid_result.docling.values
+    }
+    assert docling_by_metric["funded_ratio"].normalized_value == 0.812
+    assert "backend:docling" in docling_by_metric["funded_ratio"].evidence_refs
+    assert len(parser_result.hybrid_result.review_decisions) == 1
+    assert parser_result.hybrid_result.review_decisions[0].routing_outcome == (
+        "high_priority_review"
+    )
 
 
 def test_text_fallback_carries_page_level_text_evidence_refs() -> None:


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The repo's deterministic regex/table parsing trails the field on **complex actuarial tables** (merged cells, nested headers, multi-year columns — exactly the parser bugs in #637). Managed document-AI (Reducto ~90%, Azure ~83%) beats it but (a) hallucinates numbers (~68% of financial LLM extractions had ≥1 fabricated value) and (b) is off-box (PII-disqualifying for confidential pension data). The right move is a **self-hosted** complex-table backend behind the existing parser interface, with deterministic staying the trusted path. (Parent: #642.)

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#637](https://github.com/stranske/Pension-Data/issues/637)
- [#642](https://github.com/stranske/Pension-Data/issues/642)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Define a parser-backend interface (the deterministic parser implements it) and add a Docling-backed implementation behind a config flag, self-hosted only.
- [x] Route only tables the deterministic parser flags as low-confidence/complex to Docling; keep deterministic output as the primary.
- [x] **Cross-check**: when both run, compare extracted values; disagreements → review queue (reuse confidence/anomaly machinery), never silent overwrite.
- [x] Add complex-table golden fixtures (merged/multi-year) shared with #637.

#### Acceptance criteria
- [x] A complex multi-year actuarial table that the deterministic parser mis-reads (per #637) is correctly extracted via the Docling path, with provenance noting the backend.
- [x] Deterministic remains default; Docling is opt-in and fully on-box (no network egress).
- [x] Value disagreements between backends are routed to review, not auto-accepted.

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why
The repo's deterministic regex/table parsing trails the field on **complex actuarial tables** (merged cells, nested headers, multi-year columns — exactly the parser bugs in #637). Managed document-AI (Reducto ~90%, Azure ~83%) beats it but (a) hallucinates numbers (~68% of financial LLM extractions had ≥1 fabricated value) and (b) is off-box (PII-disqualifying for confidential pension data). The right move is a **self-hosted** complex-table backend behind the existing parser interface, with deterministic staying the trusted path. (Parent: #642.)

## Scope
Add **Docling** (open-source, self-hosted, has TableFormer table-structure + XBRL parsing) as an alternate table-extraction backend behind one interface, used only for hard tables; cross-check against the deterministic path.

## Non-Goals
- Do NOT replace the deterministic parser — it stays the trusted, no-hallucination default and the cross-check baseline.
- Do NOT add any off-box/managed service (Azure/Reducto) — PII-gated, out of scope.
- No LLM free-text extraction (separate, data-zone-gated).

## Tasks
- [x] Define a parser-backend interface (the deterministic parser implements it) and add a Docling-backed implementation behind a config flag, self-hosted only.
- [x] Route only tables the deterministic parser flags as low-confidence/complex to Docling; keep deterministic output as the primary.
- [x] **Cross-check**: when both run, compare extracted values; disagreements → review queue (reuse confidence/anomaly machinery), never silent overwrite.
- [x] Add complex-table golden fixtures (merged/multi-year) shared with #637.

## Acceptance Criteria
- [x] A complex multi-year actuarial table that the deterministic parser mis-reads (per #637) is correctly extracted via the Docling path, with provenance noting the backend.
- [x] Deterministic remains default; Docling is opt-in and fully on-box (no network egress).
- [x] Value disagreements between backends are routed to review, not auto-accepted.

## Test gate
Gate: `tests/parser/test_hybrid_backend.py` on the shared complex-table fixtures asserting (a) correct values via Docling, (b) cross-check disagreement → review. Deliberate-break: make the backends disagree on a fixture → cross-check test asserts a review item is raised.

## Implementation Notes
- Field rationale: `2026-06-28-05-field-and-opportunities.md` (Dim5/7.3) + design `2026-06-28-ANALYTICS_DESIGN.md` §3. Docling: self-hosted, TableFormer + XBRL. Keep deterministic as the trusted baseline.



</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
<!-- meta:issue:650 -->
> **Source:** Issue #650

Closes #650

<!-- pr-preamble:end -->