### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/actions/agent-run-base/action.yml
+++ b/.github/actions/agent-run-base/action.yml
@@ -66,7 +66,7 @@ runs:
     - name: Mint GitHub App token
       id: app_token
       continue-on-error: true
-      uses: actions/create-github-app-token@v3
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
       with:
         app-id: ${{ inputs.workflows_app_id || '0' }}
         private-key: ${{ inputs.workflows_app_private_key || 'dummy' }}
@@ -109,7 +109,7 @@ runs:
         printf 'Checkout auth: %s; push permitted with app token: %s.\n' "$source" "$push_allowed"
 
     - name: Checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
         ref: ${{ inputs.checkout_ref || github.ref }}
@@ -132,7 +132,7 @@ runs:
         github_token: ${{ inputs.github_token }}
 
     - name: Checkout Workflows scripts
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         repository: stranske/Workflows
         ref: ${{ inputs.workflows_ref }}

--- a/scripts/api_client.py
+++ b/scripts/api_client.py
@@ -199,7 +199,7 @@ def fetch_pull_request_diff(
         url,
         token,
         payload=None,
-        accept="application/vnd.github.diff",
+        accept="application/vnd.github.v3.diff",
         **_retry_kwargs(retry_attempts, retry_backoff),
     )
     return response.text

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -43,7 +43,7 @@ SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 EVIDENCE_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/#@-]{0,255}$")
 SECRET_LIKE_EVIDENCE_PREFIXES = ("ghp_", "github_pat_", "sk-")
 SECRET_LIKE_EVIDENCE_SEGMENT_RE = re.compile(
-    r"(?:^|[:/])(?:" + "|".join(SECRET_LIKE_EVIDENCE_PREFIXES) + r")",
+    r"(?:^|[:/#@])(?:" + "|".join(SECRET_LIKE_EVIDENCE_PREFIXES) + r")",
     re.IGNORECASE,
 )
 SUPERVISION_MODES = {

--- a/tools/check_model_registry_freshness.py
+++ b/tools/check_model_registry_freshness.py
@@ -318,16 +318,30 @@ def evaluate(
             findings.append(_finding("invalid_slot", f"slot {name!r} has no provider."))
             continue
         if explicit_model:
-            selected = selection_by_key.get((profile, provider)) if profile else None
-            if selected and selected.get("model_id") != explicit_model:
+            model = model_by_key.get((provider, explicit_model))
+            # Explicit-profile pins must match their reviewed decision.  A
+            # legacy pin without a profile is also valid at runtime when the
+            # pin is a current, unblocked catalog model.
+            effective_profile = profile or "verifier-balanced"
+            selected = selection_by_key.get((effective_profile, provider))
+            legacy_pin_is_current = bool(
+                not profile
+                and model is not None
+                and not model.get("blocked")
+                and str(model.get("lifecycle", "")).strip().lower() == "current"
+            )
+            if (
+                selected
+                and selected.get("model_id") != explicit_model
+                and not legacy_pin_is_current
+            ):
                 findings.append(
                     _finding(
                         "selection_override",
                         f"slot {name!r} pins {provider}/{explicit_model} instead of reviewed "
-                        f"selection {selected.get('model_id')}.",
+                        f"selection {selected.get('model_id')} for {effective_profile}.",
                     )
                 )
-            model = model_by_key.get((provider, explicit_model))
             if model is None:
                 findings.append(
                     _finding(

--- a/tools/ci_failure_triage.py
+++ b/tools/ci_failure_triage.py
@@ -292,28 +292,34 @@ def _get_llm_client() -> tuple[_LLMClient, str] | None:
     if not github_token and not openai_token:
         return None
 
-    from tools.llm_provider import DEFAULT_MODEL, GITHUB_MODELS_BASE_URL
+    from tools.llm_provider import GITHUB_MODELS_BASE_URL
+    from tools.llm_registry import configured_model_for_provider
 
     if github_token:
-        return (
-            cast(
-                _LLMClient,
-                ChatOpenAI(
-                    model=DEFAULT_MODEL,
-                    base_url=GITHUB_MODELS_BASE_URL,
-                    api_key=cast(Any, github_token),
-                    temperature=0.1,
+        model = configured_model_for_provider("github-models")
+        if model:
+            return (
+                cast(
+                    _LLMClient,
+                    ChatOpenAI(
+                        model=model,
+                        base_url=GITHUB_MODELS_BASE_URL,
+                        api_key=cast(Any, github_token),
+                        temperature=0.1,
+                    ),
                 ),
-            ),
-            "github-models",
-        )
+                "github-models",
+            )
     if openai_token is None:
+        return None
+    model = configured_model_for_provider("openai")
+    if not model:
         return None
     return (
         cast(
             _LLMClient,
             ChatOpenAI(
-                model=DEFAULT_MODEL,
+                model=model,
                 api_key=cast(Any, openai_token),
                 temperature=0.1,
             ),

--- a/tools/discover_model_catalog.py
+++ b/tools/discover_model_catalog.py
@@ -16,12 +16,19 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-
-import requests
+from urllib.error import URLError
+from urllib.request import Request, urlopen
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_REGISTRY_PATH = _REPO_ROOT / "config" / "model_registry.json"
 PROVIDERS = ("openai", "anthropic", "github-models")
+CATALOG_URLS = frozenset(
+    {
+        "https://models.github.ai/catalog/models",
+        "https://api.openai.com/v1/models",
+        "https://api.anthropic.com/v1/models?limit=1000",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -31,9 +38,11 @@ class CatalogModel:
 
 
 def _request_json(url: str, headers: dict[str, str]) -> Any:
-    response = requests.get(url, headers=headers, timeout=30)
-    response.raise_for_status()
-    return response.json()
+    if url not in CATALOG_URLS:
+        raise ValueError(f"unsupported catalog URL: {url}")
+    request = Request(url, headers=headers)
+    with urlopen(request, timeout=30) as response:  # noqa: S310 - validated static catalog URL
+        return json.load(response)
 
 
 def _parse_timestamp(value: object) -> dt.datetime | None:
@@ -131,7 +140,7 @@ def fetch_provider(provider: str) -> tuple[list[CatalogModel] | None, str | None
         else:  # pragma: no cover - argparse constrains values
             raise ValueError(f"unsupported provider: {provider}")
         return parse_catalog(provider, payload), None
-    except (OSError, ValueError, requests.RequestException) as exc:
+    except (OSError, URLError, ValueError) as exc:
         return None, str(exc)
 
 

--- a/tools/evaluate_model_benchmark.py
+++ b/tools/evaluate_model_benchmark.py
@@ -8,6 +8,7 @@ import json
 import math
 import sys
 from pathlib import Path
+from statistics import NormalDist
 from typing import Any
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -43,7 +44,7 @@ def _case_outcome(case: dict[str, Any]) -> tuple[str, str, bool]:
     return expected, actual, schema_valid
 
 
-def _metrics(cases: list[dict[str, Any]]) -> dict[str, Any]:
+def _metrics(cases: list[dict[str, Any]], *, z: float = Z_95) -> dict[str, Any]:
     success = false_pass = false_fail = schema_error = 0
     expected_pass = expected_non_pass = 0
     categories: dict[str, int] = {}
@@ -77,10 +78,10 @@ def _metrics(cases: list[dict[str, Any]]) -> dict[str, Any]:
         latencies.append(latency)
 
     count = len(cases)
-    success_interval = wilson_interval(success, count)
-    false_pass_interval = wilson_interval(false_pass, expected_non_pass)
-    false_fail_interval = wilson_interval(false_fail, expected_pass)
-    schema_interval = wilson_interval(schema_error, count)
+    success_interval = wilson_interval(success, count, z=z)
+    false_pass_interval = wilson_interval(false_pass, expected_non_pass, z=z)
+    false_fail_interval = wilson_interval(false_fail, expected_pass, z=z)
+    schema_interval = wilson_interval(schema_error, count, z=z)
     return {
         "sample_count": count,
         "category_counts": categories,
@@ -124,6 +125,10 @@ def evaluate_benchmark(payload: dict[str, Any], policy: dict[str, Any]) -> dict[
     profile_policy = profiles[profile]
     approval = profile_policy["approval_stage"]
     gates = approval["quality_gates"]
+    confidence_level = float(approval.get("confidence_level", 0.95))
+    if not 0.0 < confidence_level < 1.0:
+        raise ValueError("approval_stage.confidence_level must be between 0 and 1")
+    z = NormalDist().inv_cdf((1.0 + confidence_level) / 2.0)
     candidates = payload.get("candidates")
     if not isinstance(candidates, list) or len(candidates) < 2:
         raise ValueError("benchmark requires a baseline and at least one candidate")
@@ -137,7 +142,7 @@ def evaluate_benchmark(payload: dict[str, Any], policy: dict[str, Any]) -> dict[
         provider = str(candidate.get("provider", "")).strip()
         if not model_id or not provider or model_id in metrics_by_model:
             raise ValueError("candidate provider/model_id values must be non-empty and unique")
-        metrics_by_model[model_id] = _metrics(candidate["cases"])
+        metrics_by_model[model_id] = _metrics(candidate["cases"], z=z)
     if baseline_model not in metrics_by_model:
         raise ValueError("baseline_model_id must identify one candidate")
 
@@ -148,7 +153,7 @@ def evaluate_benchmark(payload: dict[str, Any], policy: dict[str, Any]) -> dict[
     noninferiority_margin = float(gates["paired_success_noninferiority_margin"])
 
     for candidate in candidates:
-        model_id = str(candidate["model_id"])
+        model_id = str(candidate["model_id"]).strip()
         metrics = metrics_by_model[model_id]
         gate_results = {
             "minimum_adjudicated_cases": metrics["sample_count"] >= minimum_cases,

--- a/tools/llm_provider.py
+++ b/tools/llm_provider.py
@@ -351,6 +351,7 @@ class GitHubModelsProvider(LLMProvider):
 
         model_name = _configured_langchain_model("github-models", fallback=DEFAULT_MODEL)
         if not model_name:
+            logger.warning("No reviewed GitHub Models selection is configured")
             return None
         self._model_name = model_name
         return ChatOpenAI(
@@ -369,7 +370,9 @@ class GitHubModelsProvider(LLMProvider):
     ) -> CompletionAnalysis:
         client = self._get_client()
         if not client:
-            raise RuntimeError("LangChain OpenAI not available")
+            raise RuntimeError(
+                "GitHub Models client unavailable or no reviewed model is configured"
+            )
 
         prompt = self._build_analysis_prompt(session_output, tasks, context)
 

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -229,6 +229,13 @@ def select_model_for_profile(
             )
         return None
     decision = matches[0]
+    if not decision.evidence_ids:
+        logger.warning(
+            "Model selection %s/%s has no evidence; refusing to use it",
+            normalized_provider,
+            profile,
+        )
+        return None
     entry = registry_entry_for(decision.provider, decision.model, registry=entries)
     if entry is None or entry.blocked or entry.lifecycle != "current":
         return None
@@ -263,40 +270,19 @@ def configured_model_for_provider(
 ) -> str:
     normalized_provider = normalize_provider(provider)
     entries = registry if registry is not None else load_model_registry()
-    path = _slot_path()
-    payload = _load_object(path, label="slot config")
-    if payload is not None:
-        for slot in _slot_entries(payload, path):
-            slot_provider = normalize_provider(str(slot.get("provider", "")))
-            if slot_provider != normalized_provider:
-                continue
-            explicit_model = str(slot.get("model", "")).strip()
-            slot_profile = str(slot.get("profile") or profile).strip()
-            model = (
-                select_model_for_profile(
-                    provider=slot_provider or "",
-                    profile=slot_profile,
-                    registry=entries,
-                )
-                or ""
-            )
-            if not model:
-                logger.warning(
-                    "No reviewed model selection for slot profile %s/%s",
-                    slot_profile,
-                    slot_provider,
-                )
-                return ""
-            if explicit_model and explicit_model != model:
-                logger.warning(
-                    "Ignoring slot model pin %s/%s; reviewed %s selection is %s",
-                    slot_provider,
-                    explicit_model,
-                    slot_profile,
-                    model or "unavailable",
-                )
-            if model and not is_model_blocked(slot_provider or "", model, registry=entries):
-                return model
+    # Use the same resolution path as runtime callers so emergency environment
+    # overrides cannot be ignored by this convenience helper.
+    for slot in resolve_slots():
+        if slot.provider == normalized_provider and not is_model_blocked(
+            slot.provider, slot.model, registry=entries
+        ):
+            return slot.model
+
+    # A readable slot config is an execution allowlist.  Do not broaden to a
+    # provider-level registry decision when that config has no usable slot for
+    # this provider (including an empty or invalid-only slots list).
+    if _load_object(_slot_path(), label="slot config") is not None:
+        return ""
 
     selected = select_model_for_profile(provider=provider, profile=profile, registry=entries)
     if selected:
@@ -352,7 +338,16 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
                 select_model_for_profile(provider=provider, profile=profile, registry=registry)
                 or ""
             )
-        if provider and explicit_model and explicit_model != model:
+        explicit_entry = registry_entry_for(provider, explicit_model, registry=registry)
+        if (
+            provider
+            and explicit_model
+            and not configured_profile
+            and explicit_entry
+            and not (explicit_entry.blocked or explicit_entry.lifecycle != "current")
+        ):
+            model = explicit_model
+        elif provider and explicit_model and explicit_model != model:
             logger.warning(
                 "Ignoring slot model pin %s/%s; reviewed %s selection is %s",
                 provider,
@@ -377,7 +372,9 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
             continue
         name = str(entry.get("name") or f"slot{idx}").strip() or f"slot{idx}"
         slots.append(SlotDefinition(name=name, provider=provider, model=model))
-    return slots if slot_entries else fallback_slots
+    # A present slot file is an allowlist.  If every configured slot is
+    # unusable, fail closed instead of broadening execution to default providers.
+    return slots
 
 
 def apply_slot_env_overrides(


### PR DESCRIPTION
## Sync Summary

### Files Updated
- ci_failure_triage.py: Classifies CI failure logs - required by pr-00-gate.yml summary generation
- runner_lib/ (1 files): Shared runner prompt assembly, output parsing, and dispatch debounce helpers
- api_client.py: Shared GitHub API client used by synced Python automation scripts
- llm_provider.py: LLM provider configuration - GitHub Models and OpenAI client setup
- llm_registry.py: LLM model registry helper - shared slot/model selection and blocked-model enforcement
- check_model_registry_freshness.py: Model-registry freshness gate - validates dated decisions, evidence, lifecycle, and profile-based slots
- discover_model_catalog.py: Advisory provider-catalog discovery - proposes new model candidates without changing reviewed selections
- evaluate_model_benchmark.py: Deterministic paired model benchmark evaluator - computes confidence-bound quality gates and cost/latency ranking
- agent-run-base/ (1 files): Shared agent runner setup action - required by reusable-codex-run.yml and reusable-claude-run.yml

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `794a7012e73e166034382f28efb7934ec952d655`
**Template hash:** `3bc58dadaae2`
**Sync branch:** `sync/workflows-3bc58dadaae2`
**Consumer repo:** `stranske/Pension-Data`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Pension-Data","source_repository":"stranske/Workflows","source_sha":"794a7012e73e166034382f28efb7934ec952d655","template_hash":"3bc58dadaae2","sync_branch":"sync/workflows-3bc58dadaae2","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"29474958706","run_attempt":"1","changes_count":9} -->