### PR TITLE
refactor(web): route build_workspace_bundle through the canonical contract validator (#639)

### DIFF
--- a/scripts/web/build_workspace_bundle.py
+++ b/scripts/web/build_workspace_bundle.py
@@ -4,16 +4,22 @@
 from __future__ import annotations
 
 import argparse
-import importlib.util
 import json
+import sys
 from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from workspace_contract import (  # noqa: E402
+    allowed_data_origins,
+    load_runtime_contract,
+    validate_workspace_bundle,
+)
+
 ROOT = Path(__file__).resolve().parents[2]
 CONTRACT_PATH = ROOT / "apps" / "contracts" / "runtime-contract.json"
-SMOKE_PATH = ROOT / "scripts" / "web" / "smoke_test.py"
 
 
 def _load_json(path: Path) -> Any:
@@ -26,23 +32,6 @@ def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
         json.dumps(payload, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
-
-
-def _load_web_smoke_test() -> Any:
-    spec = importlib.util.spec_from_file_location("web_smoke_test", SMOKE_PATH)
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"unable to load web smoke test helper: {SMOKE_PATH}")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-def _runtime_contract_version() -> str:
-    payload = _load_json(CONTRACT_PATH)
-    version = payload.get("version") if isinstance(payload, dict) else None
-    if not isinstance(version, str) or not version.strip():
-        raise ValueError(f"runtime contract missing version: {CONTRACT_PATH}")
-    return version
 
 
 def _artifact_path(pilot_run_dir: Path, manifest: Mapping[str, Any], key: str) -> Path:
@@ -160,8 +149,9 @@ def build_workspace_bundle(pilot_run_dir: Path) -> dict[str, Any]:
         )
     )
     run_id = _as_text(manifest.get("run_id")) or pilot_run_dir.name
+    contract = load_runtime_contract(CONTRACT_PATH)
     bundle = {
-        "contractVersion": _runtime_contract_version(),
+        "contractVersion": str(contract["version"]),
         "data_origin": "generated",
         "datasets": [
             {
@@ -175,11 +165,13 @@ def build_workspace_bundle(pilot_run_dir: Path) -> dict[str, Any]:
             }
         ],
     }
-    smoke = _load_web_smoke_test()
-    smoke._assert_workspace_bundle(
+    # This builder emits real generated data, so "fixture" is not an acceptable
+    # origin for its output even though the runtime contract permits it elsewhere.
+    validate_workspace_bundle(
         bundle,
         path_label="generated workspace bundle",
-        reject_fixture=True,
+        accepted_origins=allowed_data_origins(contract) - {"fixture"},
+        contract=contract,
     )
     return bundle
 

--- a/tests/web/test_build_workspace_bundle.py
+++ b/tests/web/test_build_workspace_bundle.py
@@ -22,6 +22,12 @@ assert smoke_spec is not None and smoke_spec.loader is not None
 web_smoke_test = importlib.util.module_from_spec(smoke_spec)
 smoke_spec.loader.exec_module(web_smoke_test)
 
+SERVE_PATH = ROOT / "scripts" / "web" / "serve_local.py"
+serve_spec = importlib.util.spec_from_file_location("web_serve_local", SERVE_PATH)
+assert serve_spec is not None and serve_spec.loader is not None
+web_serve_local = importlib.util.module_from_spec(serve_spec)
+serve_spec.loader.exec_module(web_serve_local)
+
 
 def _write_fixture_pilot_run(tmp_path: Path) -> Path:
     run_dir = tmp_path / "pilot-run"
@@ -84,6 +90,13 @@ def test_generator_emits_runtime_valid_generated_bundle(tmp_path: Path) -> None:
         payload,
         path_label="data/workspace.json",
         reject_fixture=True,
+    )
+    # #639: the builder is the third contract consumer, so serve_local must accept
+    # what the builder produced and smoke_test approved.
+    web_serve_local._assert_workspace_bundle(
+        payload,
+        path_label="data/workspace.json",
+        allow_fixture_demo=False,
     )
     assert payload["data_origin"] == "generated"
     dataset = payload["datasets"][0]

--- a/tests/web/test_workspace_contract.py
+++ b/tests/web/test_workspace_contract.py
@@ -88,6 +88,22 @@ def test_builder_rejects_a_contract_version_mismatched_bundle() -> None:
         )
 
 
+def test_builder_rejects_fixture_origin_even_when_contract_allows_it() -> None:
+    # #639: builder output must be generated data; fixture is only valid for the
+    # checked-in demo path, not for the generated-bundle producer.
+    contract = web_build_workspace_bundle.load_runtime_contract(
+        web_build_workspace_bundle.CONTRACT_PATH
+    )
+    accepted = web_build_workspace_bundle.allowed_data_origins(contract) - {"fixture"}
+    with pytest.raises(ValueError, match="requires data_origin of generated, live"):
+        web_build_workspace_bundle.validate_workspace_bundle(
+            _bundle(version=str(contract["version"]), data_origin="fixture"),
+            path_label="generated workspace bundle",
+            accepted_origins=accepted,
+            contract=contract,
+        )
+
+
 def _copy_web_fixture(tmp_path: Path) -> Path:
     target = tmp_path / "web"
     for relative in web_smoke_test.REQUIRED_LOCAL_FILES:

--- a/tests/web/test_workspace_contract.py
+++ b/tests/web/test_workspace_contract.py
@@ -23,6 +23,12 @@ assert _serve_spec is not None and _serve_spec.loader is not None
 web_serve_local = importlib.util.module_from_spec(_serve_spec)
 _serve_spec.loader.exec_module(web_serve_local)
 
+BUILD_PATH = ROOT / "scripts" / "web" / "build_workspace_bundle.py"
+_build_spec = importlib.util.spec_from_file_location("web_build_workspace_bundle", BUILD_PATH)
+assert _build_spec is not None and _build_spec.loader is not None
+web_build_workspace_bundle = importlib.util.module_from_spec(_build_spec)
+_build_spec.loader.exec_module(web_build_workspace_bundle)
+
 
 def _bundle(*, version: str, data_origin: str = "generated") -> dict[str, object]:
     return {
@@ -55,6 +61,31 @@ def test_smoke_and_serve_agree_on_contract_version_mismatch() -> None:
         web_smoke_test._assert_workspace_bundle(bad, path_label="bad", reject_fixture=False)
     with pytest.raises(ValueError, match="does not match runtime contract"):
         web_serve_local._assert_workspace_bundle(bad, path_label="bad", allow_fixture_demo=True)
+
+
+def test_all_three_consumers_share_one_rule_owner() -> None:
+    # #639 AC3: smoke_test, serve_local, and build_workspace_bundle must call the one
+    # canonical validator rather than keeping parallel contract logic of their own.
+    canonical = web_smoke_test.validate_workspace_bundle
+    assert web_serve_local.validate_workspace_bundle is canonical
+    assert web_build_workspace_bundle.validate_workspace_bundle is canonical
+    assert canonical.__module__ == "workspace_contract"
+
+
+def test_builder_rejects_a_contract_version_mismatched_bundle() -> None:
+    # #639 AC5: the builder rejects the same known-bad bundle its peers reject, using
+    # the contract it stamps bundles from.
+    contract = web_build_workspace_bundle.load_runtime_contract(
+        web_build_workspace_bundle.CONTRACT_PATH
+    )
+    accepted = web_build_workspace_bundle.allowed_data_origins(contract) - {"fixture"}
+    with pytest.raises(ValueError, match="does not match runtime contract"):
+        web_build_workspace_bundle.validate_workspace_bundle(
+            _bundle(version="9.9.9-mismatch"),
+            path_label="bad",
+            accepted_origins=accepted,
+            contract=contract,
+        )
 
 
 def _copy_web_fixture(tmp_path: Path) -> Path:


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:639 -->
> **Source:** Issue #639

Closes #639

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The web workspace bundle-contract is validated **three ways with inconsistent strictness**, so a bundle can pass one path and fail another:
`apps/web/app.js:112-141` (client) — `contractVersion` mismatch is **warn-only** (`:120-123`).
`scripts/web/smoke_test.py:30-120` — strict contract version + runtime-contract `data_origin` allowlist.
`scripts/web/serve_local.py:37-57` — minimal (`data_origin` + non-empty `datasets` only; **no `contractVersion` check**).

Concretely: `serve_local.py` can serve a bundle that `smoke_test.py` would reject, and `app.js` renders a contract-mismatched bundle with only a warning. Fixture handling also differs (`allow_fixture_demo` vs `reject_fixture` vs client labels). ~70 LOC of overlapping, divergent rules.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#394](https://github.com/stranske/Pension-Data/issues/394)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add `scripts/web/workspace_contract.py` with canonical validation for contract version, `data_origin` allowlist, datasets, and fixture policy, sourced from `apps/contracts/runtime-contract.json`.
- [ ] Update `scripts/web/smoke_test.py`, `scripts/web/serve_local.py`, and `scripts/web/build_workspace_bundle.py` to call `scripts/web/workspace_contract.py` and delete their local contract-validation logic.
- [ ] Fix `apps/web/app.js` to reject contract-version mismatches instead of warning, or load allowlist/version from `apps/contracts/runtime-contract.json` at build time.
  - [ ] Decide whether app.js should reject mismatches immediately or load validation rules from runtime-contract.json at build time (verify: confirm completion in repo)
  - [ ] Implement the chosen approach to make app.js enforce contract version validation consistently with Python validators (verify: confirm completion in repo)
  - [ ] Update app.js to load the contract version (verify: confirm completion in repo) data_origin allowlist from apps/contracts/runtime-contract.json during the build process (verify: confirm completion in repo)
  - [ ] Remove the warn-only behavior for contractVersion mismatches in apps/web/app.js lines 120-123 (verify: confirm completion in repo)
- [ ] Extend `tests/web/test_workspace_contract.py` under the `pytest tests/web -q` gate to assert all three consumers agree on a known-good and known-bad bundle.
  - [ ] Create or extend tests/web/test_workspace_contract.py with fixtures for known-good (verify: tests pass)
  - [ ] Create or extend tests/web/test_workspace_contract.py with known-bad bundle examples (verify: tests pass)
  - [ ] Write test cases that invoke smoke_test.py validation logic with known-good (verify: confirm completion in repo)
  - [ ] Write test cases that invoke smoke_test.py validation logic with known-bad bundles (verify: confirm completion in repo)
  - [ ] Write test cases that invoke serve_local.py validation logic with the same bundle fixtures (verify: confirm completion in repo)
  - [ ] _(2 further sub-tasks elided; split this issue)_
  - [ ] _(2 further sub-tasks elided; split this issue)_

#### Acceptance criteria
- [ ] A bundle rejected by `scripts/web/smoke_test.py` is also rejected by `scripts/web/serve_local.py` and is not served.
- [ ] `apps/web/app.js` refuses to render a bundle with a mismatched `contractVersion`.
- [ ] One Python module owns the rules, and `scripts/web/smoke_test.py`, `scripts/web/serve_local.py`, and `scripts/web/build_workspace_bundle.py` contain no parallel contract logic.
- [ ] `pytest tests/web -q` passes with coverage in `tests/web/test_workspace_contract.py` asserting all three consumers agree on a known-good and known-bad bundle.
- [ ] Deliberately bumping a bundle's `contractVersion` causes all paths to reject it, and reverting the change restores passing behavior.

**Head SHA:** 9c623fe6396570ff947adcb419fdb79e15081134
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165861717) |
| Backplane Conformance | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165604994) |
| Claude Code Review (Opt-in) | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165604825) |
| Cross-Repo Smoke | ⏭️ skipped | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165604986) |
| Entity Regression Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165604833) |
| Extraction Golden Regression | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165604844) |
| Foundation Fixture E2E | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165604841) |
| Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165604975) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165604837) |
| NL-SQL Golden | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165604839) |
| One-PDF Pilot Golden | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165604834) |
| PostgreSQL Integration | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165604826) |
| Quality Replay Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165604842) |
| Quality SLA Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165604818) |
<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace bundles are now validated consistently before use.
  * Bundles with mismatched contract versions are rejected.
  * Fixture-only data sources are excluded from generated web bundles.

* **Tests**
  * Added coverage ensuring bundle creation, serving, and smoke testing use the same validation rules.
  * Added checks for runtime contract version mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->