### PR TITLE
fix: centralize finite confidence bounds

### DIFF
--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-12T06:30:01.378539Z",
+  "emitted_at": "2026-07-12T06:37:40.748523Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-12T06:55:11.223434Z",
+  "emitted_at": "2026-07-12T07:02:54.653895Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-12T06:49:45.570954Z",
+  "emitted_at": "2026-07-12T06:55:11.223434Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-12T08:06:40.820513Z",
+  "emitted_at": "2026-07-12T08:09:59.618443Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-12T04:21:16.009596Z",
+  "emitted_at": "2026-07-12T06:30:01.378539Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "713",
+  "pr_number": "714",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-12T07:30:05.473851Z",
+  "emitted_at": "2026-07-12T08:06:40.820513Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-12T06:37:40.748523Z",
+  "emitted_at": "2026-07-12T06:43:22.694186Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-12T07:02:54.653895Z",
+  "emitted_at": "2026-07-12T07:08:38.494419Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-12T08:09:59.618443Z",
+  "emitted_at": "2026-07-12T08:12:58.998778Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-12T07:08:38.494419Z",
+  "emitted_at": "2026-07-12T07:30:05.473851Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-12T08:12:58.998778Z",
+  "emitted_at": "2026-07-12T08:16:36.513612Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-12T06:43:22.694186Z",
+  "emitted_at": "2026-07-12T06:49:45.570954Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/src/pension_data/extract/governance/consultants.py
+++ b/src/pension_data/extract/governance/consultants.py
@@ -17,7 +17,7 @@ from pension_data.db.models.consultants import (
     ConsultantRecommendation,
     PlanConsultantEngagement,
 )
-from pension_data.finite_guards import bounded_confidence, finite_or_none
+from pension_data.finite_guards import bounded_confidence_or_zero
 from pension_data.normalize.entity_tokens import normalize_entity_token
 
 ConsultantWarningCode = Literal["non_disclosure", "ambiguous_naming", "missing_topic"]
@@ -123,14 +123,6 @@ def _clean_text(value: str | None, *, fallback: str) -> str:
         return fallback
     normalized = value.strip()
     return normalized if normalized else fallback
-
-
-def _bounded_confidence(value: float) -> float:
-    # An untrusted model confidence must not abort the whole document extraction.
-    # Downgrade it to zero so the extracted record stays reviewable rather than
-    # becoming a falsely high-confidence result or disappearing in an exception.
-    finite_value = finite_or_none(value)
-    return 0.0 if finite_value is None else bounded_confidence(finite_value)
 
 
 def _dedupe_refs(evidence_refs: tuple[str, ...]) -> tuple[str, ...]:
@@ -265,7 +257,7 @@ def extract_consultant_records(
                 ambiguous_names=ambiguous_names,
             ),
             confidence=max(
-                _bounded_confidence(consultant_mention.confidence)
+                bounded_confidence_or_zero(consultant_mention.confidence)
                 for consultant_mention in consultant_group
             ),
             evidence_refs=merged_refs,
@@ -297,7 +289,7 @@ def extract_consultant_records(
                 consultant_mention.role_description, fallback="not_disclosed"
             ),
             is_disclosed=_is_disclosed_name(consultant_mention.consultant_name),
-            confidence=_bounded_confidence(consultant_mention.confidence),
+            confidence=bounded_confidence_or_zero(consultant_mention.confidence),
             evidence_refs=_dedupe_refs(consultant_mention.evidence_refs),
             source_metadata=_source_metadata(consultant_mention.source_url),
         )
@@ -383,7 +375,7 @@ def extract_consultant_records(
                 board_decision_status=normalize_board_decision_status(
                     recommendation_mention.board_decision_status
                 ),
-                confidence=_bounded_confidence(recommendation_mention.confidence),
+                confidence=bounded_confidence_or_zero(recommendation_mention.confidence),
                 evidence_refs=_dedupe_refs(recommendation_mention.evidence_refs),
                 source_metadata=_source_metadata(recommendation_mention.source_url),
             )
@@ -427,7 +419,7 @@ def extract_consultant_records(
             recommendation_topic=_clean_text(attr_mention.topic, fallback="not_disclosed"),
             observed_outcome=_clean_text(attr_mention.observed_outcome, fallback="not_disclosed"),
             strength=normalize_attribution_strength(attr_mention.strength),
-            confidence=_bounded_confidence(attr_mention.confidence),
+            confidence=bounded_confidence_or_zero(attr_mention.confidence),
             evidence_refs=_dedupe_refs(attr_mention.evidence_refs),
             source_metadata=_source_metadata(attr_mention.source_url),
         )

--- a/src/pension_data/extract/investment/risk_disclosures.py
+++ b/src/pension_data/extract/investment/risk_disclosures.py
@@ -8,7 +8,7 @@ from types import MappingProxyType
 from typing import Literal
 
 from pension_data.db.models.risk_exposures import RiskDisclosureType, RiskExposureObservation
-from pension_data.finite_guards import bounded_confidence, finite_or_none, require_finite
+from pension_data.finite_guards import bounded_confidence_or_zero, require_finite
 
 ValueUnit = Literal["usd", "thousand_usd", "million_usd", "billion_usd", "ratio"]
 SourceKind = Literal["table", "narrative"]
@@ -79,13 +79,6 @@ def _dedupe_refs(evidence_refs: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(dict.fromkeys(ref.strip() for ref in evidence_refs if ref.strip()))
 
 
-def _bounded_confidence(confidence: float) -> float:
-    # Preserve the disclosure record for review while ensuring a malformed model
-    # confidence can never be trusted or abort the full extraction.
-    finite_value = finite_or_none(confidence)
-    return 0.0 if finite_value is None else bounded_confidence(finite_value)
-
-
 def _source_metadata(
     *, source_url: str, source_kind: SourceKind, unit: ValueUnit
 ) -> MappingProxyType[str, str]:
@@ -132,7 +125,7 @@ def _make_observation(
         value_usd=_to_usd(value, unit=unit),
         value_ratio=_to_ratio(value, unit=unit),
         as_reported_text=as_reported_text.strip() or "not_disclosed",
-        confidence=_bounded_confidence(confidence),
+        confidence=bounded_confidence_or_zero(confidence),
         evidence_refs=_dedupe_refs(evidence_refs),
         source_metadata=_source_metadata(source_url=source_url, source_kind=source_kind, unit=unit),
     )

--- a/src/pension_data/finite_guards.py
+++ b/src/pension_data/finite_guards.py
@@ -51,10 +51,22 @@ def bounded_confidence(value: float) -> float:
 
 
 def bounded_confidence_or_none(value: object) -> float | None:
-    """Clamp a finite confidence or return ``None`` for an untrustworthy value."""
-    if not is_finite_number(value):
+    """Clamp a finite confidence or return ``None`` for an untrustworthy value.
+
+    Confidence tokens originate in extractor payloads, where a finite numeric
+    value can legitimately arrive as a string.  Preserve that established input
+    contract while still rejecting booleans, malformed values, NaN, and
+    infinities before routing or persistence can trust them.
+    """
+    if isinstance(value, bool):
         return None
-    return bounded_confidence(float(value))
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(parsed):
+        return None
+    return bounded_confidence(parsed)
 
 
 def bounded_confidence_or_zero(value: object) -> float:

--- a/src/pension_data/finite_guards.py
+++ b/src/pension_data/finite_guards.py
@@ -14,7 +14,7 @@ Two disposition styles are provided so callers can pick the right failure mode:
 from __future__ import annotations
 
 import math
-from typing import TypeGuard
+from typing import SupportsFloat, SupportsIndex, TypeGuard, cast
 
 __all__ = [
     "bounded_confidence",
@@ -61,7 +61,7 @@ def bounded_confidence_or_none(value: object) -> float | None:
     if isinstance(value, bool):
         return None
     try:
-        parsed = float(value)
+        parsed = float(cast(str | SupportsFloat | SupportsIndex, value))
     except (TypeError, ValueError):
         return None
     if not math.isfinite(parsed):

--- a/src/pension_data/finite_guards.py
+++ b/src/pension_data/finite_guards.py
@@ -15,7 +15,14 @@ from __future__ import annotations
 
 import math
 
-__all__ = ["bounded_confidence", "is_finite_number", "require_finite", "finite_or_none"]
+__all__ = [
+    "bounded_confidence",
+    "bounded_confidence_or_none",
+    "bounded_confidence_or_zero",
+    "is_finite_number",
+    "require_finite",
+    "finite_or_none",
+]
 
 
 def is_finite_number(value: object) -> bool:
@@ -40,3 +47,16 @@ def finite_or_none(value: float | None) -> float | None:
 def bounded_confidence(value: float) -> float:
     """Clamp a finite confidence to [0, 1]; reject NaN and infinities."""
     return round(max(0.0, min(1.0, require_finite(value, field="confidence"))), 6)
+
+
+def bounded_confidence_or_none(value: object) -> float | None:
+    """Clamp a finite confidence or return ``None`` for an untrustworthy value."""
+    if not is_finite_number(value):
+        return None
+    return bounded_confidence(float(value))
+
+
+def bounded_confidence_or_zero(value: object) -> float:
+    """Clamp a finite confidence or downgrade an untrustworthy value to zero."""
+    bounded = bounded_confidence_or_none(value)
+    return 0.0 if bounded is None else bounded

--- a/src/pension_data/finite_guards.py
+++ b/src/pension_data/finite_guards.py
@@ -14,6 +14,7 @@ Two disposition styles are provided so callers can pick the right failure mode:
 from __future__ import annotations
 
 import math
+from typing import TypeGuard
 
 __all__ = [
     "bounded_confidence",
@@ -25,7 +26,7 @@ __all__ = [
 ]
 
 
-def is_finite_number(value: object) -> bool:
+def is_finite_number(value: object) -> TypeGuard[int | float]:
     """True only for a real, finite ``int``/``float`` (``bool`` excluded)."""
     return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
 

--- a/src/pension_data/quality/confidence.py
+++ b/src/pension_data/quality/confidence.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Literal
 
-from pension_data.finite_guards import is_finite_number
+from pension_data.finite_guards import bounded_confidence_or_none
 
 RoutingOutcome = Literal["auto_accept", "publish_with_warning", "high_priority_review"]
 ReviewPriority = Literal["none", "medium", "high"]
@@ -42,21 +42,9 @@ class ConfidenceRoutingDecision:
     evidence_refs: tuple[str, ...]
 
 
-def _bounded_confidence(value: float) -> float | None:
-    """Clamp to [0, 1]; return None for a non-finite (NaN/inf) confidence.
-
-    A bare ``max(0.0, min(1.0, value))`` returns 1.0 for NaN (min(1.0, nan) == 1.0),
-    which would auto-accept a garbage extraction. None signals "not a trustworthy
-    confidence" so the caller routes it to review instead.
-    """
-    if not is_finite_number(value):
-        return None
-    return round(max(0.0, min(1.0, value)), 6)
-
-
 def route_confidence_row(row: ExtractionConfidenceInput) -> ConfidenceRoutingDecision:
     """Route one extraction row according to approved confidence policy."""
-    bounded = _bounded_confidence(row.confidence)
+    bounded = bounded_confidence_or_none(row.confidence)
     if bounded is None:
         # Non-finite confidence (NaN/inf) is never trusted: force high-priority review
         # and block publication rather than letting the clamp report a false 1.0.

--- a/src/pension_data/quant/metric_engine.py
+++ b/src/pension_data/quant/metric_engine.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from statistics import fmean
 from typing import Literal
 
+from pension_data.finite_guards import bounded_confidence_or_none
 from pension_data.quant.contracts import (
     QuantDataPoint,
     QuantSeriesContract,
@@ -135,17 +136,6 @@ def _to_float(value: object) -> float | None:
     return parsed if math.isfinite(parsed) else None
 
 
-def _bounded_confidence(value: object) -> float | None:
-    parsed = _to_float(value)
-    if parsed is None or not math.isfinite(parsed):
-        return None
-    if parsed < 0:
-        return 0.0
-    if parsed > 1:
-        return 1.0
-    return parsed
-
-
 def _as_refs(values: object) -> tuple[str, ...]:
     if isinstance(values, (str, bytes, bytearray)):
         return ()
@@ -194,7 +184,7 @@ def _build_metric_input_index(
         group_metrics = index.setdefault(group_key, {})
         group_metrics[metric_name.strip()] = _MetricInput(
             value=normalized_value,
-            confidence=_bounded_confidence(row.get("confidence")),
+            confidence=bounded_confidence_or_none(row.get("confidence")),
             fact_id=fact_id,
             evidence_refs=_as_refs(row.get("evidence_refs")),
             plan_id=group_key[0],
@@ -227,7 +217,7 @@ def _cash_flow_inputs(
             parsed = _to_float(row.get(field))
             if parsed is not None:
                 values[field] = parsed
-        confidence = _bounded_confidence(row.get("confidence"))
+        confidence = bounded_confidence_or_none(row.get("confidence"))
         entries.append(
             (
                 plan_id.strip(),

--- a/tests/extract/governance/test_consultant_extraction.py
+++ b/tests/extract/governance/test_consultant_extraction.py
@@ -22,9 +22,9 @@ FIXTURE_PATH = Path(__file__).parent / "fixtures" / "consultant_extraction_golde
 
 @pytest.mark.parametrize("value", (float("nan"), float("inf"), float("-inf")))
 def test_non_finite_consultant_confidence_is_downgraded(value: float) -> None:
-    from pension_data.extract.governance.consultants import _bounded_confidence
+    from pension_data.finite_guards import bounded_confidence_or_zero
 
-    assert _bounded_confidence(value) == 0.0
+    assert bounded_confidence_or_zero(value) == 0.0
 
 
 def _load_fixture() -> dict[str, Any]:

--- a/tests/extract/investment/test_risk_disclosures.py
+++ b/tests/extract/investment/test_risk_disclosures.py
@@ -17,9 +17,9 @@ from pension_data.extract.investment.risk_disclosures import (
 
 @pytest.mark.parametrize("value", (float("nan"), float("inf"), float("-inf")))
 def test_non_finite_risk_confidence_is_downgraded(value: float) -> None:
-    from pension_data.extract.investment.risk_disclosures import _bounded_confidence
+    from pension_data.finite_guards import bounded_confidence_or_zero
 
-    assert _bounded_confidence(value) == 0.0
+    assert bounded_confidence_or_zero(value) == 0.0
 
 
 FIXTURE_PATH = Path(__file__).parent / "fixtures" / "risk_disclosures_golden.json"

--- a/tests/quality/test_finite_bounds.py
+++ b/tests/quality/test_finite_bounds.py
@@ -52,6 +52,8 @@ def test_finite_guards_helpers() -> None:
     assert all(finite_or_none(v) is None for v in NON_FINITE + [None])
     assert bounded_confidence_or_none(1.5) == 1.0
     assert bounded_confidence_or_zero(-1.0) == 0.0
+    assert bounded_confidence_or_none("0.8") == 0.8
+    assert bounded_confidence_or_zero("0.8") == 0.8
     assert all(bounded_confidence_or_none(v) is None for v in NON_FINITE)
     assert all(bounded_confidence_or_zero(v) == 0.0 for v in NON_FINITE)
 

--- a/tests/quality/test_finite_bounds.py
+++ b/tests/quality/test_finite_bounds.py
@@ -11,7 +11,13 @@ from datetime import UTC, datetime
 
 import pytest
 
-from pension_data.finite_guards import finite_or_none, is_finite_number, require_finite
+from pension_data.finite_guards import (
+    bounded_confidence_or_none,
+    bounded_confidence_or_zero,
+    finite_or_none,
+    is_finite_number,
+    require_finite,
+)
 from pension_data.normalize.financial_units import normalize_money_to_usd
 from pension_data.normalize.investment_normalization import normalize_rate_to_ratio
 from pension_data.quality.anomaly_rules import (
@@ -44,6 +50,10 @@ def test_finite_guards_helpers() -> None:
             require_finite(v, field="x")
     assert finite_or_none(3.0) == 3.0
     assert all(finite_or_none(v) is None for v in NON_FINITE + [None])
+    assert bounded_confidence_or_none(1.5) == 1.0
+    assert bounded_confidence_or_zero(-1.0) == 0.0
+    assert all(bounded_confidence_or_none(v) is None for v in NON_FINITE)
+    assert all(bounded_confidence_or_zero(v) == 0.0 for v in NON_FINITE)
 
 
 # --- confidence routing (the P0: NaN must never auto-accept) ------------------


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:636 -->
> **Source:** Issue #636

Closes #636

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
At numeric trust boundaries the pipeline guards values with bare `< 0` / `> 1` comparisons, which **NaN and ±inf defeat** (NaN compares false to everything; +inf is "non-negative"). For a pension-fact data-integrity product this is severe and is **reachable on the production pipeline** (`ops/document_orchestration.py`). The worst case is verified: a NaN extraction confidence is clamped to **`1.0` → `auto_accept`** (`quality/confidence.py:43` `_bounded_confidence` = `round(max(0.0, min(1.0, value)), 6)`; `min(1.0, nan) == 1.0`), so a garbage/failed extraction gets maximum trust and **bypasses human review**. NaN money/flows are stored too. The repo already has the right idea elsewhere — this issue makes finite/bounds checking consistent.

These pass green CI only because golden fixtures are homogeneous (no NaN/inf/zero/edge inputs).

#### Tasks
- [x] Create a finite-aware clamp in `quality/confidence.py` that uses `math.isfinite()` to reject or flag non-finite confidence inputs instead of clamping `NaN` to `1.0`, replace the duplicated `_bounded_confidence` implementations in `quality/confidence.py:43`, `extract/governance/consultants.py:127`, `extract/investment/risk_disclosures.py:81`, and `quant/metric_engine.py:134` with this shared implementation, and add or update tests verifying `NaN`, `+inf`, and `-inf` are not converted to `1.0` and all affected tests pass.
  - [x] Create a finite-aware clamp function in `quality/confidence.py` that uses `math.isfinite()` to reject or flag non-finite confidence inputs instead of clamping NaN to 1.0 (verify: confirm completion in repo)
  - [x] Replace the duplicated `_bounded_confidence` implementation in `quality/confidence.py:43` with the new shared finite-aware clamp function (verify: confirm completion in repo)
  - [x] Replace the duplicated `_bounded_confidence` implementation in `extract/governance/consultants.py:127` with the new shared finite-aware clamp function (verify: confirm completion in repo)
  - [x] Replace the duplicated `_bounded_confidence` implementation in `extract/investment/risk_disclosures.py:81` with the new shared finite-aware clamp function (verify: confirm completion in repo)
  - [x] Replace the duplicated `_bounded_confidence` implementation in `quant/metric_engine.py:134` with the new shared finite-aware clamp function (verify: confirm completion in repo)
  - [x] _(3 further sub-tasks elided; split this issue)_
- [x] Add `math.isfinite` guards at `normalize/financial_units.py:22` (`normalize_money_to_usd`), `extract/funded/financial_flows.py:102+`, `normalize/investment_normalization.py:32`, `quant/metric_engine.py:177+`, `quant/attribution_optimization.py`, `quant/scenarios.py`, `quality/anomaly_rules.py:51+`, `quality/sla_metrics.py:144+`, `extract/persistence.py:241+`, and `provenance/metrics.py:97+` to reject or flag non-finite values instead of silently storing them.
  - [x] Add `math.isfinite` guard to `normalize/financial_units.py:22` in the `normalize_money_to_usd` function to reject or flag non-finite monetary values (verify: confirm completion in repo)
  - [x] Add `math.isfinite` guards to `extract/funded/financial_flows.py:102+` to reject or flag non-finite financial flow values (verify: confirm completion in repo)
  - [x] Add `math.isfinite` guard to `normalize/investment_normalization.py:32` to reject or flag non-finite investment values (verify: confirm completion in repo)
  - [x] Add `math.isfinite` guards to `quant/metric_engine.py:177+` to reject or flag non-finite metric computation inputs (verify: confirm completion in repo)
  - [x] Add `math.isfinite` guards to `quant/attribution_optimization.py` to reject or flag non-finite optimization inputs (verify: confirm completion in repo)
  - [x] _(5 further sub-tasks elided; split this issue)_
- [ ] Update routing so non-finite extracted values go to `high_priority_review` or blocked, never `auto_accept`.
- [x] Write `tests/quality/test_finite_bounds.py` and targeted tests in normalize/quant/extract covering NaN, `+inf`, and `-inf` at each listed boundary.
  - [x] Create `tests/quality/test_finite_bounds.py` with test cases covering NaN (verify: tests pass)
  - [x] Create `tests/quality/test_finite_bounds.py` with positive infinity (verify: tests pass)
  - [x] Create `tests/quality/test_finite_bounds.py` with and negative infinity for confidence clamping (verify: tests pass)
  - [x] Create `tests/quality/test_finite_bounds.py` with routing (verify: tests pass)
  - [x] Write targeted tests in the normalize module covering NaN, positive infinity, (verify: tests pass)
  - [x] _(8 further sub-tasks elided; split this issue)_

#### Acceptance criteria
- [ ] `route_confidence_row(confidence=float("nan"))` does not return `auto_accept`, and confidence is not reported as `1.0`.
- [ ] `normalize_money_to_usd(float("nan"), ...)` and `extract_plan_financial_flow` with NaN AUM raise or flag the value and do not store NaN.
- [ ] `compute_derived_metrics`, anomaly rules, SLA ratios, and the persistence boundary reject or flag non-finite inputs.
- [ ] `tests/quality/test_finite_bounds.py` exists, targeted normalize/quant/extract tests exist, and they cover NaN, `+inf`, and `-inf` at each listed boundary.
- [ ] Reverting one `math.isfinite` guard causes its corresponding test to fail, and restoring the guard makes the test pass.
- [ ] The full test suite stays green.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added shared “bounded confidence” utilities to standardize confidence clamping to the 0–1 range across extraction and quality workflows, including clear behavior for non-finite inputs.
- **Bug Fixes**
  - Improved consistency when confidence values contain `NaN` or ±Infinity by downgrading or marking them untrusted in a uniform way.
- **Tests**
  - Updated confidence-related tests to use the new shared helpers and expanded coverage for boundary and non-finite confidence cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->