### PR TITLE
fix: guard finite provenance evidence confidence

### DIFF
--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-12T04:15:36.069664Z",
+  "emitted_at": "2026-07-12T04:21:16.009596Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-12T02:09:39.442323Z",
+  "emitted_at": "2026-07-12T04:08:08.575346Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "712",
+  "pr_number": "713",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-12T04:08:08.575346Z",
+  "emitted_at": "2026-07-12T04:15:36.069664Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/src/pension_data/provenance/metrics.py
+++ b/src/pension_data/provenance/metrics.py
@@ -15,6 +15,7 @@ from pension_data.db.models.core_facts import (
 from pension_data.db.models.provenance import EvidenceReference, MetricEvidenceLink
 from pension_data.extract.common.evidence import build_evidence_reference, canonicalize_evidence_ref
 from pension_data.extract.common.ids import stable_id
+from pension_data.finite_guards import finite_or_none
 
 
 class EvidenceValidationError(ValueError):
@@ -223,7 +224,9 @@ def build_core_metric_evidence_artifacts(
                 metric_family=source.metric_family,
                 metric_name=source.metric_name,
                 evidence_ref_id=evidence.evidence_ref_id,
-                confidence=source.confidence,
+                # Evidence links are exported to downstream reviewers, so do not
+                # let a NaN/inf confidence cross this final provenance boundary.
+                confidence=finite_or_none(source.confidence),
             )
             links_by_id[link.link_id] = link
 

--- a/tests/extract/funded/test_financial_flows.py
+++ b/tests/extract/funded/test_financial_flows.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -125,3 +126,15 @@ def test_source_metadata_is_read_only() -> None:
     )
     with pytest.raises(TypeError):
         flow.source_metadata["unit_scale"] = "usd"
+
+
+@pytest.mark.parametrize("value", (float("nan"), float("inf"), float("-inf")))
+def test_non_finite_aum_is_rejected_before_a_flow_row_is_created(value: float) -> None:
+    fixture = _load_fixture()["complete_million_layout"]
+
+    with pytest.raises(ValueError, match="amount must be a finite number"):
+        extract_plan_financial_flow(
+            plan_id=fixture["plan_id"],
+            plan_period=fixture["plan_period"],
+            raw=replace(_raw(fixture["raw"]), beginning_aum=value),
+        )

--- a/tests/extract/test_persistence_pipeline.py
+++ b/tests/extract/test_persistence_pipeline.py
@@ -429,6 +429,24 @@ def test_persisted_fact_ids_use_normalized_evidence_refs() -> None:
     assert id_from_whitespace_dupes["evidence_refs"] == ["p14"]
 
 
+@pytest.mark.parametrize("value", (float("nan"), float("inf"), float("-inf")))
+def test_persistence_drops_non_finite_metric_values_and_confidence(value: float) -> None:
+    funded_fixture = _load_json(FUNDED_FIXTURE_PATH)["table_layout_complete"]
+    funded_rows, _ = extract_funded_and_actuarial_metrics(
+        plan_id=funded_fixture["plan_id"],
+        plan_period=funded_fixture["plan_period"],
+        raw=_raw_funded(funded_fixture["raw"]),
+    )
+
+    persisted = persist_funded_actuarial_metrics(
+        [replace(funded_rows[0], normalized_value=value, confidence=value)],
+        benchmark_version="v1",
+    )[0]
+
+    assert persisted["normalized_value"] is None
+    assert persisted["confidence"] is None
+
+
 def test_funded_diagnostics_require_warning_context() -> None:
     funded_fixture = _load_json(FUNDED_FIXTURE_PATH)["text_layout_missing_participants"]
     _, funded_diagnostics = extract_funded_and_actuarial_metrics(

--- a/tests/provenance/test_core_metric_evidence.py
+++ b/tests/provenance/test_core_metric_evidence.py
@@ -120,6 +120,23 @@ def test_builder_threads_per_link_confidence_from_fact() -> None:
     assert all(link.confidence == pytest.approx(0.91) for link in links)
 
 
+@pytest.mark.parametrize("value", (float("nan"), float("inf"), float("-inf")))
+def test_builder_drops_non_finite_fact_confidence_from_evidence_links(value: float) -> None:
+    funded_facts = (
+        FundedStatusFact(
+            context=_context(source_document_id="doc:ca:2025:funded"),
+            metric_name="funded_ratio",
+            metric_value=_value(),
+            confidence=value,
+            evidence_refs=("p.45",),
+        ),
+    )
+
+    artifacts = build_core_metric_evidence_artifacts(funded_facts=funded_facts)
+
+    assert artifacts["metric_evidence_links"][0].confidence is None
+
+
 def test_table_derived_finding_populates_method_table() -> None:
     # Parser table rows emit page locators with a table section marker. That
     # must surface method="table" through the real artifact builder path.


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:636 -->
> **Source:** Issue #636

Closes #636

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
At numeric trust boundaries the pipeline guards values with bare `< 0` / `> 1` comparisons, which **NaN and ±inf defeat** (NaN compares false to everything; +inf is "non-negative"). For a pension-fact data-integrity product this is severe and is **reachable on the production pipeline** (`ops/document_orchestration.py`). The worst case is verified: a NaN extraction confidence is clamped to **`1.0` → `auto_accept`** (`quality/confidence.py:43` `_bounded_confidence` = `round(max(0.0, min(1.0, value)), 6)`; `min(1.0, nan) == 1.0`), so a garbage/failed extraction gets maximum trust and **bypasses human review**. NaN money/flows are stored too. The repo already has the right idea elsewhere — this issue makes finite/bounds checking consistent.

These pass green CI only because golden fixtures are homogeneous (no NaN/inf/zero/edge inputs).

#### Tasks
- [ ] Create a finite-aware clamp in `quality/confidence.py` that uses `math.isfinite()` to reject or flag non-finite confidence inputs instead of clamping `NaN` to `1.0`, replace the duplicated `_bounded_confidence` implementations in `quality/confidence.py:43`, `extract/governance/consultants.py:127`, `extract/investment/risk_disclosures.py:81`, and `quant/metric_engine.py:134` with this shared implementation, and add or update tests verifying `NaN`, `+inf`, and `-inf` are not converted to `1.0` and all affected tests pass.
  - [ ] Create a finite-aware clamp function in `quality/confidence.py` that uses `math.isfinite()` to reject or flag non-finite confidence inputs instead of clamping NaN to 1.0 (verify: confirm completion in repo)
  - [ ] Replace the duplicated `_bounded_confidence` implementation in `quality/confidence.py:43` with the new shared finite-aware clamp function (verify: confirm completion in repo)
  - [ ] Replace the duplicated `_bounded_confidence` implementation in `extract/governance/consultants.py:127` with the new shared finite-aware clamp function (verify: confirm completion in repo)
  - [ ] Replace the duplicated `_bounded_confidence` implementation in `extract/investment/risk_disclosures.py:81` with the new shared finite-aware clamp function (verify: confirm completion in repo)
  - [ ] Replace the duplicated `_bounded_confidence` implementation in `quant/metric_engine.py:134` with the new shared finite-aware clamp function (verify: confirm completion in repo)
  - [ ] _(3 further sub-tasks elided; split this issue)_
- [x] Add `math.isfinite` guards at `normalize/financial_units.py:22` (`normalize_money_to_usd`), `extract/funded/financial_flows.py:102+`, `normalize/investment_normalization.py:32`, `quant/metric_engine.py:177+`, `quant/attribution_optimization.py`, `quant/scenarios.py`, `quality/anomaly_rules.py:51+`, `quality/sla_metrics.py:144+`, `extract/persistence.py:241+`, and `provenance/metrics.py:97+` to reject or flag non-finite values instead of silently storing them.
  - [x] Add `math.isfinite` guard to `normalize/financial_units.py:22` in the `normalize_money_to_usd` function to reject or flag non-finite monetary values (verify: confirm completion in repo)
  - [x] Add `math.isfinite` guards to `extract/funded/financial_flows.py:102+` to reject or flag non-finite financial flow values (verify: confirm completion in repo)
  - [x] Add `math.isfinite` guard to `normalize/investment_normalization.py:32` to reject or flag non-finite investment values (verify: confirm completion in repo)
  - [x] Add `math.isfinite` guards to `quant/metric_engine.py:177+` to reject or flag non-finite metric computation inputs (verify: confirm completion in repo)
  - [x] Add `math.isfinite` guards to `quant/attribution_optimization.py` to reject or flag non-finite optimization inputs (verify: confirm completion in repo)
  - [x] _(5 further sub-tasks elided; split this issue)_
- [ ] Update routing so non-finite extracted values go to `high_priority_review` or blocked, never `auto_accept`.
- [ ] Write `tests/quality/test_finite_bounds.py` and targeted tests in normalize/quant/extract covering NaN, `+inf`, and `-inf` at each listed boundary.
  - [ ] Create `tests/quality/test_finite_bounds.py` with test cases covering NaN (verify: tests pass)
  - [ ] Create `tests/quality/test_finite_bounds.py` with positive infinity (verify: tests pass)
  - [ ] Create `tests/quality/test_finite_bounds.py` with and negative infinity for confidence clamping (verify: tests pass)
  - [ ] Create `tests/quality/test_finite_bounds.py` with routing (verify: tests pass)
  - [ ] Write targeted tests in the normalize module covering NaN, positive infinity, (verify: tests pass)
  - [ ] _(8 further sub-tasks elided; split this issue)_

#### Acceptance criteria
- [ ] `route_confidence_row(confidence=float("nan"))` does not return `auto_accept`, and confidence is not reported as `1.0`.
- [ ] `normalize_money_to_usd(float("nan"), ...)` and `extract_plan_financial_flow` with NaN AUM raise or flag the value and do not store NaN.
- [ ] `compute_derived_metrics`, anomaly rules, SLA ratios, and the persistence boundary reject or flag non-finite inputs.
- [ ] `tests/quality/test_finite_bounds.py` exists, targeted normalize/quant/extract tests exist, and they cover NaN, `+inf`, and `-inf` at each listed boundary.
- [ ] Reverting one `math.isfinite` guard causes its corresponding test to fail, and restoring the guard makes the test pass.
- [ ] The full test suite stays green.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented non-finite (NaN/inf/-inf) confidence values from propagating into metric evidence and provenance.
  * Ensured non-finite metric values and confidence scores are not persisted and are cleared instead.
  * Added validation to reject non-finite financial flow inputs (e.g., non-finite beginning AUM).
* **Tests**
  * Added coverage to verify non-finite inputs are rejected early, dropped during persistence, and excluded when building metric evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->