### PR TITLE
test(web): cover formatting, filters, and row-detail wiring (#640)

### DIFF
--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-18T02:36:07.003109Z",
+  "emitted_at": "2026-07-25T16:02:28.412746Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "732",
+  "pr_number": "777",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/tests/web/test_workspace_contract.py
+++ b/tests/web/test_workspace_contract.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -280,36 +282,62 @@ def test_ui_surfaces_fixture_origin_marker() -> None:
     assert "data_origin" in app
 
 
-def test_ui_has_issue_640_formatting_and_filter_feedback() -> None:
-    index = (WEB_DIR / "index.html").read_text(encoding="utf-8")
-    app = (WEB_DIR / "app.js").read_text(encoding="utf-8")
+def test_ui_formatting_filters_reset_and_row_click_render_details() -> None:
+    """Run the shipped browser script against a tiny DOM instead of source markers."""
+    if shutil.which("node") is None:
+        pytest.skip("node is required for browser-script regression coverage")
 
-    assert "function formatCellValue(column, value, row)" in app
-    assert "return `$${(n / 1e9).toFixed(1)}B`" in app
-    assert 'metric.includes("ratio")' in app
-    assert "formatCellValue(column, row[column], row)" in app
-    assert 'id="result-count"' in index
-    assert "Showing ${rows.length} of ${totalRows} records" in app
-    assert "No records match current filters." in app
-    assert 'id="clear-filters"' in index
-    assert 'getElementById("clear-filters").addEventListener("click"' in app
-
-
-def test_row_click_smoke_updates_record_details() -> None:
-    index = (WEB_DIR / "index.html").read_text(encoding="utf-8")
-    app = (WEB_DIR / "app.js").read_text(encoding="utf-8")
-
-    activate_row = app[app.index("const activateRow = (index) => {") :]
-    activate_row = activate_row[: activate_row.index("};") + 2]
-    render_detail = app[app.index("function renderDetail() {") :]
-    render_detail = render_detail[: render_detail.index("\n}") + 2]
-
-    assert 'id="detail-content"' in index
-    assert 'tr.addEventListener("click", () => activateRow(index));' in app
-    assert "state.selectedRowIndex = index;" in activate_row
-    assert "renderDetail();" in activate_row
-    assert 'document.getElementById("detail-content")' in render_detail
-    assert "rows[state.selectedRowIndex]" in render_detail
+    script = f"""
+const fs = require("fs");
+const vm = require("vm");
+class Element {{
+  constructor(id = "") {{ this.id = id; this.children = []; this.listeners = {{}}; this._text = ""; this.value = ""; this.dataset = {{}}; this.classList = {{ add() {{}} }}; }}
+  get textContent() {{ return this._text; }}
+  set textContent(value) {{ this._text = String(value); this.children = []; }}
+  appendChild(child) {{ this.children.push(child); return child; }}
+  append(...children) {{ children.forEach((child) => this.appendChild(child)); }}
+  addEventListener(name, handler) {{ (this.listeners[name] ||= []).push(handler); }}
+  trigger(name, event = {{}}) {{ for (const handler of this.listeners[name] || []) handler(event); }}
+  setAttribute() {{}}
+}}
+const elements = new Map();
+const byId = (id) => elements.get(id) || (elements.set(id, new Element(id)), elements.get(id));
+const document = {{
+  getElementById: byId,
+  createElement: () => new Element(),
+  createDocumentFragment: () => new Element(),
+  createTextNode: (text) => {{ const node = new Element(); node.textContent = text; return node; }},
+  querySelector: () => new Element(),
+}};
+const source = fs.readFileSync({json.dumps(str(WEB_DIR / "app.js"))}, "utf8")
+  .replace(/init\\(\\)\\.catch\\([\\s\\S]*$/, "")
+  + "\\nglobalThis.__app = {{ state, renderTable, bindFilterHandlers }};";
+const context = {{ document, Node: Element, window: {{ setTimeout: () => 0, clearTimeout: () => {{}} }}, console, URLSearchParams }};
+vm.runInNewContext(source, context);
+const {{ state, renderTable, bindFilterHandlers }} = context.__app;
+["table-head", "table-body", "result-count", "detail-content", "clear-filters", "filter-entity", "filter-period", "filter-family", "filter-source", "filter-confidence", "filter-confidence-value"].forEach(byId);
+state.datasets = [{{ id: "demo", rows: [
+  {{ entity: "CA", plan_period: "FY2024", metric_family: "funded", metric: "funded_ratio", value: 0.81, confidence: 0.92, provenance: {{ source_document: "calpers", evidence_refs: ["p1"] }} }},
+  {{ entity: "NY", plan_period: "FY2024", metric_family: "cash", metric: "contributions", value: 1500000000, confidence: 0.75, provenance: {{ source_document: "nycers", evidence_refs: ["p2"] }} }},
+] }}];
+state.selectedDatasetId = "demo";
+state.selectedRowIndex = null;
+state.config = {{ artifactBaseUrl: "https://artifacts.example.test" }};
+state.filters = {{ entity: "", period: "", family: "", source: "", minConfidence: 0 }};
+bindFilterHandlers();
+renderTable();
+const rows = byId("table-body").children;
+if (rows.length !== 2 || rows[0].children[4].textContent !== "81%" || rows[1].children[4].textContent !== "$1.5B") throw new Error("formatted table rows were not rendered");
+byId("filter-entity").value = "missing";
+byId("filter-entity").trigger("input");
+if (byId("result-count").textContent !== "Showing 0 of 2 records" || byId("table-body").children[0].children[0].textContent !== "No records match current filters.") throw new Error("filter empty state was not rendered");
+byId("clear-filters").trigger("click");
+if (byId("filter-entity").value !== "" || byId("result-count").textContent !== "2 records") throw new Error("clear filters did not restore the table");
+byId("table-body").children[0].trigger("click");
+const detail = byId("detail-content").children[0];
+if (state.selectedRowIndex !== 0 || !detail || detail.children.length === 0) throw new Error("row click did not render record details");
+"""
+    subprocess.run(["node", "-e", script], check=True, cwd=ROOT)
 
 
 def test_fixture_guard_refuses_generated_bundle(tmp_path: Path) -> None:

--- a/tests/web/test_workspace_contract.py
+++ b/tests/web/test_workspace_contract.py
@@ -286,7 +286,7 @@ def test_ui_has_issue_640_formatting_and_filter_feedback() -> None:
 
     assert "function formatCellValue(column, value, row)" in app
     assert "return `$${(n / 1e9).toFixed(1)}B`" in app
-    assert "metric.includes(\"ratio\")" in app
+    assert 'metric.includes("ratio")' in app
     assert "formatCellValue(column, row[column], row)" in app
     assert 'id="result-count"' in index
     assert "Showing ${rows.length} of ${totalRows} records" in app

--- a/tests/web/test_workspace_contract.py
+++ b/tests/web/test_workspace_contract.py
@@ -280,6 +280,38 @@ def test_ui_surfaces_fixture_origin_marker() -> None:
     assert "data_origin" in app
 
 
+def test_ui_has_issue_640_formatting_and_filter_feedback() -> None:
+    index = (WEB_DIR / "index.html").read_text(encoding="utf-8")
+    app = (WEB_DIR / "app.js").read_text(encoding="utf-8")
+
+    assert "function formatCellValue(column, value, row)" in app
+    assert "return `$${(n / 1e9).toFixed(1)}B`" in app
+    assert "metric.includes(\"ratio\")" in app
+    assert "formatCellValue(column, row[column], row)" in app
+    assert 'id="result-count"' in index
+    assert "Showing ${rows.length} of ${totalRows} records" in app
+    assert "No records match current filters." in app
+    assert 'id="clear-filters"' in index
+    assert 'getElementById("clear-filters").addEventListener("click"' in app
+
+
+def test_row_click_smoke_updates_record_details() -> None:
+    index = (WEB_DIR / "index.html").read_text(encoding="utf-8")
+    app = (WEB_DIR / "app.js").read_text(encoding="utf-8")
+
+    activate_row = app[app.index("const activateRow = (index) => {") :]
+    activate_row = activate_row[: activate_row.index("};") + 2]
+    render_detail = app[app.index("function renderDetail() {") :]
+    render_detail = render_detail[: render_detail.index("\n}") + 2]
+
+    assert 'id="detail-content"' in index
+    assert 'tr.addEventListener("click", () => activateRow(index));' in app
+    assert "state.selectedRowIndex = index;" in activate_row
+    assert "renderDetail();" in activate_row
+    assert 'document.getElementById("detail-content")' in render_detail
+    assert "rows[state.selectedRowIndex]" in render_detail
+
+
 def test_fixture_guard_refuses_generated_bundle(tmp_path: Path) -> None:
     base_dir = _copy_web_fixture(tmp_path)
     workspace_path = base_dir / "data" / "workspace.json"


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:640 -->
> **Source:** Issue #640

Closes #640

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Observed UX gaps in `apps/web` (rendered app + `ux_review.py` panel, overall median 6.0, all items corroborated 4/4):
1. **Raw unformatted numbers** in the Table Explorer VALUE column — `98100000000` for `actuarial_liability`, `0.81` for `funded_ratio`. No thousands separators, currency symbol, percent suffix, or per-column unit metadata.
2. **No empty-state / result counter** — filtering to high confidence empties the table with no "Showing N of M", no "no rows match", no one-click reset.
3. **API chip ≠ real server** — hero shows `http://localhost:8000/api` but `api/app.py` `DEFAULT_PORT = 8765` (`config/default.json` advertises 8000).
4. **No "connect live data" guidance** — the app honestly says "Demo data — not live" but never tells the operator how to load real data.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#394](https://github.com/stranske/Pension-Data/issues/394)
- [#484](https://github.com/stranske/Pension-Data/issues/484)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add per-column/per-metric formatting in `apps/web` for currency `$`/scale K/M/B, `%` for ratios, and thousands separators, driven from dataset/metric metadata; keep raw value available for export.
  - [ ] Define the metadata schema for column formatting rules including currency (verify: formatter passes)
  - [ ] Define the metadata schema for column formatting rules including scale (verify: formatter passes)
  - [ ] Define the metadata schema for column formatting rules including percentage (verify: formatter passes)
  - [ ] Define the metadata schema for column formatting rules including and separator specifications (verify: formatter passes)
  - [ ] Implement formatting utility functions that convert raw numeric values to display strings using metadata rules (verify: formatter passes)
  - [ ] _(2 further sub-tasks elided; split this issue)_
- [ ] Add "Showing N of M records", a zero-match empty-state in the table body, and a one-click "Reset filters" in `apps/web`.
  - [ ] Add a result counter component displaying the current filtered count (verify: confirm completion in repo) total record count (verify: confirm completion in repo)
  - [ ] Implement an empty-state component that renders in the table body when no records match filters (verify: confirm completion in repo)
  - [ ] Add a reset filters button that clears all active filters (verify: confirm completion in repo) restores the full dataset view (verify: confirm completion in repo)
- [ ] Update the API chip in `apps/web` to derive from the same source as `api/app.py` `DEFAULT_PORT`, or label it "example endpoint (demo)".
  - [ ] Determine whether the API chip should dynamically derive the port from configuration or use a static demo label (verify: config validated)
  - [ ] Implement the chosen solution to either source the port value or add explicit demo labeling to the API chip (verify: confirm completion in repo)
  - [ ] Update any related documentation to reflect the API endpoint display behavior (verify: docs updated)
- [ ] Add a config-lint test that `config/default.json` `apiBaseUrl` port matches `api/app.py` `DEFAULT_PORT`.
- [ ] Add an inline Zero-Install Mode callout explaining how to generate a bundle with `build_workspace_bundle.py` and load it.
- [ ] Extend `tests/web/test_workspace_contract.py` or add a formatting unit test and a config-port-parity test.
  - [ ] Add unit tests for the formatting utility functions covering currency, percentage, (verify: tests pass) scale transformations (verify: formatter passes)
  - [ ] Implement a config-port-parity test that validates the apiBaseUrl port matches the DEFAULT_PORT constant (verify: config validated)
  - [ ] Extend test_workspace_contract.py with assertions for the formatted value display contract (verify: formatter passes)
- [ ] Add a smoke test asserting the Record Details pane updates on row click.

#### Acceptance criteria
- [ ] `actuarial_liability` renders as e.g. `$98.1B` or `98,100,000,000`, and `funded_ratio` renders as `81%`.
- [ ] Filtering to no matches shows an empty-state and reset control, and a result counter is always visible.
- [ ] The displayed API endpoint matches the real server default or is explicitly labeled demo.
- [ ] A test fails if `config/default.json` `apiBaseUrl` uses a different port than `api/app.py` `DEFAULT_PORT`.
- [ ] The test suite includes `tests/web/test_workspace_contract.py` coverage or a formatting unit test, a config-port-parity test, and a smoke test for row click updating Record Details.

**Head SHA:** 451d6e7ff8d58d10a1b06ffaede8eea102b425b4
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165928643) |
| Claude Code Review (Opt-in) | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165677056) |
| Cross-Repo Smoke | ⏭️ skipped | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165677175) |
| Entity Regression Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165677033) |
| Extraction Golden Regression | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165677034) |
| Foundation Fixture E2E | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165677035) |
| Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165677176) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165677060) |
| NL-SQL Golden | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165677039) |
| One-PDF Pilot Golden | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165677041) |
| PostgreSQL Integration | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165677037) |
| Quality Replay Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165677047) |
| Quality SLA Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30165677042) |
<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added smoke tests for the packaged web app’s formatting and ratio handling, including filter count feedback and the “clear filters” control wiring.
  * Added coverage verifying row-click behavior updates selection state and renders the corresponding record details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->