### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/scripts/capability_bundle.js
+++ b/.github/scripts/capability_bundle.js
@@ -130,8 +130,11 @@ function validateCapabilityBundle(bundle, options = {}) {
   if (!normalise(bundle.fragments.task) && !normalise(bundle.fragments.acceptance)) {
     throw new Error('capability bundle must include a task or acceptance fragment');
   }
-  if (!Array.isArray(bundle.gates) || bundle.gates.length === 0 || bundle.gates.some((gate) => !normalise(gate))) {
+  if (!Array.isArray(bundle.gates) || bundle.gates.length === 0 || bundle.gates.some((gate) => typeof gate !== 'string' || !normalise(gate))) {
     throw new Error('capability bundle must include at least one gate ref');
+  }
+  if (bundle.playbooks !== undefined && (!Array.isArray(bundle.playbooks) || bundle.playbooks.some((playbook) => typeof playbook !== 'string' || !normalise(playbook)))) {
+    throw new Error('capability bundle playbooks must be non-empty strings');
   }
   const forbidden = walkForbiddenKeys(bundle);
   if (forbidden.length > 0) {

--- a/.github/workflows/maint-76-claude-code-review.yml
+++ b/.github/workflows/maint-76-claude-code-review.yml
@@ -189,7 +189,7 @@ jobs:
       - name: Run Claude Code Review
         id: claude
         continue-on-error: true
-        uses: anthropics/claude-code-action@44423bdec74b97d67543eb16c110546762c110b2 # v1
+        uses: anthropics/claude-code-action@fa7e2f0a29a126f0b81cdcf360561b36e44cf608 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: '*'

--- a/docs/contracts/agent-runner-output.md
+++ b/docs/contracts/agent-runner-output.md
@@ -112,7 +112,7 @@ they MUST NOT infer capability identity or effects from free-form agent prose.
 
 | Output | Type | Description | Example |
 |--------|------|-------------|---------|
-| `capability-id` | string | Existing lowercase kebab capability identifier | `capability:consumer-sync` |
+| `capability-id` | string | Existing `capability:<lowercase-kebab-id>` identifier | `capability:consumer-sync` |
 | `effect-fingerprint` | string | Lowercase `sha256:` fingerprint of the bounded effect | `sha256:0000000000000000000000000000000000000000000000000000000000000000` |
 | `evidence-artifact-ref` | string | Secret-safe durable logical evidence reference | `github-actions:owner/repo:123:consumer-sync-plan` |
 | `supervision-mode` | string | `shadow` \| `human-reviewed` \| `human-on-exception` \| `unattended` | `shadow` |

--- a/tools/check_model_registry_freshness.py
+++ b/tools/check_model_registry_freshness.py
@@ -16,6 +16,14 @@ from pathlib import Path
 from typing import Any
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Direct execution puts tools/, rather than the repository root, on sys.path.
+# Always import through the package so type checking sees one symbol definition.
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from tools.llm_registry import DEFAULT_SELECTION_PROFILE  # noqa: E402
+
 DEFAULT_REGISTRY_PATH = _REPO_ROOT / "config" / "model_registry.json"
 DEFAULT_SLOTS_PATH = _REPO_ROOT / "config" / "llm_slots.json"
 DEFAULT_POLICY_PATH = _REPO_ROOT / "config" / "model_selection_policy.json"
@@ -239,8 +247,13 @@ def evaluate(
                 )
             )
 
-        evidence_ids = raw.get("evidence_ids")
-        if not isinstance(evidence_ids, list) or not evidence_ids:
+        raw_evidence_ids = raw.get("evidence_ids")
+        evidence_ids = (
+            [item.strip() for item in raw_evidence_ids if isinstance(item, str) and item.strip()]
+            if isinstance(raw_evidence_ids, list)
+            else []
+        )
+        if not evidence_ids:
             findings.append(
                 _finding(
                     "missing_evidence",
@@ -319,29 +332,21 @@ def evaluate(
             continue
         if explicit_model:
             model = model_by_key.get((provider, explicit_model))
-            # Explicit-profile pins must match their reviewed decision.  A
-            # legacy pin without a profile is also valid at runtime when the
-            # pin is a current, unblocked catalog model.
-            effective_profile = profile or "verifier-balanced"
+            effective_profile = profile or DEFAULT_SELECTION_PROFILE
             selected = selection_by_key.get((effective_profile, provider))
-            legacy_pin_is_current = bool(
-                not profile
-                and model is not None
-                and not model.get("blocked")
-                and str(model.get("lifecycle", "")).strip().lower() == "current"
-            )
-            if (
-                selected
-                and selected.get("model_id") != explicit_model
-                and not legacy_pin_is_current
-            ):
+            if not selected:
                 findings.append(
                     _finding(
-                        "selection_override",
-                        f"slot {name!r} pins {provider}/{explicit_model} instead of reviewed "
-                        f"selection {selected.get('model_id')} for {effective_profile}.",
+                        "missing_selection",
+                        f"slot {name!r} has no selection for {effective_profile}/{provider}.",
                     )
                 )
+                continue
+            # Unprofiled pins predate the reviewed-selection contract. They are
+            # advisory while consumers migrate to profiles, so runtime uses the
+            # reviewed default selection regardless of the legacy pin value.
+            if not profile:
+                continue
             if model is None:
                 findings.append(
                     _finding(
@@ -354,6 +359,14 @@ def evaluate(
                     _finding(
                         "blocked_pin",
                         f"slot {name!r} pins blocked model {provider}/{explicit_model}.",
+                    )
+                )
+            if selected.get("model_id") != explicit_model:
+                findings.append(
+                    _finding(
+                        "selection_override",
+                        f"slot {name!r} pins {provider}/{explicit_model} instead of reviewed "
+                        f"selection {selected.get('model_id')} for {effective_profile}.",
                     )
                 )
             continue

--- a/tools/langchain_client.py
+++ b/tools/langchain_client.py
@@ -508,6 +508,7 @@ def build_chat_clients(
         slot_model = model_overrides[idx] if idx < len(model_overrides) else None
         slot_model = slot_model or slot.model
         if not slot_model:
+            logger.warning("Skipping LLM slot without a resolved model: %s", slot.name)
             continue
         if _is_model_blocked(slot.provider, slot_model, registry=registry):
             logger.warning("Skipping blocked LLM model override: %s/%s", slot.provider, slot_model)

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -34,7 +34,7 @@ class ModelRegistryEntry:
     model: str
     blocked: bool
     lifecycle: str = "unknown"
-    # Retained as empty compatibility attributes for callers migrating from v1.
+    # Retained as optional compatibility attributes for callers migrating from v1.
     # They are deliberately not inputs to model selection.
     quality: dict[str, float] | None = None
     cost_score: float | None = None
@@ -70,16 +70,24 @@ def normalize_provider(value: str | None) -> str | None:
     return None
 
 
-def _configured_path(env_name: str, default: Path) -> Path | None:
+def _configured_path(
+    env_name: str, default: Path, *, empty_uses_default: bool = False
+) -> Path | None:
     configured = os.environ.get(env_name)
     if configured is None:
         return default
     configured = configured.strip()
-    return Path(configured) if configured else None
+    if configured:
+        return Path(configured)
+    return default if empty_uses_default else None
 
 
 def _registry_path() -> Path | None:
-    return _configured_path(ENV_MODEL_REGISTRY_CONFIG, DEFAULT_MODEL_REGISTRY_CONFIG_PATH)
+    return _configured_path(
+        ENV_MODEL_REGISTRY_CONFIG,
+        DEFAULT_MODEL_REGISTRY_CONFIG_PATH,
+        empty_uses_default=True,
+    )
 
 
 def _slot_path() -> Path | None:
@@ -91,6 +99,7 @@ def _load_object(path: Path | None, *, label: str) -> dict[str, object] | None:
         logger.warning("Cannot load %s: explicit configuration is empty", label)
         return None
     if not path.is_file():
+        logger.warning("Cannot load %s: %s is not a file", label, path)
         return None
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
@@ -174,7 +183,9 @@ def load_selection_decisions() -> list[SelectionDecision]:
                 model=model,
                 status=str(raw.get("status", "")).strip().lower(),
                 review_by=str(raw.get("review_by", "")).strip(),
-                evidence_ids=tuple(str(item).strip() for item in evidence if str(item).strip()),
+                evidence_ids=tuple(
+                    item.strip() for item in evidence if isinstance(item, str) and item.strip()
+                ),
             )
         )
     return decisions
@@ -223,17 +234,18 @@ def select_model_for_profile(
     entries = registry if registry is not None else load_model_registry()
     selections = decisions if decisions is not None else load_selection_decisions()
     normalized_provider = normalize_provider(provider)
+    normalized_profile = profile.strip() or DEFAULT_SELECTION_PROFILE
     matches = [
         decision
         for decision in selections
-        if decision.provider == normalized_provider and decision.profile == profile
+        if decision.provider == normalized_provider and decision.profile == normalized_profile
     ]
     if len(matches) != 1:
         if matches:
             logger.warning(
                 "Ambiguous model selections for %s/%s; expected exactly one",
                 normalized_provider,
-                profile,
+                normalized_profile,
             )
         return None
     decision = matches[0]
@@ -241,7 +253,7 @@ def select_model_for_profile(
         logger.warning(
             "Model selection %s/%s has no evidence; refusing to use it",
             normalized_provider,
-            profile,
+            normalized_profile,
         )
         return None
     entry = registry_entry_for(decision.provider, decision.model, registry=entries)
@@ -327,6 +339,11 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
         return fallback_slots
 
     registry = load_model_registry()
+    # Keep the type and fail-closed contract explicit even though a non-null
+    # payload normally implies a configured path.
+    if path is None:
+        logger.warning("Cannot load slot config: configured path is unavailable")
+        return []
     slot_entries = _slot_entries(payload, path)
     if not _model_registry_format_valid() and any(
         str(entry.get("provider", "")).strip()
@@ -366,8 +383,8 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
             model = explicit_model
         elif provider and explicit_model and explicit_model != model:
             # A caller-supplied slot file is an allowlist and must fail closed.
-            # The repository's bundled legacy file is advisory: ignore a stale
-            # pin and retain the reviewed registry selection for that provider.
+            # The repository's bundled legacy file is advisory: retain a
+            # current, unblocked pin; otherwise use the reviewed selection.
             if ENV_SLOT_CONFIG in os.environ:
                 logger.warning(
                     "Skipping unresolved slot model pin %s/%s; reviewed %s selection is %s",

--- a/tools/requirements-llm.txt
+++ b/tools/requirements-llm.txt
@@ -9,7 +9,7 @@
 #   release resolve a mutually compatible core version.
 langchain==1.3.14
 langchain-community==0.4.2
-langchain-openai==1.4.0
-langchain-anthropic==1.5.0
+langchain-openai==1.3.5
+langchain-anthropic==1.4.8
 pydantic==2.13.4
 requests==2.34.2


### PR DESCRIPTION
## Sync Summary

### Files Updated
- maint-76-claude-code-review.yml: Claude Code review (opt-in) - runs only on labeled PRs or manual dispatch
- requirements-llm.txt: Pinned LLM dependencies - exact-sync guarded for agent workflows
- capability_bundle.js: Validates and selects capability-bundle/v1 fragments for keepalive prompts and metrics
- langchain_client.py: LangChain client builder - multi-provider client with slot-based fallback and configuration
- llm_registry.py: LLM model registry helper - shared slot/model selection and blocked-model enforcement
- check_model_registry_freshness.py: Model-registry freshness gate - validates dated decisions, evidence, lifecycle, and profile-based slots
- agent-runner-output.md: Agent runner output contract specification - required for implementing new agent runners

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `50e71db08e03e46028cc5938384cd5eefa9f34d0`
**Template hash:** `238b5d755346`
**Sync branch:** `sync/workflows-238b5d755346`
**Consumer repo:** `stranske/Pension-Data`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/Pension-Data","source_repository":"stranske/Workflows","source_sha":"50e71db08e03e46028cc5938384cd5eefa9f34d0","template_hash":"238b5d755346","sync_branch":"sync/workflows-238b5d755346","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"29999421851","run_attempt":"1","changes_count":7} -->