### PR TITLE
refactor(query): consolidate to one read-only SQL validator — fixes #638

### DIFF
--- a/src/pension_data/query/sql_service.py
+++ b/src/pension_data/query/sql_service.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -18,26 +17,12 @@ from pension_data.query.run_record import (
     record_relative_path,
     write_query_run_record,
 )
+from pension_data.query.sql_safety import SQLSafetyValidationError, validate_read_only_sql
 
 DatabaseDialect = Literal["sqlite", "postgresql"]
 SqlParams = Mapping[str, Any] | tuple[Any, ...] | list[Any]
 
-_FORBIDDEN_SQL_TOKENS: tuple[str, ...] = (
-    "insert",
-    "update",
-    "delete",
-    "drop",
-    "alter",
-    "create",
-    "replace",
-    "attach",
-    "detach",
-    "pragma",
-    "vacuum",
-    "reindex",
-)
 _RESERVED_PAGING_PARAM_KEYS: frozenset[str] = frozenset({"_pd_limit", "_pd_offset"})
-_SQL_WORD_PATTERN = re.compile(r"\b[a-z_][a-z0-9_]*\b", re.IGNORECASE)
 
 
 @dataclass(frozen=True, slots=True)
@@ -131,13 +116,6 @@ class DBConnection(Protocol):
         """Execute SQL and return DB-API cursor-like result."""
 
 
-def _normalized_sql(sql: str) -> str:
-    normalized = sql.strip().rstrip(";").strip()
-    if not normalized:
-        raise SQLExecutionValidationError("SQL query must be non-empty")
-    return normalized
-
-
 def _validate_request(request: SQLQueryRequest) -> None:
     if request.page < 1:
         raise SQLExecutionValidationError("page must be >= 1")
@@ -147,95 +125,6 @@ def _validate_request(request: SQLQueryRequest) -> None:
         raise SQLExecutionValidationError("timeout_ms must be >= 1")
     if request.max_rows < 1:
         raise SQLExecutionValidationError("max_rows must be >= 1")
-
-
-def _enforce_read_only_sql(sql: str) -> None:
-    sanitized = _strip_sql_comments_and_strings(sql)
-    lowered = sanitized.lower().lstrip()
-    if not lowered.startswith(("select", "with")):
-        raise SQLExecutionValidationError("only read-only SELECT/WITH queries are allowed")
-    if ";" in sanitized:
-        raise SQLExecutionValidationError("multiple SQL statements are not allowed")
-    tokens = {match.group(0).lower() for match in _SQL_WORD_PATTERN.finditer(sanitized)}
-    forbidden = sorted(token for token in _FORBIDDEN_SQL_TOKENS if token in tokens)
-    if forbidden:
-        raise SQLExecutionValidationError(
-            "query contains forbidden token(s): " + ", ".join(forbidden)
-        )
-
-
-def _strip_sql_comments_and_strings(sql: str) -> str:
-    result: list[str] = []
-    index = 0
-    in_single = False
-    in_double = False
-    in_line_comment = False
-    in_block_comment = False
-    while index < len(sql):
-        current = sql[index]
-        nxt = sql[index + 1] if index + 1 < len(sql) else ""
-
-        if in_line_comment:
-            if current == "\n":
-                in_line_comment = False
-                result.append("\n")
-            else:
-                result.append(" ")
-            index += 1
-            continue
-        if in_block_comment:
-            if current == "*" and nxt == "/":
-                in_block_comment = False
-                result.extend((" ", " "))
-                index += 2
-            else:
-                result.append(" ")
-                index += 1
-            continue
-        if in_single:
-            if current == "'" and nxt == "'":
-                result.extend((" ", " "))
-                index += 2
-                continue
-            if current == "'":
-                in_single = False
-            result.append(" ")
-            index += 1
-            continue
-        if in_double:
-            if current == '"' and nxt == '"':
-                result.extend((" ", " "))
-                index += 2
-                continue
-            if current == '"':
-                in_double = False
-            result.append(" ")
-            index += 1
-            continue
-
-        if current == "-" and nxt == "-":
-            in_line_comment = True
-            result.extend((" ", " "))
-            index += 2
-            continue
-        if current == "/" and nxt == "*":
-            in_block_comment = True
-            result.extend((" ", " "))
-            index += 2
-            continue
-        if current == "'":
-            in_single = True
-            result.append(" ")
-            index += 1
-            continue
-        if current == '"':
-            in_double = True
-            result.append(" ")
-            index += 1
-            continue
-        result.append(current)
-        index += 1
-    return "".join(result)
 
 
 def _normalize_params(params: SqlParams | None) -> SqlParams | tuple[()]:
@@ -481,8 +370,10 @@ def execute_sql_query(
 
     try:
         _validate_request(request)
-        sql = _normalized_sql(request.sql)
-        _enforce_read_only_sql(sql)
+        try:
+            sql = validate_read_only_sql(request.sql)
+        except SQLSafetyValidationError as exc:
+            raise SQLExecutionValidationError(str(exc)) from exc
         params = _normalize_params(request.params)
 
         deadline = start + (request.timeout_ms / 1000.0)

--- a/tests/query/test_sql_validator_consolidation.py
+++ b/tests/query/test_sql_validator_consolidation.py
@@ -1,0 +1,61 @@
+"""#638: one read-only SQL validator, shared by both consumers.
+
+`query/sql_service.execute_sql_query` and `langchain/eval_harness` (via
+`validate_read_only_sql`) must reach the SAME accept/reject decision. Documented
+semicolon policy: a single trailing `;` is allowed (stripped); any statement after
+a `;` is rejected as multi-statement.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from pension_data.query.sql_safety import SQLSafetyValidationError, validate_read_only_sql
+from pension_data.query.sql_service import SQLQueryRequest, execute_sql_query
+
+
+def _seed() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE t (id INTEGER)")
+    conn.execute("INSERT INTO t (id) VALUES (1)")
+    conn.commit()
+    return conn
+
+
+def _service_ok(sql: str) -> bool:
+    resp = execute_sql_query(
+        connection=_seed(),
+        request=SQLQueryRequest(sql=sql),
+        caller_key_id="key:test",
+    )
+    return resp.status == "ok"
+
+
+def _safety_ok(sql: str) -> bool:
+    try:
+        validate_read_only_sql(sql)
+        return True
+    except SQLSafetyValidationError:
+        return False
+
+
+@pytest.mark.parametrize(
+    ("sql", "accepted"),
+    [
+        ("SELECT id FROM t", True),
+        ("SELECT id FROM t;", True),  # single trailing semicolon allowed
+        ("SELECT id FROM t ;  ", True),  # trailing ; + whitespace allowed
+        ("SELECT id FROM t; SELECT id FROM t", False),  # multi-statement rejected
+        ("SELECT id FROM t; DROP TABLE t", False),  # injected 2nd statement rejected
+        ("DELETE FROM t", False),  # non-read-only rejected
+    ],
+)
+def test_both_paths_agree(sql: str, accepted: bool) -> None:
+    assert _safety_ok(sql) is accepted
+    assert _service_ok(sql) is accepted
+
+
+def test_trailing_semicolon_is_stripped_by_the_single_validator() -> None:
+    assert validate_read_only_sql("SELECT id FROM t;") == "SELECT id FROM t"


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:638 -->
> **Source:** Issue #638

Closes #638

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The read-only SQL safety gate is implemented twice with divergent behavior — a correctness/security risk because the two paths can disagree on whether the same query is safe:
- `query/sql_safety.py` (`validate_read_only_sql`, `_strip_sql_comments_and_strings`, `_FORBIDDEN_SQL_TOKENS`, `_SQL_WORD_PATTERN`) allows a trailing semicolon when nothing follows.
- `query/sql_service.py` (`_enforce_read_only_sql`, plus its own copy of the stripper + constants) rejects any `;` in sanitized SQL (`sql_service.py:157-158`).

~95 duplicated LOC. `validate_read_only_sql` is used by `langchain/eval_harness.py`; `_enforce_read_only_sql` is reached via `query/sql_service.execute_sql_query`. The API SQL route `routes/sql.py` is currently unmounted, so live exposure is limited today, but both validators are real and the divergence is a latent footgun for when the SQL path is wired.

#### Tasks
- [ ] Update `query/sql_service.py` to import and call `validate_read_only_sql` or a shared internal helper from `query/sql_safety.py`.
- [ ] Delete `_enforce_read_only_sql` and the duplicated stripper/constants from `query/sql_service.py`.
- [ ] Update `query/sql_safety.py` to implement and document one semicolon policy in the single shared helper.
  - [ ] Document the agreed semicolon policy in the docstring of the shared validator function (verify: docs updated)
  - [ ] Update the shared validator implementation to enforce the documented semicolon policy (verify: confirm completion in repo)
  - [ ] Add inline comments explaining why the semicolon policy was chosen for security (verify: confirm completion in repo)
- [ ] Test `langchain/eval_harness.py` and `query/sql_service` with the same `DELETE` and `;`-bearing inputs to verify identical accept/reject behavior.
  - [ ] Create a test that feeds DELETE queries through both eval_harness (verify: confirm completion in repo) sql_service paths (verify: confirm completion in repo) asserts both reject (verify: confirm completion in repo)
  - [ ] Create a test that feeds semicolon-bearing queries through both code paths (verify: confirm completion in repo) asserts identical behavior (verify: confirm completion in repo)
  - [ ] Add a test case that verifies trailing semicolons are handled consistently across both validators (verify: confirm completion in repo)
- [ ] Add or update SQL-safety tests to assert the documented trailing-semicolon policy and cover both code paths.
  - [ ] Add a test case in the SQL safety test suite that verifies the trailing semicolon policy with valid queries (verify: confirm completion in repo)
  - [ ] Add a test case that verifies queries with multiple semicolons are rejected per the policy (verify: confirm completion in repo)
  - [ ] Update existing SQL safety tests to cover both the eval_harness (verify: tests pass) sql_service code paths (verify: confirm completion in repo)
- [ ] Run `pytest tests -k sql_safety -q` and the `sql_service` read-only tests.

#### Acceptance criteria
- [ ] Exactly one read-only SQL validator and one comment/string stripper exist in `query/`.
- [ ] `query/sql_service.py` no longer contains `_enforce_read_only_sql` or duplicated SQL-safety constants/stripper logic.
- [ ] The same input string returns the same accept/reject decision through both the `langchain/eval_harness.py` and `query/sql_service.execute_sql_query` paths.
- [ ] Existing SQL-safety tests pass.
- [ ] A trailing-semicolon test exists and matches the documented semicolon policy.

**Head SHA:** 70ae631a5ead4fdfe4a6103cb2cab57b2626e8ce
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Pension-Data/actions/runs/29012033213) |
| Backplane Conformance | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/29011635353) |
| Cross-Repo Smoke | ⏭️ skipped | [View run](https://github.com/stranske/Pension-Data/actions/runs/29011635404) |
| Entity Regression Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/29011634990) |
| Extraction Golden Regression | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/29011635029) |
| Foundation Fixture E2E | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/29011635055) |
| Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/29011635417) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/29011635006) |
| NL-SQL Golden | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/29011635002) |
| One-PDF Pilot Golden | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/29011635064) |
| PostgreSQL Integration | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/29011634996) |
| Quality Replay Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/29011635015) |
| Quality SLA Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/29011635096) |
| Running Copilot Code Review | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/29011647500) |
<!-- auto-status-summary:end -->