### PR TITLE
test: add parser extraction regression fixtures

### DIFF
--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T08:42:48.903307Z",
+  "emitted_at": "2026-07-17T08:48:45.744176Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T01:40:03.001585Z",
+  "emitted_at": "2026-07-17T01:47:09.123659Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T16:20:04.488850Z",
+  "emitted_at": "2026-07-16T16:25:46.884725Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T13:21:01.448090Z",
+  "emitted_at": "2026-07-16T13:26:02.580695Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T08:30:25.787182Z",
+  "emitted_at": "2026-07-17T08:37:09.316304Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T19:57:53.111250Z",
+  "emitted_at": "2026-07-16T20:03:44.839992Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T19:53:10.641049Z",
+  "emitted_at": "2026-07-16T19:57:53.111250Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T07:36:59.073171Z",
+  "emitted_at": "2026-07-17T07:44:27.049223Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T13:38:11.201306Z",
+  "emitted_at": "2026-07-16T13:44:16.712534Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T12:44:38.811415Z",
+  "emitted_at": "2026-07-16T12:50:12.267874Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T17:50:07.389815Z",
+  "emitted_at": "2026-07-16T17:56:15.035306Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T06:09:58.619539Z",
+  "emitted_at": "2026-07-17T06:16:40.620038Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T01:03:10.030866Z",
+  "emitted_at": "2026-07-17T01:09:18.079279Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T20:47:30.846456Z",
+  "emitted_at": "2026-07-16T20:54:23.438494Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T14:21:06.406411Z",
+  "emitted_at": "2026-07-16T14:28:45.127677Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T15:59:58.077590Z",
+  "emitted_at": "2026-07-16T16:05:56.039887Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T08:12:49.717726Z",
+  "emitted_at": "2026-07-17T08:18:48.786947Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T04:19:34.031616Z",
+  "emitted_at": "2026-07-17T04:25:37.657624Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T13:51:13.652785Z",
+  "emitted_at": "2026-07-16T13:56:57.158054Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T05:04:23.463518Z",
+  "emitted_at": "2026-07-17T05:10:23.870178Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T20:59:39.801601Z",
+  "emitted_at": "2026-07-16T21:05:14.827343Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T20:03:44.839992Z",
+  "emitted_at": "2026-07-16T20:09:19.719814Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T21:05:14.827343Z",
+  "emitted_at": "2026-07-16T21:13:50.073416Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T17:16:23.168197Z",
+  "emitted_at": "2026-07-16T17:22:30.334386Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T04:25:37.657624Z",
+  "emitted_at": "2026-07-17T04:29:10.879568Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T17:44:19.830282Z",
+  "emitted_at": "2026-07-16T17:50:07.389815Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T07:50:41.530433Z",
+  "emitted_at": "2026-07-17T07:56:55.259576Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T02:30:30.088139Z",
+  "emitted_at": "2026-07-17T02:44:18.549805Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T20:14:29.117676Z",
+  "emitted_at": "2026-07-16T20:19:38.472517Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T12:56:07.811885Z",
+  "emitted_at": "2026-07-16T13:02:16.229907Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T22:21:03.672399Z",
+  "emitted_at": "2026-07-17T00:58:12.157459Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T03:12:55.221558Z",
+  "emitted_at": "2026-07-17T03:18:41.854427Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T01:59:47.766224Z",
+  "emitted_at": "2026-07-17T02:05:19.025423Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T15:21:44.641511Z",
+  "emitted_at": "2026-07-16T15:27:09.700708Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T15:54:03.711332Z",
+  "emitted_at": "2026-07-16T15:59:58.077590Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T13:32:04.634968Z",
+  "emitted_at": "2026-07-16T13:38:11.201306Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T21:19:34.537818Z",
+  "emitted_at": "2026-07-16T21:25:19.581543Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T18:20:25.642440Z",
+  "emitted_at": "2026-07-16T18:27:39.585716Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T16:05:56.039887Z",
+  "emitted_at": "2026-07-16T16:14:01.637989Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T15:41:21.634706Z",
+  "emitted_at": "2026-07-16T15:47:23.754142Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T16:49:58.952008Z",
+  "emitted_at": "2026-07-16T16:54:49.589981Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T03:43:23.398783Z",
+  "emitted_at": "2026-07-17T03:48:36.767216Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T13:15:51.184717Z",
+  "emitted_at": "2026-07-16T13:21:01.448090Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T05:36:01.452605Z",
+  "emitted_at": "2026-07-17T05:41:16.028269Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T03:36:51.738865Z",
+  "emitted_at": "2026-07-17T03:43:23.398783Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T01:28:28.397393Z",
+  "emitted_at": "2026-07-17T01:34:29.305061Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T08:01:22.282913Z",
+  "emitted_at": "2026-07-17T08:06:49.947781Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T05:33:12.740799Z",
+  "emitted_at": "2026-07-17T05:36:01.452605Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T04:33:56.016285Z",
+  "emitted_at": "2026-07-17T04:39:51.829223Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T06:51:50.328946Z",
+  "emitted_at": "2026-07-17T06:57:16.716701Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T15:47:23.754142Z",
+  "emitted_at": "2026-07-16T15:54:03.711332Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T15:03:09.773716Z",
+  "emitted_at": "2026-07-16T15:08:54.515206Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T14:09:36.604211Z",
+  "emitted_at": "2026-07-16T14:15:16.339085Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T16:54:49.589981Z",
+  "emitted_at": "2026-07-16T17:00:27.017106Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T14:37:14.531784Z",
+  "emitted_at": "2026-07-16T14:44:02.640465Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T08:06:49.947781Z",
+  "emitted_at": "2026-07-17T08:12:49.717726Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T08:54:35.697673Z",
+  "emitted_at": "2026-07-17T09:00:12.592774Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T17:56:15.035306Z",
+  "emitted_at": "2026-07-16T18:02:52.123427Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T14:44:02.640465Z",
+  "emitted_at": "2026-07-16T14:50:45.229781Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T16:14:01.637989Z",
+  "emitted_at": "2026-07-16T16:20:04.488850Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T01:47:09.123659Z",
+  "emitted_at": "2026-07-17T01:54:19.091668Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T04:29:10.879568Z",
+  "emitted_at": "2026-07-17T04:33:56.016285Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T06:45:35.323096Z",
+  "emitted_at": "2026-07-17T06:51:50.328946Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T03:24:37.767842Z",
+  "emitted_at": "2026-07-17T03:30:56.198504Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T17:11:09.838473Z",
+  "emitted_at": "2026-07-16T17:16:23.168197Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T06:57:16.716701Z",
+  "emitted_at": "2026-07-17T07:02:20.876128Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T15:08:54.515206Z",
+  "emitted_at": "2026-07-16T15:15:55.200992Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T19:14:02.713272Z",
+  "emitted_at": "2026-07-16T19:19:48.722890Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T20:54:23.438494Z",
+  "emitted_at": "2026-07-16T20:59:39.801601Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T16:38:45.738236Z",
+  "emitted_at": "2026-07-16T16:44:29.512649Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T04:45:58.348328Z",
+  "emitted_at": "2026-07-17T04:51:10.326613Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T17:34:01.197793Z",
+  "emitted_at": "2026-07-16T17:39:03.936124Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T04:14:18.168363Z",
+  "emitted_at": "2026-07-17T04:19:34.031616Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T14:28:45.127677Z",
+  "emitted_at": "2026-07-16T14:32:51.134976Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T05:50:39.392152Z",
+  "emitted_at": "2026-07-17T05:56:50.079335Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T20:42:07.141407Z",
+  "emitted_at": "2026-07-16T20:47:30.846456Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T06:27:12.866602Z",
+  "emitted_at": "2026-07-17T06:33:11.605463Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T20:37:27.855764Z",
+  "emitted_at": "2026-07-16T20:42:07.141407Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T05:56:50.079335Z",
+  "emitted_at": "2026-07-17T06:04:09.353460Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T22:15:16.040543Z",
+  "emitted_at": "2026-07-16T22:21:03.672399Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T07:20:28.571772Z",
+  "emitted_at": "2026-07-17T07:26:09.165199Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T13:44:16.712534Z",
+  "emitted_at": "2026-07-16T13:48:13.178649Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T18:39:37.092710Z",
+  "emitted_at": "2026-07-16T18:44:31.913197Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T15:27:09.700708Z",
+  "emitted_at": "2026-07-16T15:33:43.934526Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T17:22:30.334386Z",
+  "emitted_at": "2026-07-16T17:28:17.346584Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T14:02:53.425156Z",
+  "emitted_at": "2026-07-16T14:09:36.604211Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T22:09:53.028272Z",
+  "emitted_at": "2026-07-16T22:15:16.040543Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T04:51:10.326613Z",
+  "emitted_at": "2026-07-17T04:58:59.996492Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T02:25:01.774653Z",
+  "emitted_at": "2026-07-17T02:30:30.088139Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T19:46:37.962523Z",
+  "emitted_at": "2026-07-16T19:53:10.641049Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T14:15:16.339085Z",
+  "emitted_at": "2026-07-16T14:21:06.406411Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T12:32:09.537703Z",
+  "emitted_at": "2026-07-16T12:35:45.759255Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T18:15:10.906902Z",
+  "emitted_at": "2026-07-16T18:20:25.642440Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T06:33:11.605463Z",
+  "emitted_at": "2026-07-17T06:39:30.896469Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T06:21:04.585026Z",
+  "emitted_at": "2026-07-17T06:27:12.866602Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T14:32:51.134976Z",
+  "emitted_at": "2026-07-16T14:37:14.531784Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T07:32:44.858530Z",
+  "emitted_at": "2026-07-17T07:36:59.073171Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T02:49:55.235028Z",
+  "emitted_at": "2026-07-17T02:55:13.455286Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T21:29:03.227210Z",
+  "emitted_at": "2026-07-16T21:34:51.064506Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T02:44:18.549805Z",
+  "emitted_at": "2026-07-17T02:49:55.235028Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T12:38:37.882769Z",
+  "emitted_at": "2026-07-16T12:44:38.811415Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T03:55:29.181950Z",
+  "emitted_at": "2026-07-17T04:00:47.949768Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T05:22:05.315924Z",
+  "emitted_at": "2026-07-17T05:28:09.225834Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T17:39:03.936124Z",
+  "emitted_at": "2026-07-16T17:44:19.830282Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-12T08:16:36.513612Z",
+  "emitted_at": "2026-07-16T12:32:09.537703Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "714",
+  "pr_number": "727",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T21:25:19.581543Z",
+  "emitted_at": "2026-07-16T21:29:03.227210Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T21:40:04.126341Z",
+  "emitted_at": "2026-07-16T21:46:03.570736Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T06:16:40.620038Z",
+  "emitted_at": "2026-07-17T06:21:04.585026Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T04:39:51.829223Z",
+  "emitted_at": "2026-07-17T04:45:58.348328Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T19:43:17.028955Z",
+  "emitted_at": "2026-07-16T19:46:37.962523Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T18:33:00.716827Z",
+  "emitted_at": "2026-07-16T18:39:37.092710Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T05:10:23.870178Z",
+  "emitted_at": "2026-07-17T05:15:43.137201Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T17:28:17.346584Z",
+  "emitted_at": "2026-07-16T17:34:01.197793Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T15:33:43.934526Z",
+  "emitted_at": "2026-07-16T15:41:21.634706Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T03:07:01.731867Z",
+  "emitted_at": "2026-07-17T03:12:55.221558Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T20:26:03.459692Z",
+  "emitted_at": "2026-07-16T20:31:49.031152Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T07:14:10.926196Z",
+  "emitted_at": "2026-07-17T07:20:28.571772Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T07:26:09.165199Z",
+  "emitted_at": "2026-07-17T07:32:44.858530Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T18:44:31.913197Z",
+  "emitted_at": "2026-07-16T18:50:22.590946Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T12:35:45.759255Z",
+  "emitted_at": "2026-07-16T12:38:37.882769Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T03:01:38.583019Z",
+  "emitted_at": "2026-07-17T03:07:01.731867Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T16:32:45.684559Z",
+  "emitted_at": "2026-07-16T16:38:45.738236Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T08:37:09.316304Z",
+  "emitted_at": "2026-07-17T08:42:48.903307Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T04:00:47.949768Z",
+  "emitted_at": "2026-07-17T04:06:35.713671Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T15:15:55.200992Z",
+  "emitted_at": "2026-07-16T15:21:44.641511Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T12:50:12.267874Z",
+  "emitted_at": "2026-07-16T12:56:07.811885Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T08:18:48.786947Z",
+  "emitted_at": "2026-07-17T08:24:02.418017Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T18:27:39.585716Z",
+  "emitted_at": "2026-07-16T18:33:00.716827Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T07:56:55.259576Z",
+  "emitted_at": "2026-07-17T08:01:22.282913Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T03:18:41.854427Z",
+  "emitted_at": "2026-07-17T03:24:37.767842Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T21:34:51.064506Z",
+  "emitted_at": "2026-07-16T21:40:04.126341Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T13:26:02.580695Z",
+  "emitted_at": "2026-07-16T13:32:04.634968Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T01:34:29.305061Z",
+  "emitted_at": "2026-07-17T01:40:03.001585Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T18:56:18.835544Z",
+  "emitted_at": "2026-07-16T19:02:00.311457Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T19:29:50.551752Z",
+  "emitted_at": "2026-07-16T19:36:27.762177Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T05:15:43.137201Z",
+  "emitted_at": "2026-07-17T05:22:05.315924Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T07:08:24.969339Z",
+  "emitted_at": "2026-07-17T07:14:10.926196Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T01:09:18.079279Z",
+  "emitted_at": "2026-07-17T01:14:57.902056Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T02:05:19.025423Z",
+  "emitted_at": "2026-07-17T02:12:24.570319Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T01:20:36.416928Z",
+  "emitted_at": "2026-07-17T01:28:28.397393Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T19:19:48.722890Z",
+  "emitted_at": "2026-07-16T19:24:35.221719Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T17:05:29.283261Z",
+  "emitted_at": "2026-07-16T17:11:09.838473Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T08:24:02.418017Z",
+  "emitted_at": "2026-07-17T08:30:25.787182Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T08:48:45.744176Z",
+  "emitted_at": "2026-07-17T08:54:35.697673Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T05:28:09.225834Z",
+  "emitted_at": "2026-07-17T05:30:40.792885Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T20:31:49.031152Z",
+  "emitted_at": "2026-07-16T20:37:27.855764Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T02:55:13.455286Z",
+  "emitted_at": "2026-07-17T03:01:38.583019Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T20:19:38.472517Z",
+  "emitted_at": "2026-07-16T20:26:03.459692Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T19:24:35.221719Z",
+  "emitted_at": "2026-07-16T19:29:50.551752Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T19:07:20.454504Z",
+  "emitted_at": "2026-07-16T19:14:02.713272Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T13:56:57.158054Z",
+  "emitted_at": "2026-07-16T14:02:53.425156Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T06:39:30.896469Z",
+  "emitted_at": "2026-07-17T06:45:35.323096Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T07:44:27.049223Z",
+  "emitted_at": "2026-07-17T07:50:41.530433Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T01:14:57.902056Z",
+  "emitted_at": "2026-07-17T01:20:36.416928Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T20:09:19.719814Z",
+  "emitted_at": "2026-07-16T20:14:29.117676Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T16:25:46.884725Z",
+  "emitted_at": "2026-07-16T16:32:45.684559Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T05:45:08.432614Z",
+  "emitted_at": "2026-07-17T05:50:39.392152Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T19:36:27.762177Z",
+  "emitted_at": "2026-07-16T19:43:17.028955Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T06:04:09.353460Z",
+  "emitted_at": "2026-07-17T06:09:58.619539Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T18:02:52.123427Z",
+  "emitted_at": "2026-07-16T18:09:08.821622Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T21:52:05.732791Z",
+  "emitted_at": "2026-07-16T22:03:53.778584Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T02:12:24.570319Z",
+  "emitted_at": "2026-07-17T02:19:29.529171Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T03:48:36.767216Z",
+  "emitted_at": "2026-07-17T03:55:29.181950Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T05:30:40.792885Z",
+  "emitted_at": "2026-07-17T05:33:12.740799Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T17:00:27.017106Z",
+  "emitted_at": "2026-07-16T17:05:29.283261Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T00:58:12.157459Z",
+  "emitted_at": "2026-07-17T01:03:10.030866Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T04:06:35.713671Z",
+  "emitted_at": "2026-07-17T04:14:18.168363Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T18:50:22.590946Z",
+  "emitted_at": "2026-07-16T18:56:18.835544Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T13:48:13.178649Z",
+  "emitted_at": "2026-07-16T13:51:13.652785Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T14:56:39.268242Z",
+  "emitted_at": "2026-07-16T15:03:09.773716Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T01:54:19.091668Z",
+  "emitted_at": "2026-07-17T01:59:47.766224Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T05:41:16.028269Z",
+  "emitted_at": "2026-07-17T05:45:08.432614Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T07:02:20.876128Z",
+  "emitted_at": "2026-07-17T07:08:24.969339Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T13:02:16.229907Z",
+  "emitted_at": "2026-07-16T13:09:15.379702Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T22:03:53.778584Z",
+  "emitted_at": "2026-07-16T22:09:53.028272Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T21:46:03.570736Z",
+  "emitted_at": "2026-07-16T21:52:05.732791Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T21:13:50.073416Z",
+  "emitted_at": "2026-07-16T21:19:34.537818Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T13:09:15.379702Z",
+  "emitted_at": "2026-07-16T13:15:51.184717Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T16:44:29.512649Z",
+  "emitted_at": "2026-07-16T16:49:58.952008Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T19:02:00.311457Z",
+  "emitted_at": "2026-07-16T19:07:20.454504Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T04:58:59.996492Z",
+  "emitted_at": "2026-07-17T05:04:23.463518Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T02:19:29.529171Z",
+  "emitted_at": "2026-07-17T02:25:01.774653Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-17T03:30:56.198504Z",
+  "emitted_at": "2026-07-17T03:36:51.738865Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T18:09:08.821622Z",
+  "emitted_at": "2026-07-16T18:15:10.906902Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-16T14:50:45.229781Z",
+  "emitted_at": "2026-07-16T14:56:39.268242Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/tests/extract/funded/fixtures/funded_actuarial_637_regressions.json
+++ b/tests/extract/funded/fixtures/funded_actuarial_637_regressions.json
@@ -1,0 +1,42 @@
+{
+  "alias_not_disclosed": {
+    "plan_id": "WA-SRS",
+    "plan_period": "FY2024",
+    "raw": {
+      "source_document_id": "doc:wa:2024:funded",
+      "source_url": "https://example.gov/wa-2024-acfr.pdf",
+      "effective_date": "2024-06-30",
+      "ingestion_date": "2025-01-05",
+      "default_money_unit_scale": "million_usd",
+      "text_blocks": [
+        "Funded ratio not disclosed. AAL was $410.5 million. AVA was $333.7 million. Discount rate was 6.75%. Employer contribution rate was 11.1%. Employee contribution rate was 7.1%. Participant count was 112000."
+      ],
+      "table_rows": []
+    },
+    "missing_metric": "funded_ratio"
+  },
+  "european_separators": {
+    "plan_id": "DE-PERS",
+    "plan_period": "FY2024",
+    "raw": {
+      "source_document_id": "doc:de:2024:funded",
+      "source_url": "https://example.gov/de-2024-acfr.pdf",
+      "effective_date": "2024-06-30",
+      "ingestion_date": "2025-01-05",
+      "default_money_unit_scale": "million_usd",
+      "text_blocks": [
+        "Funded ratio was 81,2%. AAL was 1.234,56 million. AVA was 325.000 million. Discount rate was 6,75%. Employer contribution rate was 11,1%. Employee contribution rate was 7,1%. Participant count was 325.000."
+      ],
+      "table_rows": []
+    },
+    "expected": {
+      "funded_ratio": 0.812,
+      "aal_usd": 1234560000.0,
+      "ava_usd": 325000000000.0,
+      "discount_rate": 0.0675,
+      "employer_contribution_rate": 0.111,
+      "employee_contribution_rate": 0.071,
+      "participant_count": 325000.0
+    }
+  }
+}

--- a/tests/extract/funded/fixtures/funded_actuarial_637_regressions.json
+++ b/tests/extract/funded/fixtures/funded_actuarial_637_regressions.json
@@ -13,7 +13,39 @@
       ],
       "table_rows": []
     },
-    "missing_metric": "funded_ratio"
+    "missing_metric": "funded_ratio",
+    "expected_present_metrics": {
+      "aal_usd": 410500000.0,
+      "ava_usd": 333700000.0,
+      "discount_rate": 0.0675,
+      "employer_contribution_rate": 0.111,
+      "employee_contribution_rate": 0.071,
+      "participant_count": 112000.0
+    }
+  },
+  "alias_not_disclosed_same_sentence": {
+    "plan_id": "WA-SRS",
+    "plan_period": "FY2024",
+    "raw": {
+      "source_document_id": "doc:wa:2024:funded:semicolon",
+      "source_url": "https://example.gov/wa-2024-acfr.pdf",
+      "effective_date": "2024-06-30",
+      "ingestion_date": "2025-01-05",
+      "default_money_unit_scale": "million_usd",
+      "text_blocks": [
+        "Funded ratio not disclosed; AAL was $410.5 million. AVA was $333.7 million. Discount rate was 6.75%. Employer contribution rate was 11.1%. Employee contribution rate was 7.1%. Participant count was 112000."
+      ],
+      "table_rows": []
+    },
+    "missing_metric": "funded_ratio",
+    "expected_present_metrics": {
+      "aal_usd": 410500000.0,
+      "ava_usd": 333700000.0,
+      "discount_rate": 0.0675,
+      "employer_contribution_rate": 0.111,
+      "employee_contribution_rate": 0.071,
+      "participant_count": 112000.0
+    }
   },
   "european_separators": {
     "plan_id": "DE-PERS",

--- a/tests/extract/funded/test_funded_actuarial_metrics.py
+++ b/tests/extract/funded/test_funded_actuarial_metrics.py
@@ -77,13 +77,24 @@ def test_637_regression_golden_fixtures_cover_boundary_and_locale_cases() -> Non
     """Keep the #637 edge cases in a reviewed fixture consumed by CI."""
     regressions = _load_fixture(REGRESSION_FIXTURE_PATH)
 
-    alias_case = regressions["alias_not_disclosed"]
-    facts, _ = extract_funded_and_actuarial_metrics(
-        plan_id=alias_case["plan_id"],
-        plan_period=alias_case["plan_period"],
-        raw=_raw(alias_case["raw"]),
-    )
-    assert alias_case["missing_metric"] not in {item.metric_name for item in facts}
+    for fixture_name in (
+        "alias_not_disclosed",
+        "alias_not_disclosed_same_sentence",
+    ):
+        alias_case = regressions[fixture_name]
+        facts, diagnostics = extract_funded_and_actuarial_metrics(
+            plan_id=alias_case["plan_id"],
+            plan_period=alias_case["plan_period"],
+            raw=_raw(alias_case["raw"]),
+        )
+        metrics = {item.metric_name: item.normalized_value for item in facts}
+        assert alias_case["missing_metric"] not in metrics
+        assert metrics == alias_case["expected_present_metrics"]
+        assert any(
+            diagnostic.metric_name == alias_case["missing_metric"]
+            and diagnostic.code == "missing_metric"
+            for diagnostic in diagnostics
+        )
 
     european_case = regressions["european_separators"]
     facts, _ = extract_funded_and_actuarial_metrics(

--- a/tests/extract/funded/test_funded_actuarial_metrics.py
+++ b/tests/extract/funded/test_funded_actuarial_metrics.py
@@ -14,10 +14,13 @@ from pension_data.extract.actuarial.metrics import (
 from pension_data.extract.funded.status import extract_funded_status_metrics
 
 FIXTURE_PATH = Path(__file__).parent / "fixtures" / "funded_actuarial_golden.json"
+REGRESSION_FIXTURE_PATH = (
+    Path(__file__).parent / "fixtures" / "funded_actuarial_637_regressions.json"
+)
 
 
-def _load_fixture() -> dict[str, Any]:
-    with FIXTURE_PATH.open(encoding="utf-8") as handle:
+def _load_fixture(path: Path = FIXTURE_PATH) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
         return json.load(handle)
 
 
@@ -68,6 +71,28 @@ def test_european_number_format_parses_to_correct_magnitude() -> None:
     )
     aal = next((item for item in facts if item.metric_name == "aal_usd"), None)
     assert aal is not None and aal.normalized_value == 1_234_560_000.0
+
+
+def test_637_regression_golden_fixtures_cover_boundary_and_locale_cases() -> None:
+    """Keep the #637 edge cases in a reviewed fixture consumed by CI."""
+    regressions = _load_fixture(REGRESSION_FIXTURE_PATH)
+
+    alias_case = regressions["alias_not_disclosed"]
+    facts, _ = extract_funded_and_actuarial_metrics(
+        plan_id=alias_case["plan_id"],
+        plan_period=alias_case["plan_period"],
+        raw=_raw(alias_case["raw"]),
+    )
+    assert alias_case["missing_metric"] not in {item.metric_name for item in facts}
+
+    european_case = regressions["european_separators"]
+    facts, _ = extract_funded_and_actuarial_metrics(
+        plan_id=european_case["plan_id"],
+        plan_period=european_case["plan_period"],
+        raw=_raw(european_case["raw"]),
+    )
+    metrics = {item.metric_name: item.normalized_value for item in facts}
+    assert metrics == european_case["expected"]
 
 
 def test_table_layout_extracts_all_required_metrics_with_confidence() -> None:

--- a/tests/golden/extraction_fallback_baseline.json
+++ b/tests/golden/extraction_fallback_baseline.json
@@ -3,6 +3,61 @@
   "baseline_version": "v1",
   "documents": [
     {
+      "document_id": "funded-alias-not-disclosed",
+      "fields": {
+        "__escalation__": {
+          "confidence": 0.0,
+          "evidence": "stages:3",
+          "value": "parser_fallback_exhaustion"
+        }
+      }
+    },
+    {
+      "document_id": "funded-european-separators",
+      "fields": {
+        "__fallback_stage__": {
+          "confidence": 1.0,
+          "evidence": "funded_text_only",
+          "value": "text_fallback"
+        },
+        "aal_usd": {
+          "confidence": 0.84,
+          "evidence": "text:1",
+          "value": 1234560000.0
+        },
+        "ava_usd": {
+          "confidence": 0.84,
+          "evidence": "text:1",
+          "value": 325000000000.0
+        },
+        "discount_rate": {
+          "confidence": 0.84,
+          "evidence": "text:1",
+          "value": 0.0675
+        },
+        "employee_contribution_rate": {
+          "confidence": 0.84,
+          "evidence": "text:1",
+          "value": 0.071
+        },
+        "employer_contribution_rate": {
+          "confidence": 0.84,
+          "evidence": "text:1",
+          "value": 0.111
+        },
+        "funded_ratio": {
+          "confidence": 0.84,
+          "evidence": "text:1",
+          "value": 0.812
+        },
+        "participant_count": {
+          "confidence": 0.84,
+          "evidence": "text:1",
+          "value": 325000.0
+        }
+      }
+    },
+    {
       "document_id": "funded-fallback-exhausted",
       "fields": {
         "__escalation__": {

--- a/tests/golden/extraction_fallback_corpus.json
+++ b/tests/golden/extraction_fallback_corpus.json
@@ -11,6 +11,14 @@
     {
       "document_id": "funded-fallback-exhausted",
       "content": "{\"domain\": \"funded\", \"plan_id\": \"WA-SRS\", \"plan_period\": \"FY2025\", \"raw\": {\"source_document_id\": \"doc:wa:2025:funded\", \"source_url\": \"https://example.gov/wa-2025-funded.pdf\", \"effective_date\": \"2025-06-30\", \"ingestion_date\": \"2026-01-15\", \"default_money_unit_scale\": \"million_usd\", \"text_blocks\": [\"No funded metrics disclosed in this section.\"], \"table_rows\": []}}"
+    },
+    {
+      "document_id": "funded-alias-not-disclosed",
+      "content": "{\"domain\": \"funded\", \"plan_id\": \"WA-SRS\", \"plan_period\": \"FY2024\", \"raw\": {\"source_document_id\": \"doc:wa:2024:funded\", \"source_url\": \"https://example.gov/wa-2024-funded.pdf\", \"effective_date\": \"2024-06-30\", \"ingestion_date\": \"2025-01-05\", \"default_money_unit_scale\": \"million_usd\", \"text_blocks\": [\"Funded ratio not disclosed. AAL was $410.5 million. AVA was $333.7 million. Discount rate was 6.75%. Employer contribution rate was 11.1%. Employee contribution rate was 7.1%. Participant count was 112000.\"], \"table_rows\": []}}"
+    },
+    {
+      "document_id": "funded-european-separators",
+      "content": "{\"domain\": \"funded\", \"plan_id\": \"DE-PERS\", \"plan_period\": \"FY2024\", \"raw\": {\"source_document_id\": \"doc:de:2024:funded\", \"source_url\": \"https://example.gov/de-2024-funded.pdf\", \"effective_date\": \"2024-06-30\", \"ingestion_date\": \"2025-01-05\", \"default_money_unit_scale\": \"million_usd\", \"text_blocks\": [\"Funded ratio was 81,2%. AAL was 1.234,56 million. AVA was 325.000 million. Discount rate was 6,75%. Employer contribution rate was 11,1%. Employee contribution rate was 7,1%. Participant count was 325.000.\"], \"table_rows\": []}}"
     }
   ]
 }

--- a/tests/parser/fixtures/table_period_selection_golden.json
+++ b/tests/parser/fixtures/table_period_selection_golden.json
@@ -1,0 +1,14 @@
+{
+  "two_value_columns": {
+    "line": "Funded Ratio | 78.4% | 81.2%",
+    "expected_value": "81.2%"
+  },
+  "year_header_columns": {
+    "line": "Funded Ratio | 2023 | 2024 | 78.4% | 81.2%",
+    "expected_value": "81.2%"
+  },
+  "single_value_column": {
+    "line": "Funded Ratio | 78.4%",
+    "expected_value": "78.4%"
+  }
+}

--- a/tests/parser/test_table_row_period_selection.py
+++ b/tests/parser/test_table_row_period_selection.py
@@ -9,7 +9,6 @@ import pytest
 
 from pension_data.parser.pdf_pipeline import _extract_table_rows
 
-
 FIXTURE_PATH = Path(__file__).parent / "fixtures" / "table_period_selection_golden.json"
 
 

--- a/tests/parser/test_table_row_period_selection.py
+++ b/tests/parser/test_table_row_period_selection.py
@@ -2,7 +2,15 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
+import pytest
+
 from pension_data.parser.pdf_pipeline import _extract_table_rows
+
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "table_period_selection_golden.json"
 
 
 def _value(line: str) -> str:
@@ -11,14 +19,12 @@ def _value(line: str) -> str:
     return rows[0]["value"]
 
 
-def test_two_value_columns_select_most_recent() -> None:
-    # prior|current year values, no header row -> take the rightmost (most recent).
-    assert _value("Funded Ratio | 78.4% | 81.2%") == "81.2%"
+def _cases() -> list[tuple[str, str]]:
+    with FIXTURE_PATH.open(encoding="utf-8") as handle:
+        fixtures = json.load(handle)
+    return [(case["line"], case["expected_value"]) for case in fixtures.values()]
 
 
-def test_year_header_columns_are_not_returned_as_values() -> None:
-    assert _value("Funded Ratio | 2023 | 2024 | 78.4% | 81.2%") == "81.2%"
-
-
-def test_single_value_column_is_unchanged() -> None:
-    assert _value("Funded Ratio | 78.4%") == "78.4%"
+@pytest.mark.parametrize(("line", "expected_value"), _cases())
+def test_period_selection_golden_cases(line: str, expected_value: str) -> None:
+    assert _value(line) == expected_value


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:637 -->
> **Source:** Issue #637

Closes #637

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Three text/table extraction heuristics can silently produce wrong pension facts (worse than missing, for this product):
1. **Number-stealing across boundaries** — `extract/actuarial/metrics.py:85` `_parse_numeric_token_after_alias` scans a 96-char window after an alias without stopping at sentence/metric boundaries. Input `"Funded ratio not disclosed. AAL was $410.5 million."` yields a `funded_ratio` fact of `410.5` (normalized `4.105`).
2. **Hardcoded value column** — `parser/pdf_pipeline.py:264` `_extract_table_rows` takes the 2nd column as the value. Pension reports routinely have prior-year/current-year columns: `"Funded Ratio | 78.4% | 81.2%"` picks `78.4%`; `"Funded Ratio | 2023 | 2024 | 78.4% | 81.2%"` picks `"2023"`.
3. **Locale separators** — `extract/actuarial/metrics.py:22,67` assumes US separators then strips commas: `"1.234,56 million"`→`1.234`, `"81,2%"`→`812.0`, `"325.000"`→`325.0`.

These pass CI because golden fixtures are homogeneous (happy-path US-format single-value).

#### Tasks
- [x] Update `extract/actuarial/metrics.py` `_parse_numeric_token_after_alias` to stop at sentence terminators or the next metric alias, and return "not disclosed" when no value precedes the boundary.
  - [x] Update `_parse_numeric_token_after_alias` to detect and stop scanning at sentence terminators for period (verify: confirm completion in repo)
  - [x] Update `_parse_numeric_token_after_alias` to detect and stop scanning at sentence terminators for question mark (verify: confirm completion in repo)
  - [x] Update `_parse_numeric_token_after_alias` to detect (verify: confirm completion in repo) stop scanning when encountering another metric alias keyword (verify: confirm completion in repo)
  - [x] Update `_parse_numeric_token_after_alias` to return a not-disclosed indicator when no numeric value is found before a boundary (verify: confirm completion in repo)
- [x] Update `ops/document_orchestration.py:271` to match the `_parse_numeric_token_after_alias` boundary-stop fix, or consolidate the duplicated number-token parser first.
- [x] Update `parser/pdf_pipeline.py` `_extract_table_rows` to use header awareness or plan-period selection instead of a fixed column index, select the requested period or latest value, and skip year-like tokens.
  - [x] Implement header-aware column detection in `_extract_table_rows` to identify column purposes from table headers (verify: confirm completion in repo)
  - [x] Add plan-period selection logic to `_extract_table_rows` to match requested fiscal periods against available columns (verify: confirm completion in repo)
  - [x] Implement fallback logic in `_extract_table_rows` to select the latest period when the requested period is unavailable (verify: confirm completion in repo)
  - [x] Add year-token detection (verify: confirm completion in repo) filtering to `_extract_table_rows` to skip columns containing only year values (verify: confirm completion in repo)
- [x] Fix numeric parsing in `extract/actuarial/metrics.py:22,67` to detect decimal-comma vs thous-dot locale separators, instead of blind comma stripping.
  - [x] Implement locale separator detection heuristics in numeric parsing to distinguish decimal-comma from thousands-dot formats (verify: formatter passes)
  - [x] Update numeric parsing at line 22 to apply locale-aware separator handling instead of unconditional comma removal (verify: confirm completion in repo)
- [x] Add golden fixtures covering alias-with-no-value, multi-year columns, and European separators, and wire them into the extraction-golden regression suite.
  - [x] Create golden fixture files covering alias-with-no-value scenarios for boundary-stop validation (verify: confirm completion in repo)
  - [x] Create golden fixture files covering multi-year table columns with various header formats (verify: formatter passes)
  - [x] Create golden fixture files covering European numeric separator formats for decimal comma (verify: formatter passes)
  - [x] Create golden fixture files covering European numeric separator formats for thousands dot (verify: formatter passes)
  - [x] Wire the new golden fixtures into the extraction-golden regression test suite configuration (verify: config validated)
- [x] Test `pytest tests/extract/actuarial -q` and the extraction-golden-regression suite, including the deliberate-break check for the boundary-stop fix.

#### Acceptance criteria
- [x] `"Funded ratio not disclosed. AAL was $410.5 million."` does not produce a `funded_ratio` fact.
- [x] `"Funded Ratio | 78.4% | 81.2%"` and `"Funded Ratio | 2023 | 2024 | 78.4% | 81.2%"` select the correct period value and do not return a year token.
- [x] European-format inputs such as `"1.234,56 million"`, `"81,2%"`, and `"325.000"` parse to the correct magnitude.
- [ ] New golden fixtures cover alias-with-no-value, multi-year columns, and European separators.
- [ ] `pytest tests/extract/actuarial -q` passes.
- [ ] The extraction-golden regression CI includes the new fixtures and passes.
- [x] Reverting the boundary-stop fix causes the alias-no-value test to fail, and restoring the fix makes it pass.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved funded metric extraction to correctly handle missing/aliased metrics and ensure the output omits missing values when appropriate.
  * Enhanced normalization for European-style numeric separators, including funded ratio and related financial fields.
  * Fixed “Funded Ratio” table period-selection across varying column layouts.

* **Tests**
  * Added CI regression golden coverage for funded alias-not-disclosed and European separator scenarios.
  * Updated and expanded fallback and parsing golden fixtures; switched period-selection assertions to fixture-driven checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->