### PR TITLE
Fix remaining finite-value boundaries for #636

### DIFF
--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-11T23:44:09.923359Z",
+  "emitted_at": "2026-07-12T01:04:26.356372Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-11T22:08:55.499982Z",
+  "emitted_at": "2026-07-11T22:18:41.042007Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-12T02:06:38.507974Z",
+  "emitted_at": "2026-07-12T02:09:39.442323Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-12T01:32:43.427181Z",
+  "emitted_at": "2026-07-12T02:06:38.507974Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-12T01:11:37.679344Z",
+  "emitted_at": "2026-07-12T01:32:43.427181Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-11T22:43:49.496942Z",
+  "emitted_at": "2026-07-11T22:48:00.340140Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-11T20:14:22.651403Z",
+  "emitted_at": "2026-07-11T22:08:55.499982Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "711",
+  "pr_number": "712",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-11T22:48:00.340140Z",
+  "emitted_at": "2026-07-11T23:40:25.935355Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-11T22:37:39.964957Z",
+  "emitted_at": "2026-07-11T22:43:49.496942Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-12T01:04:26.356372Z",
+  "emitted_at": "2026-07-12T01:11:37.679344Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-11T22:18:41.042007Z",
+  "emitted_at": "2026-07-11T22:37:39.964957Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-11T23:40:25.935355Z",
+  "emitted_at": "2026-07-11T23:44:09.923359Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/src/pension_data/extract/governance/consultants.py
+++ b/src/pension_data/extract/governance/consultants.py
@@ -17,7 +17,7 @@ from pension_data.db.models.consultants import (
     ConsultantRecommendation,
     PlanConsultantEngagement,
 )
-from pension_data.finite_guards import bounded_confidence
+from pension_data.finite_guards import bounded_confidence, finite_or_none
 from pension_data.normalize.entity_tokens import normalize_entity_token
 
 ConsultantWarningCode = Literal["non_disclosure", "ambiguous_naming", "missing_topic"]
@@ -126,7 +126,11 @@ def _clean_text(value: str | None, *, fallback: str) -> str:
 
 
 def _bounded_confidence(value: float) -> float:
-    return bounded_confidence(value)
+    # An untrusted model confidence must not abort the whole document extraction.
+    # Downgrade it to zero so the extracted record stays reviewable rather than
+    # becoming a falsely high-confidence result or disappearing in an exception.
+    finite_value = finite_or_none(value)
+    return 0.0 if finite_value is None else bounded_confidence(finite_value)
 
 
 def _dedupe_refs(evidence_refs: tuple[str, ...]) -> tuple[str, ...]:

--- a/src/pension_data/extract/governance/consultants.py
+++ b/src/pension_data/extract/governance/consultants.py
@@ -17,6 +17,7 @@ from pension_data.db.models.consultants import (
     ConsultantRecommendation,
     PlanConsultantEngagement,
 )
+from pension_data.finite_guards import bounded_confidence
 from pension_data.normalize.entity_tokens import normalize_entity_token
 
 ConsultantWarningCode = Literal["non_disclosure", "ambiguous_naming", "missing_topic"]
@@ -125,7 +126,7 @@ def _clean_text(value: str | None, *, fallback: str) -> str:
 
 
 def _bounded_confidence(value: float) -> float:
-    return round(max(0.0, min(1.0, value)), 6)
+    return bounded_confidence(value)
 
 
 def _dedupe_refs(evidence_refs: tuple[str, ...]) -> tuple[str, ...]:

--- a/src/pension_data/extract/investment/risk_disclosures.py
+++ b/src/pension_data/extract/investment/risk_disclosures.py
@@ -8,7 +8,7 @@ from types import MappingProxyType
 from typing import Literal
 
 from pension_data.db.models.risk_exposures import RiskDisclosureType, RiskExposureObservation
-from pension_data.finite_guards import bounded_confidence, require_finite
+from pension_data.finite_guards import bounded_confidence, finite_or_none, require_finite
 
 ValueUnit = Literal["usd", "thousand_usd", "million_usd", "billion_usd", "ratio"]
 SourceKind = Literal["table", "narrative"]
@@ -80,7 +80,10 @@ def _dedupe_refs(evidence_refs: tuple[str, ...]) -> tuple[str, ...]:
 
 
 def _bounded_confidence(confidence: float) -> float:
-    return bounded_confidence(confidence)
+    # Preserve the disclosure record for review while ensuring a malformed model
+    # confidence can never be trusted or abort the full extraction.
+    finite_value = finite_or_none(confidence)
+    return 0.0 if finite_value is None else bounded_confidence(finite_value)
 
 
 def _source_metadata(

--- a/src/pension_data/extract/investment/risk_disclosures.py
+++ b/src/pension_data/extract/investment/risk_disclosures.py
@@ -8,6 +8,7 @@ from types import MappingProxyType
 from typing import Literal
 
 from pension_data.db.models.risk_exposures import RiskDisclosureType, RiskExposureObservation
+from pension_data.finite_guards import bounded_confidence, require_finite
 
 ValueUnit = Literal["usd", "thousand_usd", "million_usd", "billion_usd", "ratio"]
 SourceKind = Literal["table", "narrative"]
@@ -79,7 +80,7 @@ def _dedupe_refs(evidence_refs: tuple[str, ...]) -> tuple[str, ...]:
 
 
 def _bounded_confidence(confidence: float) -> float:
-    return round(max(0.0, min(1.0, confidence)), 6)
+    return bounded_confidence(confidence)
 
 
 def _source_metadata(
@@ -93,14 +94,14 @@ def _to_usd(value: float | None, *, unit: ValueUnit) -> float | None:
         return None
     if unit == "ratio":
         return None
-    return round(value * _UNIT_MULTIPLIER[unit], 6)
+    return round(require_finite(value, field="risk exposure") * _UNIT_MULTIPLIER[unit], 6)
 
 
 def _to_ratio(value: float | None, *, unit: ValueUnit) -> float | None:
     if value is None:
         return None
     if unit == "ratio":
-        return round(value, 6)
+        return round(require_finite(value, field="risk exposure"), 6)
     return None
 
 

--- a/src/pension_data/finite_guards.py
+++ b/src/pension_data/finite_guards.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import math
 
-__all__ = ["is_finite_number", "require_finite", "finite_or_none"]
+__all__ = ["bounded_confidence", "is_finite_number", "require_finite", "finite_or_none"]
 
 
 def is_finite_number(value: object) -> bool:
@@ -35,3 +35,8 @@ def finite_or_none(value: float | None) -> float | None:
     if value is None:
         return None
     return float(value) if is_finite_number(value) else None
+
+
+def bounded_confidence(value: float) -> float:
+    """Clamp a finite confidence to [0, 1]; reject NaN and infinities."""
+    return round(max(0.0, min(1.0, require_finite(value, field="confidence"))), 6)

--- a/src/pension_data/normalize/investment_normalization.py
+++ b/src/pension_data/normalize/investment_normalization.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pension_data.finite_guards import require_finite
 from pension_data.normalize.financial_units import UnitScale, normalize_money_to_usd
 
 _ALLOCATION_CATEGORY_ALIASES: dict[str, str] = {
@@ -29,6 +30,7 @@ def normalize_rate_to_ratio(rate: float | None) -> float | None:
     """Normalize fee or contribution rates into ratio units."""
     if rate is None:
         return None
+    rate = require_finite(rate, field="rate")
     if rate > 1.0:
         return round(rate / 100.0, 9)
     return round(rate, 9)

--- a/src/pension_data/quant/attribution_optimization.py
+++ b/src/pension_data/quant/attribution_optimization.py
@@ -48,7 +48,9 @@ def compute_attribution(
         if bucket not in realized_returns:
             raise ValueError(f"missing realized return for bucket '{bucket}'")
         weight = require_finite(weight, field=f"weights[{bucket!r}]")
-        return_rate = require_finite(realized_returns[bucket], field=f"realized_returns[{bucket!r}]")
+        return_rate = require_finite(
+            realized_returns[bucket], field=f"realized_returns[{bucket!r}]"
+        )
         rows.append(
             AttributionRow(
                 bucket=bucket,

--- a/src/pension_data/quant/attribution_optimization.py
+++ b/src/pension_data/quant/attribution_optimization.py
@@ -10,6 +10,8 @@ from itertools import product
 from pathlib import Path
 from typing import Literal
 
+from pension_data.finite_guards import require_finite
+
 _MAX_GRID_CANDIDATES = 250_000
 
 
@@ -45,7 +47,8 @@ def compute_attribution(
         weight = weights[bucket]
         if bucket not in realized_returns:
             raise ValueError(f"missing realized return for bucket '{bucket}'")
-        return_rate = realized_returns[bucket]
+        weight = require_finite(weight, field=f"weights[{bucket!r}]")
+        return_rate = require_finite(realized_returns[bucket], field=f"realized_returns[{bucket!r}]")
         rows.append(
             AttributionRow(
                 bucket=bucket,
@@ -65,6 +68,9 @@ def reconcile_attribution(
     tolerance: float = 1e-6,
 ) -> AttributionReconciliation:
     """Reconcile computed attribution total against a source aggregate."""
+    computed_total = require_finite(computed_total, field="computed_total")
+    source_aggregate = require_finite(source_aggregate, field="source_aggregate")
+    tolerance = require_finite(tolerance, field="tolerance")
     if tolerance < 0:
         raise ValueError("tolerance must be >= 0")
     delta = computed_total - source_aggregate

--- a/src/pension_data/quant/scenarios.py
+++ b/src/pension_data/quant/scenarios.py
@@ -82,7 +82,11 @@ def _validate_input(scenario: ScenarioInput, config: ScenarioRunConfig) -> None:
             raise ValueError("macro_shocks values must be numeric")
         if not math.isfinite(shock):
             raise ValueError("macro_shocks values must be finite")
-    for field, value in (("contribution_delta", scenario.contribution_delta), ("fee_delta_bps", scenario.fee_delta_bps), ("return_override", scenario.return_override)):
+    for field, value in (
+        ("contribution_delta", scenario.contribution_delta),
+        ("fee_delta_bps", scenario.fee_delta_bps),
+        ("return_override", scenario.return_override),
+    ):
         if value is not None and not math.isfinite(value):
             raise ValueError(f"{field} must be finite")
 

--- a/src/pension_data/quant/scenarios.py
+++ b/src/pension_data/quant/scenarios.py
@@ -12,6 +12,8 @@ from random import Random
 from statistics import fmean
 from typing import Literal
 
+from pension_data.finite_guards import require_finite
+
 ScenarioMode = Literal["deterministic", "simulation"]
 
 
@@ -87,8 +89,8 @@ def _validate_input(scenario: ScenarioInput, config: ScenarioRunConfig) -> None:
         ("fee_delta_bps", scenario.fee_delta_bps),
         ("return_override", scenario.return_override),
     ):
-        if value is not None and not math.isfinite(value):
-            raise ValueError(f"{field} must be finite")
+        if value is not None:
+            require_finite(value, field=field)
 
 
 def _normalized_macro_shocks(values: Mapping[str, float]) -> dict[str, float]:

--- a/src/pension_data/quant/scenarios.py
+++ b/src/pension_data/quant/scenarios.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from numbers import Real
@@ -79,6 +80,11 @@ def _validate_input(scenario: ScenarioInput, config: ScenarioRunConfig) -> None:
             raise ValueError("macro_shocks keys must be non-empty")
         if isinstance(shock, bool) or not isinstance(shock, Real):
             raise ValueError("macro_shocks values must be numeric")
+        if not math.isfinite(shock):
+            raise ValueError("macro_shocks values must be finite")
+    for field, value in (("contribution_delta", scenario.contribution_delta), ("fee_delta_bps", scenario.fee_delta_bps), ("return_override", scenario.return_override)):
+        if value is not None and not math.isfinite(value):
+            raise ValueError(f"{field} must be finite")
 
 
 def _normalized_macro_shocks(values: Mapping[str, float]) -> dict[str, float]:

--- a/tests/extract/governance/test_consultant_extraction.py
+++ b/tests/extract/governance/test_consultant_extraction.py
@@ -6,6 +6,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from pension_data.extract.governance.consultants import (
     AttributionMention,
     ConsultantMention,
@@ -16,6 +18,13 @@ from pension_data.extract.governance.consultants import (
 )
 
 FIXTURE_PATH = Path(__file__).parent / "fixtures" / "consultant_extraction_golden.json"
+
+
+@pytest.mark.parametrize("value", (float("nan"), float("inf"), float("-inf")))
+def test_non_finite_consultant_confidence_is_downgraded(value: float) -> None:
+    from pension_data.extract.governance.consultants import _bounded_confidence
+
+    assert _bounded_confidence(value) == 0.0
 
 
 def _load_fixture() -> dict[str, Any]:

--- a/tests/extract/investment/test_risk_disclosures.py
+++ b/tests/extract/investment/test_risk_disclosures.py
@@ -21,6 +21,7 @@ def test_non_finite_risk_confidence_is_downgraded(value: float) -> None:
 
     assert _bounded_confidence(value) == 0.0
 
+
 FIXTURE_PATH = Path(__file__).parent / "fixtures" / "risk_disclosures_golden.json"
 
 

--- a/tests/extract/investment/test_risk_disclosures.py
+++ b/tests/extract/investment/test_risk_disclosures.py
@@ -14,6 +14,13 @@ from pension_data.extract.investment.risk_disclosures import (
     extract_risk_exposure_observations,
 )
 
+
+@pytest.mark.parametrize("value", (float("nan"), float("inf"), float("-inf")))
+def test_non_finite_risk_confidence_is_downgraded(value: float) -> None:
+    from pension_data.extract.investment.risk_disclosures import _bounded_confidence
+
+    assert _bounded_confidence(value) == 0.0
+
 FIXTURE_PATH = Path(__file__).parent / "fixtures" / "risk_disclosures_golden.json"
 
 

--- a/tests/quality/test_finite_bounds.py
+++ b/tests/quality/test_finite_bounds.py
@@ -97,7 +97,9 @@ def test_attribution_rejects_non_finite(value: float) -> None:
         reconcile_attribution(computed_total=0.05, source_aggregate=0.05, tolerance=value)
 
 
-@pytest.mark.parametrize("field", ("macro_shocks", "contribution_delta", "fee_delta_bps", "return_override"))
+@pytest.mark.parametrize(
+    "field", ("macro_shocks", "contribution_delta", "fee_delta_bps", "return_override")
+)
 @pytest.mark.parametrize("value", NON_FINITE)
 def test_scenario_rejects_non_finite_input(field: str, value: float) -> None:
     scenario_fields: dict[str, object] = {"name": "bad", "macro_shocks": {"funded_ratio": 0.0}}

--- a/tests/quality/test_finite_bounds.py
+++ b/tests/quality/test_finite_bounds.py
@@ -13,6 +13,7 @@ import pytest
 
 from pension_data.finite_guards import finite_or_none, is_finite_number, require_finite
 from pension_data.normalize.financial_units import normalize_money_to_usd
+from pension_data.normalize.investment_normalization import normalize_rate_to_ratio
 from pension_data.quality.anomaly_rules import (
     AnomalyThresholds,
     TimeSeriesPoint,
@@ -20,7 +21,13 @@ from pension_data.quality.anomaly_rules import (
 )
 from pension_data.quality.confidence import ExtractionConfidenceInput, route_confidence_row
 from pension_data.quality.sla_metrics import _safe_ratio
+from pension_data.quant.attribution_optimization import compute_attribution, reconcile_attribution
 from pension_data.quant.metric_engine import _to_float
+from pension_data.quant.scenarios import (
+    ScenarioInput,
+    ScenarioRunConfig,
+    run_deterministic_scenario,
+)
 
 NON_FINITE = [float("nan"), float("inf"), float("-inf")]
 
@@ -68,6 +75,25 @@ def test_normalize_money_rejects_non_finite(value: float) -> None:
 def test_normalize_money_finite_ok_and_none_passthrough() -> None:
     assert normalize_money_to_usd(1.5, unit_scale="million_usd") == 1_500_000.0
     assert normalize_money_to_usd(None, unit_scale="usd") is None
+
+
+@pytest.mark.parametrize("value", NON_FINITE)
+def test_investment_rate_rejects_non_finite(value: float) -> None:
+    with pytest.raises(ValueError):
+        normalize_rate_to_ratio(value)
+
+
+@pytest.mark.parametrize("value", NON_FINITE)
+def test_attribution_rejects_non_finite(value: float) -> None:
+    with pytest.raises(ValueError):
+        compute_attribution(weights={"equity": value}, realized_returns={"equity": 0.05})
+    with pytest.raises(ValueError):
+        reconcile_attribution(computed_total=0.05, source_aggregate=value)
+
+
+def test_scenario_rejects_non_finite_input() -> None:
+    with pytest.raises(ValueError, match="finite"):
+        run_deterministic_scenario(plan_id="p", plan_period="FY", baseline_metrics={"funded_ratio": 0.8}, scenario=ScenarioInput(name="bad", macro_shocks={"funded_ratio": float("nan")}), config=ScenarioRunConfig(module_version="v1"), source_snapshot_id="s")
 
 
 # --- SLA ratios ---------------------------------------------------------------

--- a/tests/quality/test_finite_bounds.py
+++ b/tests/quality/test_finite_bounds.py
@@ -88,16 +88,26 @@ def test_attribution_rejects_non_finite(value: float) -> None:
     with pytest.raises(ValueError):
         compute_attribution(weights={"equity": value}, realized_returns={"equity": 0.05})
     with pytest.raises(ValueError):
+        compute_attribution(weights={"equity": 0.5}, realized_returns={"equity": value})
+    with pytest.raises(ValueError):
         reconcile_attribution(computed_total=0.05, source_aggregate=value)
+    with pytest.raises(ValueError):
+        reconcile_attribution(computed_total=value, source_aggregate=0.05)
+    with pytest.raises(ValueError):
+        reconcile_attribution(computed_total=0.05, source_aggregate=0.05, tolerance=value)
 
 
-def test_scenario_rejects_non_finite_input() -> None:
+@pytest.mark.parametrize("field", ("macro_shocks", "contribution_delta", "fee_delta_bps", "return_override"))
+@pytest.mark.parametrize("value", NON_FINITE)
+def test_scenario_rejects_non_finite_input(field: str, value: float) -> None:
+    scenario_fields: dict[str, object] = {"name": "bad", "macro_shocks": {"funded_ratio": 0.0}}
+    scenario_fields[field] = {"funded_ratio": value} if field == "macro_shocks" else value
     with pytest.raises(ValueError, match="finite"):
         run_deterministic_scenario(
             plan_id="p",
             plan_period="FY",
             baseline_metrics={"funded_ratio": 0.8},
-            scenario=ScenarioInput(name="bad", macro_shocks={"funded_ratio": float("nan")}),
+            scenario=ScenarioInput(**scenario_fields),  # type: ignore[arg-type]
             config=ScenarioRunConfig(module_version="v1"),
             source_snapshot_id="s",
         )

--- a/tests/quality/test_finite_bounds.py
+++ b/tests/quality/test_finite_bounds.py
@@ -93,7 +93,14 @@ def test_attribution_rejects_non_finite(value: float) -> None:
 
 def test_scenario_rejects_non_finite_input() -> None:
     with pytest.raises(ValueError, match="finite"):
-        run_deterministic_scenario(plan_id="p", plan_period="FY", baseline_metrics={"funded_ratio": 0.8}, scenario=ScenarioInput(name="bad", macro_shocks={"funded_ratio": float("nan")}), config=ScenarioRunConfig(module_version="v1"), source_snapshot_id="s")
+        run_deterministic_scenario(
+            plan_id="p",
+            plan_period="FY",
+            baseline_metrics={"funded_ratio": 0.8},
+            scenario=ScenarioInput(name="bad", macro_shocks={"funded_ratio": float("nan")}),
+            config=ScenarioRunConfig(module_version="v1"),
+            source_snapshot_id="s",
+        )
 
 
 # --- SLA ratios ---------------------------------------------------------------


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:636 -->
> **Source:** Issue #636

Closes #636

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
At numeric trust boundaries the pipeline guards values with bare `< 0` / `> 1` comparisons, which **NaN and ±inf defeat** (NaN compares false to everything; +inf is "non-negative"). For a pension-fact data-integrity product this is severe and is **reachable on the production pipeline** (`ops/document_orchestration.py`). The worst case is verified: a NaN extraction confidence is clamped to **`1.0` → `auto_accept`** (`quality/confidence.py:43` `_bounded_confidence` = `round(max(0.0, min(1.0, value)), 6)`; `min(1.0, nan) == 1.0`), so a garbage/failed extraction gets maximum trust and **bypasses human review**. NaN money/flows are stored too. The repo already has the right idea elsewhere — this issue makes finite/bounds checking consistent.

These pass green CI only because golden fixtures are homogeneous (no NaN/inf/zero/edge inputs).

#### Tasks
- [x] Create a finite-aware clamp in `quality/confidence.py` that uses `math.isfinite()` to reject or flag non-finite confidence inputs instead of clamping `NaN` to `1.0`, replace the duplicated `_bounded_confidence` implementations in `quality/confidence.py:43`, `extract/governance/consultants.py:127`, `extract/investment/risk_disclosures.py:81`, and `quant/metric_engine.py:134` with this shared implementation, and add or update tests verifying `NaN`, `+inf`, and `-inf` are not converted to `1.0` and all affected tests pass.
  - [x] Create a finite-aware clamp function in `quality/confidence.py` that uses `math.isfinite()` to reject or flag non-finite confidence inputs instead of clamping NaN to 1.0 (verify: confirm completion in repo)
  - [x] Replace the duplicated `_bounded_confidence` implementation in `quality/confidence.py:43` with the new shared finite-aware clamp function (verify: confirm completion in repo)
  - [x] Replace the duplicated `_bounded_confidence` implementation in `extract/governance/consultants.py:127` with the new shared finite-aware clamp function (verify: confirm completion in repo)
  - [x] Replace the duplicated `_bounded_confidence` implementation in `extract/investment/risk_disclosures.py:81` with the new shared finite-aware clamp function (verify: confirm completion in repo)
  - [x] Replace the duplicated `_bounded_confidence` implementation in `quant/metric_engine.py:134` with the new shared finite-aware clamp function (verify: confirm completion in repo)
  - [x] _(3 further sub-tasks elided; split this issue)_
- [x] Add `math.isfinite` guards at `normalize/financial_units.py:22` (`normalize_money_to_usd`), `extract/funded/financial_flows.py:102+`, `normalize/investment_normalization.py:32`, `quant/metric_engine.py:177+`, `quant/attribution_optimization.py`, `quant/scenarios.py`, `quality/anomaly_rules.py:51+`, `quality/sla_metrics.py:144+`, `extract/persistence.py:241+`, and `provenance/metrics.py:97+` to reject or flag non-finite values instead of silently storing them.
  - [x] Add `math.isfinite` guard to `normalize/financial_units.py:22` in the `normalize_money_to_usd` function to reject or flag non-finite monetary values (verify: confirm completion in repo)
  - [x] Add `math.isfinite` guards to `extract/funded/financial_flows.py:102+` to reject or flag non-finite financial flow values (verify: confirm completion in repo)
  - [x] Add `math.isfinite` guard to `normalize/investment_normalization.py:32` to reject or flag non-finite investment values (verify: confirm completion in repo)
  - [x] Add `math.isfinite` guards to `quant/metric_engine.py:177+` to reject or flag non-finite metric computation inputs (verify: confirm completion in repo)
  - [x] Add `math.isfinite` guards to `quant/attribution_optimization.py` to reject or flag non-finite optimization inputs (verify: confirm completion in repo)
  - [x] _(5 further sub-tasks elided; split this issue)_
- [x] Update routing so non-finite extracted values go to `high_priority_review` or blocked, never `auto_accept`.
- [x] Write `tests/quality/test_finite_bounds.py` and targeted tests in normalize/quant/extract covering NaN, `+inf`, and `-inf` at each listed boundary.
  - [x] Create `tests/quality/test_finite_bounds.py` with test cases covering NaN (verify: tests pass)
  - [x] Create `tests/quality/test_finite_bounds.py` with positive infinity (verify: tests pass)
  - [x] Create `tests/quality/test_finite_bounds.py` with and negative infinity for confidence clamping (verify: tests pass)
  - [x] Create `tests/quality/test_finite_bounds.py` with routing (verify: tests pass)
  - [x] Write targeted tests in the normalize module covering NaN, positive infinity, (verify: tests pass)
  - [x] _(8 further sub-tasks elided; split this issue)_

#### Acceptance criteria
- [x] `route_confidence_row(confidence=float("nan"))` does not return `auto_accept`, and confidence is not reported as `1.0`.
- [ ] `normalize_money_to_usd(float("nan"), ...)` and `extract_plan_financial_flow` with NaN AUM raise or flag the value and do not store NaN.
- [ ] `compute_derived_metrics`, anomaly rules, SLA ratios, and the persistence boundary reject or flag non-finite inputs.
- [ ] `tests/quality/test_finite_bounds.py` exists, targeted normalize/quant/extract tests exist, and they cover NaN, `+inf`, and `-inf` at each listed boundary.
- [ ] Reverting one `math.isfinite` guard causes its corresponding test to fail, and restoring the guard makes the test pass.
- [ ] The full test suite stays green.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation across investment normalization, attribution optimization, risk disclosures, consultant governance confidence handling, and deterministic scenario processing by rejecting non-finite numeric inputs (`NaN`, `+∞`, `-∞`).
  * Standardized bounded “confidence” values to consistently enforce finite inputs, clamp to the 0–1 range, and apply uniform 6-decimal rounding during normalization.

* **Tests**
  * Added regression tests asserting `NaN`/`±∞` rejection for rate normalization and attribution compute/reconcile, and failure when `macro_shocks` contains `NaN`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->