### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/actions/agent-run-base/action.yml
+++ b/.github/actions/agent-run-base/action.yml
@@ -66,7 +66,7 @@ runs:
     - name: Mint GitHub App token
       id: app_token
       continue-on-error: true
-      uses: actions/create-github-app-token@v3
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
       with:
         app-id: ${{ inputs.workflows_app_id || '0' }}
         private-key: ${{ inputs.workflows_app_private_key || 'dummy' }}
@@ -93,6 +93,16 @@ runs:
           push_allowed="false"
         fi
 
+        env_name_pattern='^[A-Za-z_][A-Za-z0-9_]*$'
+        if [[ ! "$MODE_ENV_NAME" =~ $env_name_pattern ]]; then
+          echo "Invalid mode_env_name: expected a shell environment variable name" >&2
+          exit 1
+        fi
+        if [[ ! "$PR_NUMBER_ENV_NAME" =~ $env_name_pattern ]]; then
+          echo "Invalid pr_number_env_name: expected a shell environment variable name" >&2
+          exit 1
+        fi
+
         {
           echo "checkout_token=${checkout_token}"
           echo "push_token=${push_token}"
@@ -109,7 +119,7 @@ runs:
         printf 'Checkout auth: %s; push permitted with app token: %s.\n' "$source" "$push_allowed"
 
     - name: Checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
         ref: ${{ inputs.checkout_ref || github.ref }}
@@ -132,7 +142,7 @@ runs:
         github_token: ${{ inputs.github_token }}
 
     - name: Checkout Workflows scripts
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         repository: stranske/Workflows
         ref: ${{ inputs.workflows_ref }}

--- a/.github/scripts/capability_bundle.js
+++ b/.github/scripts/capability_bundle.js
@@ -45,7 +45,6 @@ function sha256Hex(value) {
 function bundleHashPayload(bundle) {
   const {
     content_hash: _contentHash,
-    contentHash: _contentHashCamel,
     ...payload
   } = bundle || {};
   return payload;

--- a/.github/scripts/keepalive_prompt_composer.js
+++ b/.github/scripts/keepalive_prompt_composer.js
@@ -19,7 +19,7 @@ function normaliseSegmentId(value, fallback) {
 }
 
 function coerceSegments(value) {
-  if (value === undefined || value === null || value === '') {
+  if (value === undefined || value === null || value === '' || value === false) {
     return [];
   }
   if (Array.isArray(value)) {

--- a/docs/SETUP_CHECKLIST.md
+++ b/docs/SETUP_CHECKLIST.md
@@ -591,21 +591,20 @@ curl -o .github/workflows/agents-70-orchestrator.yml \
 
 ### 4.2 Autofix Versions Configuration
 
-> **Important**: Each repository maintains its own `autofix-versions.env` file
-> with dependency versions matching its lock files. This file is NOT synced.
+> **Important**: `autofix-versions.env` is not part of the general template sync.
+> Registered first-party consumers receive the canonical shared tool pins through
+> `maint-52-sync-dev-versions.yml`, together with matching dependency-file updates.
 
 Create `.github/workflows/autofix-versions.env`:
 
 ```bash
-# Tool versions for autofix - match your project's lock files
-RUFF_VERSION=0.8.1
-MYPY_VERSION=1.14.0
-BLACK_VERSION=24.10.0
-ISORT_VERSION=5.13.2
+curl -fsSL \
+  https://raw.githubusercontent.com/stranske/Workflows/main/.github/workflows/autofix-versions.env \
+  -o .github/workflows/autofix-versions.env
 ```
 
 - [ ] `autofix-versions.env` file created
-- [ ] Versions match project's dependency versions
+- [ ] Shared tool versions match the canonical Workflows pins and project lock files
 
 To find your current versions:
 ```bash

--- a/scripts/api_client.py
+++ b/scripts/api_client.py
@@ -199,7 +199,7 @@ def fetch_pull_request_diff(
         url,
         token,
         payload=None,
-        accept="application/vnd.github.diff",
+        accept="application/vnd.github.v3.diff",
         **_retry_kwargs(retry_attempts, retry_backoff),
     )
     return response.text

--- a/scripts/runner_lib/core.py
+++ b/scripts/runner_lib/core.py
@@ -43,7 +43,7 @@ SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 EVIDENCE_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/#@-]{0,255}$")
 SECRET_LIKE_EVIDENCE_PREFIXES = ("ghp_", "github_pat_", "sk-")
 SECRET_LIKE_EVIDENCE_SEGMENT_RE = re.compile(
-    r"(?:^|[:/])(?:" + "|".join(SECRET_LIKE_EVIDENCE_PREFIXES) + r")",
+    r"(?:^|[:/#@])(?:" + "|".join(SECRET_LIKE_EVIDENCE_PREFIXES) + r")",
     re.IGNORECASE,
 )
 SUPERVISION_MODES = {

--- a/scripts/sync_dev_dependencies.py
+++ b/scripts/sync_dev_dependencies.py
@@ -13,7 +13,7 @@ Usage:
     python sync_dev_dependencies.py --check           # Verify versions match
     python sync_dev_dependencies.py --apply           # Update pyproject.toml
     python sync_dev_dependencies.py --apply --create-if-missing  # Create dev deps if missing
-    python sync_dev_dependencies.py --apply  # Syncs requirements.lock automatically if it exists
+    python sync_dev_dependencies.py --apply  # Syncs supported requirements lockfiles when present
 """
 
 from __future__ import annotations
@@ -26,7 +26,7 @@ from pathlib import Path
 # Default paths (can be overridden for testing)
 PIN_FILE = Path(".github/workflows/autofix-versions.env")
 PYPROJECT_FILE = Path("pyproject.toml")
-LOCKFILE_FILE = Path("requirements.lock")
+LOCKFILE_FILES = (Path("requirements.lock"), Path("requirements-dev.lock"))
 
 # Map env file keys to package names
 # Format: ENV_KEY -> (package_name, optional_alternative_names)
@@ -280,8 +280,10 @@ def sync_pyproject(
             if pkg_lower in current_packages:
                 actual_pkg, current_op, current_ver = current_packages[pkg_lower]
 
-                # Check if version differs
-                if current_ver != target_version:
+                # Normalize both the version and the operator. A dependency that
+                # already has the target version but still uses ">=" is not in
+                # sync with the reproducible, exact-pin contract.
+                if current_ver != target_version or (use_exact_pins and current_op != "=="):
                     new_section, changed = update_dependency_in_section(
                         new_section, actual_pkg, target_version, use_exact_pins
                     )
@@ -316,7 +318,7 @@ def _build_lockfile_targets(pins: dict[str, str]) -> dict[str, str]:
 def sync_lockfile(
     lockfile_path: Path, pins: dict[str, str], apply: bool = False
 ) -> tuple[list[str], list[str]]:
-    """Sync versions from pin file to requirements.lock."""
+    """Sync direct tool pins in one supported requirements lockfile."""
     if not lockfile_path.exists():
         return [], []
 
@@ -336,7 +338,7 @@ def sync_lockfile(
         version = match.group("version")
         target_version = targets.get(name.lower())
         if target_version and version != target_version:
-            changes.append(f"requirements.lock:{name}: {version} -> =={target_version}")
+            changes.append(f"{lockfile_path.name}:{name}: {version} -> =={target_version}")
             if apply:
                 updated_lines.append(
                     f"{match.group('lead')}{name}=={target_version}{match.group('trail')}"
@@ -368,7 +370,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--apply",
         action="store_true",
-        help="Apply version updates to pyproject.toml",
+        help="Apply version updates to pyproject.toml and supported requirements lockfiles",
     )
     parser.add_argument(
         "--create-if-missing",
@@ -383,7 +385,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--lockfile",
         action="store_true",
-        help="Force lockfile sync even if requirements.lock doesn't exist (no-op)",
+        help="Compatibility flag; supported requirements lockfiles are always checked",
     )
     parser.add_argument(
         "--pin-file",
@@ -421,9 +423,8 @@ def main(argv: list[str] | None = None) -> int:
         create_if_missing=args.create_if_missing,
     )
 
-    lockfile_enabled = args.lockfile or LOCKFILE_FILE.exists()
-    if lockfile_enabled:
-        lock_changes, lock_errors = sync_lockfile(LOCKFILE_FILE, pins, apply=args.apply)
+    for lockfile_path in LOCKFILE_FILES:
+        lock_changes, lock_errors = sync_lockfile(lockfile_path, pins, apply=args.apply)
         changes.extend(lock_changes)
         errors.extend(lock_errors)
 

--- a/tools/check_model_registry_freshness.py
+++ b/tools/check_model_registry_freshness.py
@@ -318,16 +318,30 @@ def evaluate(
             findings.append(_finding("invalid_slot", f"slot {name!r} has no provider."))
             continue
         if explicit_model:
-            selected = selection_by_key.get((profile, provider)) if profile else None
-            if selected and selected.get("model_id") != explicit_model:
+            model = model_by_key.get((provider, explicit_model))
+            # Explicit-profile pins must match their reviewed decision.  A
+            # legacy pin without a profile is also valid at runtime when the
+            # pin is a current, unblocked catalog model.
+            effective_profile = profile or "verifier-balanced"
+            selected = selection_by_key.get((effective_profile, provider))
+            legacy_pin_is_current = bool(
+                not profile
+                and model is not None
+                and not model.get("blocked")
+                and str(model.get("lifecycle", "")).strip().lower() == "current"
+            )
+            if (
+                selected
+                and selected.get("model_id") != explicit_model
+                and not legacy_pin_is_current
+            ):
                 findings.append(
                     _finding(
                         "selection_override",
                         f"slot {name!r} pins {provider}/{explicit_model} instead of reviewed "
-                        f"selection {selected.get('model_id')}.",
+                        f"selection {selected.get('model_id')} for {effective_profile}.",
                     )
                 )
-            model = model_by_key.get((provider, explicit_model))
             if model is None:
                 findings.append(
                     _finding(

--- a/tools/ci_failure_triage.py
+++ b/tools/ci_failure_triage.py
@@ -292,28 +292,34 @@ def _get_llm_client() -> tuple[_LLMClient, str] | None:
     if not github_token and not openai_token:
         return None
 
-    from tools.llm_provider import DEFAULT_MODEL, GITHUB_MODELS_BASE_URL
+    from tools.llm_provider import GITHUB_MODELS_BASE_URL
+    from tools.llm_registry import configured_model_for_provider
 
     if github_token:
-        return (
-            cast(
-                _LLMClient,
-                ChatOpenAI(
-                    model=DEFAULT_MODEL,
-                    base_url=GITHUB_MODELS_BASE_URL,
-                    api_key=cast(Any, github_token),
-                    temperature=0.1,
+        model = configured_model_for_provider("github-models")
+        if model:
+            return (
+                cast(
+                    _LLMClient,
+                    ChatOpenAI(
+                        model=model,
+                        base_url=GITHUB_MODELS_BASE_URL,
+                        api_key=cast(Any, github_token),
+                        temperature=0.1,
+                    ),
                 ),
-            ),
-            "github-models",
-        )
-    if openai_token is None:
+                "github-models",
+            )
+    if not openai_token:
+        return None
+    model = configured_model_for_provider("openai")
+    if not model:
         return None
     return (
         cast(
             _LLMClient,
             ChatOpenAI(
-                model=DEFAULT_MODEL,
+                model=model,
                 api_key=cast(Any, openai_token),
                 temperature=0.1,
             ),

--- a/tools/discover_model_catalog.py
+++ b/tools/discover_model_catalog.py
@@ -16,12 +16,19 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-
-import requests
+from urllib.error import URLError
+from urllib.request import Request, urlopen
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_REGISTRY_PATH = _REPO_ROOT / "config" / "model_registry.json"
 PROVIDERS = ("openai", "anthropic", "github-models")
+CATALOG_URLS = frozenset(
+    {
+        "https://models.github.ai/catalog/models",
+        "https://api.openai.com/v1/models",
+        "https://api.anthropic.com/v1/models?limit=1000",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -31,9 +38,11 @@ class CatalogModel:
 
 
 def _request_json(url: str, headers: dict[str, str]) -> Any:
-    response = requests.get(url, headers=headers, timeout=30)
-    response.raise_for_status()
-    return response.json()
+    if url not in CATALOG_URLS:
+        raise ValueError(f"unsupported catalog URL: {url}")
+    request = Request(url, headers=headers)
+    with urlopen(request, timeout=30) as response:  # noqa: S310 - validated static catalog URL
+        return json.load(response)
 
 
 def _parse_timestamp(value: object) -> dt.datetime | None:
@@ -131,7 +140,7 @@ def fetch_provider(provider: str) -> tuple[list[CatalogModel] | None, str | None
         else:  # pragma: no cover - argparse constrains values
             raise ValueError(f"unsupported provider: {provider}")
         return parse_catalog(provider, payload), None
-    except (OSError, ValueError, requests.RequestException) as exc:
+    except (OSError, URLError, ValueError) as exc:
         return None, str(exc)
 
 

--- a/tools/evaluate_model_benchmark.py
+++ b/tools/evaluate_model_benchmark.py
@@ -8,6 +8,7 @@ import json
 import math
 import sys
 from pathlib import Path
+from statistics import NormalDist
 from typing import Any
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -43,7 +44,7 @@ def _case_outcome(case: dict[str, Any]) -> tuple[str, str, bool]:
     return expected, actual, schema_valid
 
 
-def _metrics(cases: list[dict[str, Any]]) -> dict[str, Any]:
+def _metrics(cases: list[dict[str, Any]], *, z: float = Z_95) -> dict[str, Any]:
     success = false_pass = false_fail = schema_error = 0
     expected_pass = expected_non_pass = 0
     categories: dict[str, int] = {}
@@ -77,10 +78,10 @@ def _metrics(cases: list[dict[str, Any]]) -> dict[str, Any]:
         latencies.append(latency)
 
     count = len(cases)
-    success_interval = wilson_interval(success, count)
-    false_pass_interval = wilson_interval(false_pass, expected_non_pass)
-    false_fail_interval = wilson_interval(false_fail, expected_pass)
-    schema_interval = wilson_interval(schema_error, count)
+    success_interval = wilson_interval(success, count, z=z)
+    false_pass_interval = wilson_interval(false_pass, expected_non_pass, z=z)
+    false_fail_interval = wilson_interval(false_fail, expected_pass, z=z)
+    schema_interval = wilson_interval(schema_error, count, z=z)
     return {
         "sample_count": count,
         "category_counts": categories,
@@ -124,6 +125,13 @@ def evaluate_benchmark(payload: dict[str, Any], policy: dict[str, Any]) -> dict[
     profile_policy = profiles[profile]
     approval = profile_policy["approval_stage"]
     gates = approval["quality_gates"]
+    confidence_level = float(approval.get("confidence_level", 0.95))
+    if not 0.0 < confidence_level < 1.0:
+        raise ValueError("approval_stage.confidence_level must be between 0 and 1")
+    # Keep the inverse CDF strictly inside its finite domain even when a
+    # valid float extremely close to 0 or 1 rounds at machine precision.
+    probability = min(1.0 - 1e-15, max(1e-15, (1.0 + confidence_level) / 2.0))
+    z = NormalDist().inv_cdf(probability)
     candidates = payload.get("candidates")
     if not isinstance(candidates, list) or len(candidates) < 2:
         raise ValueError("benchmark requires a baseline and at least one candidate")
@@ -137,7 +145,7 @@ def evaluate_benchmark(payload: dict[str, Any], policy: dict[str, Any]) -> dict[
         provider = str(candidate.get("provider", "")).strip()
         if not model_id or not provider or model_id in metrics_by_model:
             raise ValueError("candidate provider/model_id values must be non-empty and unique")
-        metrics_by_model[model_id] = _metrics(candidate["cases"])
+        metrics_by_model[model_id] = _metrics(candidate["cases"], z=z)
     if baseline_model not in metrics_by_model:
         raise ValueError("baseline_model_id must identify one candidate")
 
@@ -148,7 +156,7 @@ def evaluate_benchmark(payload: dict[str, Any], policy: dict[str, Any]) -> dict[
     noninferiority_margin = float(gates["paired_success_noninferiority_margin"])
 
     for candidate in candidates:
-        model_id = str(candidate["model_id"])
+        model_id = str(candidate["model_id"]).strip()
         metrics = metrics_by_model[model_id]
         gate_results = {
             "minimum_adjudicated_cases": metrics["sample_count"] >= minimum_cases,

--- a/tools/langchain_client.py
+++ b/tools/langchain_client.py
@@ -21,6 +21,7 @@ from tools.llm_registry import (
     ModelRegistryEntry,
     SlotDefinition,
     apply_slot_env_overrides,
+    configured_model_for_provider,
     default_slots,
     is_model_blocked,
     load_model_registry,
@@ -227,6 +228,11 @@ def build_chat_client(
 
     selected_provider, provider_explicit = _resolve_provider(provider, force_openai=force_openai)
     if provider_explicit and selected_provider is None:
+        return None
+    if selected_provider and not selected_model:
+        selected_model = configured_model_for_provider(selected_provider)
+    if selected_provider and not selected_model:
+        logger.warning("No reviewed model is configured for provider %s", selected_provider)
         return None
     if selected_provider and _is_model_blocked(selected_provider, selected_model):
         logger.warning("Refusing blocked LLM model: %s/%s", selected_provider, selected_model)

--- a/tools/llm_provider.py
+++ b/tools/llm_provider.py
@@ -351,6 +351,7 @@ class GitHubModelsProvider(LLMProvider):
 
         model_name = _configured_langchain_model("github-models", fallback=DEFAULT_MODEL)
         if not model_name:
+            logger.warning("No reviewed GitHub Models selection is configured")
             return None
         self._model_name = model_name
         return ChatOpenAI(
@@ -369,7 +370,9 @@ class GitHubModelsProvider(LLMProvider):
     ) -> CompletionAnalysis:
         client = self._get_client()
         if not client:
-            raise RuntimeError("LangChain OpenAI not available")
+            raise RuntimeError(
+                "GitHub Models client unavailable: install langchain-openai or configure a reviewed model"
+            )
 
         prompt = self._build_analysis_prompt(session_output, tasks, context)
 

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -85,7 +85,7 @@ def _load_object(path: Path, *, label: str) -> dict[str, object] | None:
         return None
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         logger.warning("Could not read %s %s", label, path)
         return None
     if not isinstance(payload, dict):
@@ -166,7 +166,7 @@ def load_selection_decisions() -> list[SelectionDecision]:
                 model=model,
                 status=str(raw.get("status", "")).strip().lower(),
                 review_by=str(raw.get("review_by", "")).strip(),
-                evidence_ids=tuple(str(item) for item in evidence if str(item).strip()),
+                evidence_ids=tuple(str(item).strip() for item in evidence if str(item).strip()),
             )
         )
     return decisions
@@ -229,6 +229,13 @@ def select_model_for_profile(
             )
         return None
     decision = matches[0]
+    if not decision.evidence_ids:
+        logger.warning(
+            "Model selection %s/%s has no evidence; refusing to use it",
+            normalized_provider,
+            profile,
+        )
+        return None
     entry = registry_entry_for(decision.provider, decision.model, registry=entries)
     if entry is None or entry.blocked or entry.lifecycle != "current":
         return None
@@ -263,40 +270,21 @@ def configured_model_for_provider(
 ) -> str:
     normalized_provider = normalize_provider(provider)
     entries = registry if registry is not None else load_model_registry()
-    path = _slot_path()
-    payload = _load_object(path, label="slot config")
-    if payload is not None:
-        for slot in _slot_entries(payload, path):
-            slot_provider = normalize_provider(str(slot.get("provider", "")))
-            if slot_provider != normalized_provider:
-                continue
-            explicit_model = str(slot.get("model", "")).strip()
-            slot_profile = str(slot.get("profile") or profile).strip()
-            model = (
-                select_model_for_profile(
-                    provider=slot_provider or "",
-                    profile=slot_profile,
-                    registry=entries,
-                )
-                or ""
-            )
-            if not model:
-                logger.warning(
-                    "No reviewed model selection for slot profile %s/%s",
-                    slot_profile,
-                    slot_provider,
-                )
-                return ""
-            if explicit_model and explicit_model != model:
-                logger.warning(
-                    "Ignoring slot model pin %s/%s; reviewed %s selection is %s",
-                    slot_provider,
-                    explicit_model,
-                    slot_profile,
-                    model or "unavailable",
-                )
-            if model and not is_model_blocked(slot_provider or "", model, registry=entries):
-                return model
+    # An explicit slot config is an execution allowlist, including when its
+    # path is missing or malformed. Never broaden execution because a
+    # configured allowlist cannot be read or does not contain this provider.
+    if os.environ.get(ENV_SLOT_CONFIG):
+        configured_slots = load_slot_config()
+        if not configured_slots:
+            return ""
+        for slot in apply_slot_env_overrides(configured_slots):
+            if (
+                slot.provider == normalized_provider
+                and slot.model
+                and not is_model_blocked(slot.provider, slot.model, registry=entries)
+            ):
+                return slot.model
+        return ""
 
     selected = select_model_for_profile(provider=provider, profile=profile, registry=entries)
     if selected:
@@ -315,8 +303,7 @@ def default_slots(*, github_default_model: str = "") -> list[SlotDefinition]:
         model = select_model_for_profile(provider=provider)
         if not model and provider == PROVIDER_GITHUB:
             model = github_default_model.strip()
-        if model:
-            slots.append(SlotDefinition(name=f"slot{index}", provider=provider, model=model))
+        slots.append(SlotDefinition(name=f"slot{index}", provider=provider, model=model or ""))
     return slots
 
 
@@ -325,6 +312,10 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
     payload = _load_object(path, label="slot config")
     fallback_slots = default_slots(github_default_model=github_default_model)
     if payload is None:
+        # An unreadable or missing explicitly configured slot file must fail
+        # closed. Only an unconfigured default path permits default slots.
+        if os.environ.get(ENV_SLOT_CONFIG):
+            return []
         return fallback_slots
 
     registry = load_model_registry()
@@ -337,7 +328,7 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
         ).strip()
         for entry in slot_entries
     ):
-        return fallback_slots
+        return [] if os.environ.get(ENV_SLOT_CONFIG) else fallback_slots
 
     slots: list[SlotDefinition] = []
     fallback_by_provider = {slot.provider: slot for slot in fallback_slots}
@@ -352,14 +343,32 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
                 select_model_for_profile(provider=provider, profile=profile, registry=registry)
                 or ""
             )
-        if provider and explicit_model and explicit_model != model:
+        explicit_entry = (
+            registry_entry_for(provider, explicit_model, registry=registry)
+            if provider and explicit_model
+            else None
+        )
+        if (
+            provider
+            and explicit_model
+            and not configured_profile
+            and explicit_entry
+            and not (explicit_entry.blocked or explicit_entry.lifecycle != "current")
+        ):
+            model = explicit_model
+        elif provider and explicit_model and explicit_model != model:
             logger.warning(
-                "Ignoring slot model pin %s/%s; reviewed %s selection is %s",
+                "Skipping unresolved slot model pin %s/%s; reviewed %s selection is %s",
                 provider,
                 explicit_model,
                 profile,
                 model or "unavailable",
             )
+            # A caller-supplied slot file is an allowlist and must fail closed.
+            # The repository's bundled legacy file is advisory: ignore a stale
+            # pin and retain the reviewed registry selection for that provider.
+            if os.environ.get(ENV_SLOT_CONFIG):
+                continue
         if provider and configured_profile and not model:
             logger.warning(
                 "Skipping slot with unresolved reviewed profile: %s/%s",
@@ -377,7 +386,9 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
             continue
         name = str(entry.get("name") or f"slot{idx}").strip() or f"slot{idx}"
         slots.append(SlotDefinition(name=name, provider=provider, model=model))
-    return slots if slot_entries else fallback_slots
+    # A present slot file is an allowlist.  If every configured slot is
+    # unusable, fail closed instead of broadening execution to default providers.
+    return slots
 
 
 def apply_slot_env_overrides(
@@ -417,7 +428,7 @@ def resolve_slots(
     # Preserve an explicit runtime override as an emergency bootstrap when the
     # registry file is unavailable. Empty models are never invoked directly;
     # langchain_client skips them when the override cannot serve that provider.
-    if not slots and os.environ.get(env_model_name):
+    if not slots and not os.environ.get(ENV_SLOT_CONFIG) and os.environ.get(env_model_name):
         slots = [
             SlotDefinition(name=f"slot{index}", provider=provider, model="")
             for index, provider in enumerate(


### PR DESCRIPTION
## Sync Summary

### Files Updated
- sync_dev_dependencies.py: Syncs dev dependency versions from autofix-versions.env to pyproject.toml
- ci_failure_triage.py: Classifies CI failure logs - required by pr-00-gate.yml summary generation
- runner_lib/ (1 files): Shared runner prompt assembly, output parsing, and dispatch debounce helpers
- keepalive_prompt_composer.js: Composes prompts for keepalive Codex calls
- capability_bundle.js: Validates and selects capability-bundle/v1 fragments for keepalive prompts and metrics
- api_client.py: Shared GitHub API client used by synced Python automation scripts
- llm_provider.py: LLM provider configuration - GitHub Models and OpenAI client setup
- langchain_client.py: LangChain client builder - multi-provider client with slot-based fallback and configuration
- llm_registry.py: LLM model registry helper - shared slot/model selection and blocked-model enforcement
- check_model_registry_freshness.py: Model-registry freshness gate - validates dated decisions, evidence, lifecycle, and profile-based slots
- discover_model_catalog.py: Advisory provider-catalog discovery - proposes new model candidates without changing reviewed selections
- evaluate_model_benchmark.py: Deterministic paired model benchmark evaluator - computes confidence-bound quality gates and cost/latency ranking
- agent-run-base/ (1 files): Shared agent runner setup action - required by reusable-codex-run.yml and reusable-claude-run.yml
- SETUP_CHECKLIST.md: Consumer repo setup checklist. Includes the default_workflow_permissions=write step in section 3.3.1 that prevents a Gate startup_failure on fresh consumers (see #2157). Synced so it no longer drifts across the fleet.

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `47304edda491ca61939d8ef5977749b9d4ad9f82`
**Template hash:** `8b1e3c31a32f`
**Sync branch:** `sync/workflows-8b1e3c31a32f`
**Consumer repo:** `stranske/Pension-Data`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Pension-Data","source_repository":"stranske/Workflows","source_sha":"47304edda491ca61939d8ef5977749b9d4ad9f82","template_hash":"8b1e3c31a32f","sync_branch":"sync/workflows-8b1e3c31a32f","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"29623119601","run_attempt":"1","changes_count":14} -->