### PR TITLE
refactor(web): consolidate workspace bundle-contract validation — fixes #639

### DIFF
--- a/apps/web/app.js
+++ b/apps/web/app.js
@@ -118,8 +118,10 @@ function normalizeWorkspaceBundle(payload) {
     throw new Error("workspace bundle is missing contractVersion");
   }
   if (contractVersion !== RUNTIME_CONTRACT_VERSION) {
-    console.warn(
-      `workspace contractVersion '${contractVersion}' differs from expected '${RUNTIME_CONTRACT_VERSION}'`
+    // Reject (do not merely warn): a contractVersion mismatch means the bundle was
+    // built against a different contract and may not match the renderer's assumptions.
+    throw new Error(
+      `workspace contractVersion '${contractVersion}' does not match expected '${RUNTIME_CONTRACT_VERSION}'`
     );
   }
   const dataOrigin = normalizeDataOrigin(payload.data_origin);

--- a/scripts/web/serve_local.py
+++ b/scripts/web/serve_local.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from collections.abc import Mapping
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from workspace_contract import validate_workspace_bundle  # noqa: E402
 
 ROOT = Path(__file__).resolve().parents[2]
 WEB_ROOT = ROOT / "apps" / "web"
@@ -47,14 +51,11 @@ def _assert_workspace_bundle(
     path_label: str,
     allow_fixture_demo: bool,
 ) -> None:
-    data_origin = payload.get("data_origin")
-    allowed = ALLOWED_ORIGINS | (frozenset({"fixture"}) if allow_fixture_demo else frozenset())
-    if data_origin not in allowed:
-        allowed_text = ", ".join(sorted(allowed))
-        raise ValueError(f"{path_label} must declare data_origin of {allowed_text}")
-    datasets = payload.get("datasets")
-    if not isinstance(datasets, list) or not datasets:
-        raise ValueError(f"{path_label} must contain at least one dataset")
+    # Delegate to the shared validator so serve_local enforces the SAME invariants
+    # smoke_test does (crucially the contractVersion match it previously skipped).
+    # serve's origin policy: generated/live, plus fixture only in explicit demo mode.
+    accepted = ALLOWED_ORIGINS | (frozenset({"fixture"}) if allow_fixture_demo else frozenset())
+    validate_workspace_bundle(payload, path_label=path_label, accepted_origins=accepted)
 
 
 def load_workspace_bundle(path: Path, *, allow_fixture_demo: bool = False) -> dict[str, Any]:

--- a/scripts/web/smoke_test.py
+++ b/scripts/web/smoke_test.py
@@ -6,10 +6,18 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sys
 from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.parse import urljoin
 from urllib.request import Request, urlopen
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from workspace_contract import (  # noqa: E402
+    allowed_data_origins,
+    load_runtime_contract,
+    validate_workspace_bundle,
+)
 
 REQUIRED_CONFIG_KEYS = ("environment", "apiBaseUrl", "artifactBaseUrl")
 REQUIRED_LOCAL_FILES = (
@@ -51,21 +59,13 @@ def _assert_workspace_bundle(
     reject_fixture: bool,
     require_fixture: bool = False,
 ) -> str:
-    contract = _load_runtime_contract()
-    contract_version = payload.get("contractVersion")
-    if not isinstance(contract_version, str) or not contract_version.strip():
-        raise ValueError(f"workspace bundle missing contractVersion in {path_label}")
-    if contract_version != contract.get("version"):
-        raise ValueError(
-            f"workspace contractVersion '{contract_version}' does not match runtime contract"
-        )
-
-    data_origins = _allowed_data_origins(contract)
-    data_origin = payload.get("data_origin")
-    if not isinstance(data_origin, str) or data_origin not in data_origins:
-        raise ValueError(
-            f"workspace bundle requires data_origin of {', '.join(sorted(data_origins))} in {path_label}"
-        )
+    contract = load_runtime_contract()
+    data_origin = validate_workspace_bundle(
+        payload,
+        path_label=path_label,
+        accepted_origins=allowed_data_origins(contract),
+        contract=contract,
+    )
     if require_fixture and data_origin != "fixture":
         raise ValueError(
             "Refusing to deploy non-synthetic bundle to external Cloudflare Pages: "
@@ -73,51 +73,14 @@ def _assert_workspace_bundle(
         )
     if reject_fixture and data_origin == "fixture":
         raise ValueError(f"fixture workspace bundle is not allowed for runtime smoke: {path_label}")
-    datasets = payload.get("datasets")
-    if not isinstance(datasets, list) or not datasets:
-        raise ValueError(f"workspace dataset inventory is empty in {path_label}")
     return data_origin
 
 
 def _load_runtime_contract() -> dict[str, object]:
-    if not CONTRACT_PATH.exists():
-        raise ValueError(f"runtime contract missing: {CONTRACT_PATH}")
-    payload = _load_json(CONTRACT_PATH)
-    version = payload.get("version")
-    workspace_bundle = payload.get("workspaceBundle")
-    if not isinstance(version, str) or not version.strip():
-        raise ValueError(f"runtime contract missing version in {CONTRACT_PATH}")
-    if not isinstance(workspace_bundle, dict):
-        raise ValueError(f"runtime contract missing workspaceBundle in {CONTRACT_PATH}")
-    required_fields = workspace_bundle.get("requiredTopLevelFields")
-    if not isinstance(required_fields, list) or not required_fields:
-        raise ValueError("runtime contract requiredTopLevelFields must be a non-empty list")
-    normalized_required = {
-        field for field in required_fields if isinstance(field, str) and field.strip()
-    }
-    if len(normalized_required) != len(required_fields):
-        raise ValueError("runtime contract requiredTopLevelFields must contain non-empty strings")
-    required_workspace_fields = {"contractVersion", "data_origin", "datasets"}
-    missing_fields = required_workspace_fields.difference(normalized_required)
-    if missing_fields:
-        raise ValueError(
-            "runtime contract missing required workspace fields: "
-            + ", ".join(sorted(missing_fields))
-        )
-    return payload
-
-
-def _allowed_data_origins(contract: dict[str, object]) -> frozenset[str]:
-    workspace_bundle = contract["workspaceBundle"]
-    if not isinstance(workspace_bundle, dict):
-        raise ValueError("runtime contract workspaceBundle must be an object")
-    origins = workspace_bundle.get("dataOrigins")
-    if not isinstance(origins, list) or not origins:
-        raise ValueError("runtime contract dataOrigins must be a non-empty list")
-    normalized = [origin for origin in origins if isinstance(origin, str) and origin.strip()]
-    if len(normalized) != len(origins):
-        raise ValueError("runtime contract dataOrigins must contain non-empty strings")
-    return frozenset(normalized)
+    # Delegates to the single owner (workspace_contract); retained because tests and
+    # local callers reference this name. Pass CONTRACT_PATH through so tests that
+    # monkeypatch smoke_test.CONTRACT_PATH still steer the loader.
+    return load_runtime_contract(CONTRACT_PATH)
 
 
 def _smoke_local(base_dir: Path, *, require_runtime: bool, require_fixture: bool = False) -> None:

--- a/scripts/web/workspace_contract.py
+++ b/scripts/web/workspace_contract.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Single source of truth for web workspace bundle-contract validation (#639).
+
+`smoke_test.py`, `serve_local.py`, and `build_workspace_bundle.py` previously each
+validated the workspace bundle differently — most importantly `serve_local` did NOT
+check `contractVersion`, so it could serve a bundle that `smoke_test` rejects. This
+module owns the shared invariants (contractVersion matches the runtime contract; a
+non-empty dataset inventory; `data_origin` within the caller's accepted set). Each
+caller supplies its own legitimate accepted-origins policy — serve rejects fixture
+by default, smoke allows it — but they now agree on every shared rule.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
+
+CONTRACT_PATH = Path("apps/contracts/runtime-contract.json")
+
+
+class WorkspaceContractError(ValueError):
+    """Raised when a workspace bundle violates the runtime contract."""
+
+
+def load_runtime_contract(contract_path: Path = CONTRACT_PATH) -> dict[str, Any]:
+    """Load and structurally validate the runtime contract JSON."""
+    if not contract_path.exists():
+        raise WorkspaceContractError(f"runtime contract missing: {contract_path}")
+    payload = json.loads(contract_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise WorkspaceContractError(f"runtime contract must be a JSON object: {contract_path}")
+    version = payload.get("version")
+    workspace_bundle = payload.get("workspaceBundle")
+    if not isinstance(version, str) or not version.strip():
+        raise WorkspaceContractError(f"runtime contract missing version: {contract_path}")
+    if not isinstance(workspace_bundle, dict):
+        raise WorkspaceContractError(
+            f"runtime contract workspaceBundle must be an object: {contract_path}"
+        )
+    required_fields = workspace_bundle.get("requiredTopLevelFields")
+    if not isinstance(required_fields, list) or not required_fields:
+        raise WorkspaceContractError(
+            "runtime contract requiredTopLevelFields must be a non-empty list"
+        )
+    normalized_required = {
+        field for field in required_fields if isinstance(field, str) and field.strip()
+    }
+    if len(normalized_required) != len(required_fields):
+        raise WorkspaceContractError(
+            "runtime contract requiredTopLevelFields must contain non-empty strings"
+        )
+    missing_fields = {"contractVersion", "data_origin", "datasets"}.difference(normalized_required)
+    if missing_fields:
+        raise WorkspaceContractError(
+            "runtime contract missing required workspace fields: "
+            + ", ".join(sorted(missing_fields))
+        )
+    return payload
+
+
+def allowed_data_origins(contract: Mapping[str, Any]) -> frozenset[str]:
+    """Return the full set of data origins the runtime contract permits."""
+    workspace_bundle = contract.get("workspaceBundle")
+    if not isinstance(workspace_bundle, dict):
+        raise WorkspaceContractError("runtime contract workspaceBundle must be an object")
+    origins = workspace_bundle.get("dataOrigins")
+    if not isinstance(origins, list) or not origins:
+        raise WorkspaceContractError("runtime contract dataOrigins must be a non-empty list")
+    normalized = [origin for origin in origins if isinstance(origin, str) and origin.strip()]
+    if len(normalized) != len(origins):
+        raise WorkspaceContractError("runtime contract dataOrigins must be non-empty strings")
+    return frozenset(normalized)
+
+
+def validate_workspace_bundle(
+    payload: Mapping[str, Any],
+    *,
+    path_label: str,
+    accepted_origins: Iterable[str],
+    contract: Mapping[str, Any] | None = None,
+) -> str:
+    """Validate a bundle against the shared contract invariants; return its data_origin.
+
+    ``accepted_origins`` is the caller's policy (a subset of the contract origins);
+    the ``contractVersion`` match and non-empty ``datasets`` checks are shared by all.
+    """
+    resolved = dict(contract) if contract is not None else load_runtime_contract()
+    accepted = frozenset(accepted_origins)
+
+    contract_version = payload.get("contractVersion")
+    if not isinstance(contract_version, str) or not contract_version.strip():
+        raise WorkspaceContractError(f"workspace bundle missing contractVersion in {path_label}")
+    if contract_version != resolved.get("version"):
+        raise WorkspaceContractError(
+            f"workspace contractVersion '{contract_version}' does not match runtime contract "
+            f"in {path_label}"
+        )
+
+    data_origin = payload.get("data_origin")
+    if not isinstance(data_origin, str) or data_origin not in accepted:
+        raise WorkspaceContractError(
+            f"workspace bundle requires data_origin of {', '.join(sorted(accepted))} in {path_label}"
+        )
+
+    datasets = payload.get("datasets")
+    if not isinstance(datasets, list) or not datasets:
+        raise WorkspaceContractError(f"workspace dataset inventory is empty in {path_label}")
+    return data_origin

--- a/tests/web/test_workspace_contract.py
+++ b/tests/web/test_workspace_contract.py
@@ -17,6 +17,45 @@ assert spec is not None and spec.loader is not None
 web_smoke_test = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(web_smoke_test)
 
+SERVE_PATH = ROOT / "scripts" / "web" / "serve_local.py"
+_serve_spec = importlib.util.spec_from_file_location("web_serve_local", SERVE_PATH)
+assert _serve_spec is not None and _serve_spec.loader is not None
+web_serve_local = importlib.util.module_from_spec(_serve_spec)
+_serve_spec.loader.exec_module(web_serve_local)
+
+
+def _bundle(*, version: str, data_origin: str = "generated") -> dict[str, object]:
+    return {
+        "contractVersion": version,
+        "data_origin": data_origin,
+        "datasets": [{"name": "core", "rows": []}],
+    }
+
+
+def _runtime_version() -> str:
+    return str(web_smoke_test._load_runtime_contract()["version"])
+
+
+def test_smoke_and_serve_agree_on_a_good_bundle() -> None:
+    # #639: a known-good bundle is accepted by BOTH consumers.
+    good = _bundle(version=_runtime_version())
+    assert (
+        web_smoke_test._assert_workspace_bundle(good, path_label="good", reject_fixture=False)
+        == "generated"
+    )
+    web_serve_local._assert_workspace_bundle(
+        good, path_label="good", allow_fixture_demo=True
+    )  # does not raise
+
+
+def test_smoke_and_serve_agree_on_contract_version_mismatch() -> None:
+    # #639: the divergence that let serve_local serve a bundle smoke rejected.
+    bad = _bundle(version="9.9.9-mismatch")
+    with pytest.raises(ValueError, match="does not match runtime contract"):
+        web_smoke_test._assert_workspace_bundle(bad, path_label="bad", reject_fixture=False)
+    with pytest.raises(ValueError, match="does not match runtime contract"):
+        web_serve_local._assert_workspace_bundle(bad, path_label="bad", allow_fixture_demo=True)
+
 
 def _copy_web_fixture(tmp_path: Path) -> Path:
     target = tmp_path / "web"


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:639 -->
> **Source:** Issue #639

Closes #639

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The web workspace bundle-contract is validated **three ways with inconsistent strictness**, so a bundle can pass one path and fail another:
`apps/web/app.js:112-141` (client) — `contractVersion` mismatch is **warn-only** (`:120-123`).
`scripts/web/smoke_test.py:30-120` — strict contract version + runtime-contract `data_origin` allowlist.
`scripts/web/serve_local.py:37-57` — minimal (`data_origin` + non-empty `datasets` only; **no `contractVersion` check**).

Concretely: `serve_local.py` can serve a bundle that `smoke_test.py` would reject, and `app.js` renders a contract-mismatched bundle with only a warning. Fixture handling also differs (`allow_fixture_demo` vs `reject_fixture` vs client labels). ~70 LOC of overlapping, divergent rules.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#394](https://github.com/stranske/Pension-Data/issues/394)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add `scripts/web/workspace_contract.py` with canonical validation for contract version, `data_origin` allowlist, datasets, and fixture policy, sourced from `apps/contracts/runtime-contract.json`.
- [ ] Update `scripts/web/smoke_test.py`, `scripts/web/serve_local.py`, and `scripts/web/build_workspace_bundle.py` to call `scripts/web/workspace_contract.py` and delete their local contract-validation logic.
- [ ] Fix `apps/web/app.js` to reject contract-version mismatches instead of warning, or load allowlist/version from `apps/contracts/runtime-contract.json` at build time.
  - [ ] Decide whether app.js should reject mismatches immediately or load validation rules from runtime-contract.json at build time (verify: confirm completion in repo)
  - [ ] Implement the chosen approach to make app.js enforce contract version validation consistently with Python validators (verify: confirm completion in repo)
  - [ ] Update app.js to load the contract version (verify: confirm completion in repo) data_origin allowlist from apps/contracts/runtime-contract.json during the build process (verify: confirm completion in repo)
  - [ ] Remove the warn-only behavior for contractVersion mismatches in apps/web/app.js lines 120-123 (verify: confirm completion in repo)
- [ ] Extend `tests/web/test_workspace_contract.py` under the `pytest tests/web -q` gate to assert all three consumers agree on a known-good and known-bad bundle.
  - [ ] Create or extend tests/web/test_workspace_contract.py with fixtures for known-good (verify: tests pass)
  - [ ] Create or extend tests/web/test_workspace_contract.py with known-bad bundle examples (verify: tests pass)
  - [ ] Write test cases that invoke smoke_test.py validation logic with known-good (verify: confirm completion in repo)
  - [ ] Write test cases that invoke smoke_test.py validation logic with known-bad bundles (verify: confirm completion in repo)
  - [ ] Write test cases that invoke serve_local.py validation logic with the same bundle fixtures (verify: confirm completion in repo)
  - [ ] _(2 further sub-tasks elided; split this issue)_
  - [ ] _(2 further sub-tasks elided; split this issue)_

#### Acceptance criteria
- [ ] A bundle rejected by `scripts/web/smoke_test.py` is also rejected by `scripts/web/serve_local.py` and is not served.
- [ ] `apps/web/app.js` refuses to render a bundle with a mismatched `contractVersion`.
- [ ] One Python module owns the rules, and `scripts/web/smoke_test.py`, `scripts/web/serve_local.py`, and `scripts/web/build_workspace_bundle.py` contain no parallel contract logic.
- [ ] `pytest tests/web -q` passes with coverage in `tests/web/test_workspace_contract.py` asserting all three consumers agree on a known-good and known-bad bundle.
- [ ] Deliberately bumping a bundle's `contractVersion` causes all paths to reject it, and reverting the change restores passing behavior.

**Head SHA:** b4f67fdfcf5f531b3331008687d2864225cba14e
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Pension-Data/actions/runs/29013970021) |
| Cross-Repo Smoke | ⏭️ skipped | [View run](https://github.com/stranske/Pension-Data/actions/runs/29012138936) |
| Entity Regression Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/29012138640) |
| Extraction Golden Regression | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/29012138653) |
| Foundation Fixture E2E | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/29012138608) |
| Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/29012138907) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/29012138656) |
| NL-SQL Golden | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/29012138643) |
| One-PDF Pilot Golden | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/29012138609) |
| PostgreSQL Integration | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/29012138646) |
| Quality Replay Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/29012138582) |
| Quality SLA Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/29012138601) |
| Running Copilot Code Review | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/29012150916) |
| Web Cloudflare Pages | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/29012138636) |
<!-- auto-status-summary:end -->