### PR TITLE
docs(sql-safety): document the single semicolon policy + cover it in tests (#638)

### DIFF
--- a/src/pension_data/query/sql_safety.py
+++ b/src/pension_data/query/sql_safety.py
@@ -181,17 +181,33 @@ def _strip_sql_comments_and_strings(sql: str) -> str:
 
 
 def validate_read_only_sql(sql: str) -> str:
-    """Validate generated SQL and return normalized read-only statement text."""
+    """Validate generated SQL and return normalized read-only statement text.
+
+    This is the only read-only SQL validator in the package: both
+    ``query.sql_service.execute_sql_query`` and ``langchain.eval_harness`` call
+    it, so the two paths cannot diverge on whether a given string is safe.
+
+    Semicolon policy: at most one semicolon is accepted, and only as a bare
+    statement terminator with nothing but whitespace following it, in which case
+    it is stripped from the returned text. A semicolon followed by any further
+    content, and any second semicolon, is rejected as a multi-statement
+    submission.
+    """
     normalized = sql.strip()
     if not normalized:
         raise SQLSafetyValidationError("generated SQL is empty")
 
     sanitized = _strip_sql_comments_and_strings(normalized)
+    # Semicolons are counted on the sanitized text so that a ";" hidden inside a
+    # comment or string literal cannot smuggle a second statement past this gate.
     semicolon_indices = [index for index, char in enumerate(sanitized) if char == ";"]
     if len(semicolon_indices) > 1:
         raise SQLSafetyValidationError("multiple SQL statements are not allowed")
     if len(semicolon_indices) == 1:
         semicolon_index = semicolon_indices[0]
+        # A bare trailing ";" is cosmetic and safe to drop, but anything else after
+        # it is a chained statement (e.g. "; DROP TABLE t"), which must be rejected
+        # rather than silently truncated away.
         if any(not char.isspace() for char in sanitized[semicolon_index + 1 :]):
             raise SQLSafetyValidationError("multiple SQL statements are not allowed")
         normalized = normalized[:semicolon_index].strip()

--- a/tests/query/test_sql_safety.py
+++ b/tests/query/test_sql_safety.py
@@ -106,6 +106,14 @@ class TestValidateReadOnlySql:
         assert "SELECT" in result
         assert not result.endswith(";")
 
+    def test_rejects_repeated_semicolons(self) -> None:
+        with pytest.raises(SQLSafetyValidationError, match="multiple"):
+            validate_read_only_sql("SELECT 1;;")
+
+    def test_allows_semicolon_inside_string_literal(self) -> None:
+        sql = "SELECT plan_id FROM curated_metric_facts WHERE plan_id = 'a;b'"
+        assert validate_read_only_sql(sql) == sql
+
     def test_rejects_empty(self) -> None:
         with pytest.raises(SQLSafetyValidationError, match="empty"):
             validate_read_only_sql("")


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:638 -->
> **Source:** Issue #638

Closes #638

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The read-only SQL safety gate is implemented twice with divergent behavior — a correctness/security risk because the two paths can disagree on whether the same query is safe:
- `query/sql_safety.py` (`validate_read_only_sql`, `_strip_sql_comments_and_strings`, `_FORBIDDEN_SQL_TOKENS`, `_SQL_WORD_PATTERN`) allows a trailing semicolon when nothing follows.
- `query/sql_service.py` (`_enforce_read_only_sql`, plus its own copy of the stripper + constants) rejects any `;` in sanitized SQL (`sql_service.py:157-158`).

~95 duplicated LOC. `validate_read_only_sql` is used by `langchain/eval_harness.py`; `_enforce_read_only_sql` is reached via `query/sql_service.execute_sql_query`. The API SQL route `routes/sql.py` is currently unmounted, so live exposure is limited today, but both validators are real and the divergence is a latent footgun for when the SQL path is wired.

#### Tasks
- [ ] Update `query/sql_service.py` to import and call `validate_read_only_sql` or a shared internal helper from `query/sql_safety.py`.
- [ ] Delete `_enforce_read_only_sql` and the duplicated stripper/constants from `query/sql_service.py`.
- [ ] Update `query/sql_safety.py` to implement and document one semicolon policy in the single shared helper.
  - [ ] Document the agreed semicolon policy in the docstring of the shared validator function (verify: docs updated)
  - [ ] Update the shared validator implementation to enforce the documented semicolon policy (verify: confirm completion in repo)
  - [ ] Add inline comments explaining why the semicolon policy was chosen for security (verify: confirm completion in repo)
- [ ] Test `langchain/eval_harness.py` and `query/sql_service` with the same `DELETE` and `;`-bearing inputs to verify identical accept/reject behavior.
  - [ ] Create a test that feeds DELETE queries through both eval_harness (verify: confirm completion in repo) sql_service paths (verify: confirm completion in repo) asserts both reject (verify: confirm completion in repo)
  - [ ] Create a test that feeds semicolon-bearing queries through both code paths (verify: confirm completion in repo) asserts identical behavior (verify: confirm completion in repo)
  - [ ] Add a test case that verifies trailing semicolons are handled consistently across both validators (verify: confirm completion in repo)
- [ ] Add or update SQL-safety tests to assert the documented trailing-semicolon policy and cover both code paths.
  - [ ] Add a test case in the SQL safety test suite that verifies the trailing semicolon policy with valid queries (verify: confirm completion in repo)
  - [ ] Add a test case that verifies queries with multiple semicolons are rejected per the policy (verify: confirm completion in repo)
  - [ ] Update existing SQL safety tests to cover both the eval_harness (verify: tests pass) sql_service code paths (verify: confirm completion in repo)
- [ ] Run `pytest tests -k sql_safety -q` and the `sql_service` read-only tests.

#### Acceptance criteria
- [ ] Exactly one read-only SQL validator and one comment/string stripper exist in `query/`.
- [ ] `query/sql_service.py` no longer contains `_enforce_read_only_sql` or duplicated SQL-safety constants/stripper logic.
- [ ] The same input string returns the same accept/reject decision through both the `langchain/eval_harness.py` and `query/sql_service.execute_sql_query` paths.
- [ ] Existing SQL-safety tests pass.
- [ ] A trailing-semicolon test exists and matches the documented semicolon policy.

**Head SHA:** b4088e252c418601ff603147d030bffaa5002f5d
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents Auto-Pilot | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30164252005) |
| Agents Gate Followups | ⏹️ cancelled | [View run](https://github.com/stranske/Pension-Data/actions/runs/30164252334) |
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165475361) |
| Agents Verifier | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30164252467) |
| Autofix | ⏹️ cancelled | [View run](https://github.com/stranske/Pension-Data/actions/runs/30164252527) |
| Backplane Conformance | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30164247617) |
| Claude Code Review (Opt-in) | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30164252085) |
| Create New PR from Verification | ⏭️ skipped | [View run](https://github.com/stranske/Pension-Data/actions/runs/30164252303) |
| Cross-Repo Smoke | ⏭️ skipped | [View run](https://github.com/stranske/Pension-Data/actions/runs/30164247680) |
| Entity Regression Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30164247390) |
| Extraction Golden Regression | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30164247362) |
| Foundation Fixture E2E | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30164247377) |
| Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30164252516) |
| Health 45 Agents Guard | ⏹️ cancelled | [View run](https://github.com/stranske/Pension-Data/actions/runs/30164252146) |
| NL-SQL Golden | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30164247414) |
| One-PDF Pilot Golden | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30164247415) |
| PostgreSQL Integration | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30164247421) |
| Quality Replay Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30164247358) |
| Quality SLA Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30164247416) |
<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified rules for semicolon usage in read-only SQL validation.
  * Added guidance explaining how semicolons in comments and quoted strings are handled.

* **Bug Fixes**
  * Improved validation coverage for multiple semicolons and semicolons inside string values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->