### PR TITLE
Codex bootstrap for #645

### DIFF
--- a/.agents/issue-645-ledger.yml
+++ b/.agents/issue-645-ledger.yml
@@ -1,0 +1,322 @@
+version: 1
+issue: 645
+base: main
+branch: codex/issue-645
+tasks:
+  - id: task-01
+    title: Add a PPD API client in `sources/` or `ingest/` for `GET https://publicplansdata.org/api/?q=QVariables&variables=...&filterfystart=..&filterfyend=..&format=json`
+      and pull the codebook once from `https://publicplansdata.org/api/?q=gettemplate&template=data-codebook&format=csv...`.
+    status: doing
+    started_at: '2026-06-29T04:21:39Z'
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-02
+    title: 'Create a PPD API client module in sources/ or ingest/ with base HTTP request
+      handling (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-03
+    title: 'Create a PPD API client module in sources/ or ingest/ with error management
+      (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-04
+    title: 'Implement the QVariables endpoint method to fetch plan data with configurable
+      variables (verify: config validated)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-05
+    title: 'Implement the QVariables endpoint method to fetch plan data with fiscal
+      year filters (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-06
+    title: 'Implement the codebook endpoint method to fetch (verify: confirm completion
+      in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-07
+    title: 'parse the data dictionary CSV from the gettemplate API (verify: confirm
+      completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-08
+    title: Map PPD variables to existing `FundingTrendInput` and `AllocationPeerInput`
+      fields for funded ratio AVA & MVA, contributions, benefit payments, allocation
+      by class, and `peer_group`.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-09
+    title: 'Create mapping functions from PPD variables to FundingTrendInput fields
+      including funded ratio AVA (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-10
+    title: 'Create mapping functions from PPD variables to FundingTrendInput fields
+      including contributions (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-11
+    title: 'Create mapping functions from PPD variables to FundingTrendInput fields
+      including and benefit payments (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-12
+    title: 'Create mapping functions from PPD variables to AllocationPeerInput fields
+      for allocation by asset class percentages (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-13
+    title: 'Implement peer_group field mapping logic that extracts or derives cohort
+      classification from PPD data (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-14
+    title: Persist a peer-universe dataset keyed by `ppd_id` + fy and record provenance
+      with source=PPD, as_of, and url using the existing provenance layer.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-15
+    title: 'Implement persistence logic to store peer-universe records keyed by ppd_id
+      (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-16
+    title: 'fiscal year with appropriate indexing (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-17
+    title: 'Integrate the existing provenance layer to attach source, as_of timestamp,
+      (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-18
+    title: 'API URL metadata to each persisted record (verify: confirm completion
+      in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-19
+    title: Implement `peer_group` derivation for plan type, size, state, and maturity
+      so `allocation_peer_compare` has real cohorts.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-20
+    title: 'Implement plan type classification logic to categorize plans into defined
+      peer groups based on PPD plan_type field (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-21
+    title: 'Implement plan size classification using asset thresholds to create small,
+      medium, (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-22
+    title: 'large peer cohorts (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-23
+    title: 'Implement state-based peer grouping to enable geographic comparison cohorts
+      (verify: confirm completion in repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-24
+    title: 'Implement maturity classification using liability-to-asset or beneficiary
+      ratios to identify mature versus growing plans (verify: confirm completion in
+      repo)'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-25
+    title: Add cached on-disk responses so the ingestion is offline-reusable and avoids
+      repeated API calls.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-26
+    title: "Write `tests/sources/test_ppd_ingest.py` against a saved PPD API fixture\
+      \ asserting field mapping and \u2265N plans."
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-27
+    title: Test a deliberate mapped-variable rename in the fixture path so the mapping
+      test fails, then restore the correct mapping.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-28
+    title: "Running the client populates \u2265200 plans across multiple years into\
+      \ the peer dataset with cached offline-reusable data."
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-29
+    title: '`allocation_peer_compare` and `funding_trend` produce peer mean, median,
+      and delta for a chosen subject `ppd_id` without fixtures.'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-30
+    title: Every ingested row includes provenance with source=PPD, as_of, and url.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-31
+    title: Re-running a refresh with the same source data is idempotent.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-32
+    title: "`tests/sources/test_ppd_ingest.py` passes against a saved PPD API fixture\
+      \ and asserts field mapping plus \u2265N plans."
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-33
+    title: Renaming a mapped variable causes the mapping test to fail.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-34
+    title: 'Add a PPD API client (`sources/` or `ingest/`): `GET https://publicplansdata.org/api/?q=QVariables&variables=...&filterfystart=..&filterfyend=..&format=json`;
+      pull the codebook once for variable names.'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-35
+    title: "Map PPD variables \u2192 the existing `FundingTrendInput`/`AllocationPeerInput`\
+      \ fields (funded ratio AVA & MVA, contributions, benefit payments, allocation\
+      \ by class, peer_group) + the new metric fields from issue B."
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-36
+    title: Persist as a peer-universe dataset keyed by `ppd_id`+fy; record provenance
+      (source=PPD, as_of, url) using the existing provenance layer.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-37
+    title: A `peer_group` derivation (plan type/size/state/maturity) so `allocation_peer_compare`
+      has real cohorts.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-38
+    title: "Running the client populates \u2265200 plans \xD7 multiple years into\
+      \ the peer dataset, offline-reusable (cached)."
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-39
+    title: '`allocation_peer_compare` and `funding_trend` produce real peer mean/median/delta
+      for a chosen subject `ppd_id` (no fixtures).'
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []
+  - id: task-40
+    title: Every ingested row carries PPD provenance; a refresh is idempotent.
+    status: todo
+    started_at: null
+    finished_at: null
+    commit: ''
+    notes: []

--- a/.agents/issue-645-ledger.yml
+++ b/.agents/issue-645-ledger.yml
@@ -6,10 +6,10 @@ tasks:
   - id: task-01
     title: Add a PPD API client in `sources/` or `ingest/` for `GET https://publicplansdata.org/api/?q=QVariables&variables=...&filterfystart=..&filterfyend=..&format=json`
       and pull the codebook once from `https://publicplansdata.org/api/?q=gettemplate&template=data-codebook&format=csv...`.
-    status: doing
+    status: done
     started_at: '2026-06-29T04:21:39Z'
-    finished_at: null
-    commit: ''
+    finished_at: '2026-06-29T04:21:48Z'
+    commit: 29b7003eb1f5b36ba1ae58f99389b492b4769b97
     notes: []
   - id: task-02
     title: 'Create a PPD API client module in sources/ or ingest/ with base HTTP request

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,0 +1,16 @@
+{
+  "agent": "codex",
+  "cli_version": "0.125.0",
+  "emitted_at": "2026-07-25T23:02:28.280583Z",
+  "execution_profile": "codex-default",
+  "fallback_models": [
+    "gpt-5.4"
+  ],
+  "operation_role": "worker",
+  "pr_number": "778",
+  "requested_model": "gpt-5.5",
+  "runner": "reusable-codex-run",
+  "schema": "langsmith-fleet/v1",
+  "selected_model": "gpt-5.5",
+  "selection_reason": "input"
+}


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
To benchmark one plan we need a real peer universe. For US **public** plans the keystone is the **Public Plans Database (PPD)** — ~230 plans, FY2001-2023, ~95% of public-pension assets, 100+ variables, stable `ppd_id`, **free JSON/CSV/XML API (no key)**. The repo's `allocation_peer_compare`/`funding_trend` primitives already expect peer rows keyed by plan_id/plan_period/peer_group — they're just fed fixtures today. This issue feeds them real data. (Parent: #642.)

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#642](https://github.com/stranske/Pension-Data/issues/642)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add a PPD API client in `sources/` or `ingest/` for `GET https://publicplansdata.org/api/?q=QVariables&variables=...&filterfystart=..&filterfyend=..&format=json` and pull the codebook once from `https://publicplansdata.org/api/?q=gettemplate&template=data-codebook&format=csv...`.
  - [ ] Create a PPD API client module in sources/ or ingest/ with base HTTP request handling (verify: confirm completion in repo)
  - [ ] Create a PPD API client module in sources/ or ingest/ with error management (verify: confirm completion in repo)
  - [ ] Implement the QVariables endpoint method to fetch plan data with configurable variables (verify: config validated)
  - [ ] Implement the QVariables endpoint method to fetch plan data with fiscal year filters (verify: confirm completion in repo)
  - [ ] Implement the codebook endpoint method to fetch (verify: confirm completion in repo) parse the data dictionary CSV from the gettemplate API (verify: confirm completion in repo)
- [ ] Map PPD variables to existing `FundingTrendInput` and `AllocationPeerInput` fields for funded ratio AVA & MVA, contributions, benefit payments, allocation by class, and `peer_group`.
  - [ ] Create mapping functions from PPD variables to FundingTrendInput fields including funded ratio AVA (verify: confirm completion in repo)
  - [ ] Create mapping functions from PPD variables to FundingTrendInput fields including contributions (verify: confirm completion in repo)
  - [ ] Create mapping functions from PPD variables to FundingTrendInput fields including and benefit payments (verify: confirm completion in repo)
  - [ ] Create mapping functions from PPD variables to AllocationPeerInput fields for allocation by asset class percentages (verify: confirm completion in repo)
  - [ ] Implement peer_group field mapping logic that extracts or derives cohort classification from PPD data (verify: confirm completion in repo)
- [ ] Persist a peer-universe dataset keyed by `ppd_id` + fy and record provenance with source=PPD, as_of, and url using the existing provenance layer.
  - [ ] Implement persistence logic to store peer-universe records keyed by ppd_id (verify: confirm completion in repo) fiscal year with appropriate indexing (verify: confirm completion in repo)
  - [ ] Integrate the existing provenance layer to attach source, as_of timestamp, (verify: confirm completion in repo)
  - [ ] API URL metadata to each persisted record (verify: confirm completion in repo)
- [ ] Implement `peer_group` derivation for plan type, size, state, and maturity so `allocation_peer_compare` has real cohorts.
  - [ ] Implement plan type classification logic to categorize plans into defined peer groups based on PPD plan_type field (verify: confirm completion in repo)
  - [ ] Implement plan size classification using asset thresholds to create small, medium, (verify: confirm completion in repo) large peer cohorts (verify: confirm completion in repo)
  - [ ] Implement state-based peer grouping to enable geographic comparison cohorts (verify: confirm completion in repo)
  - [ ] Implement maturity classification using liability-to-asset or beneficiary ratios to identify mature versus growing plans (verify: confirm completion in repo)
- [ ] Add cached on-disk responses so the ingestion is offline-reusable and avoids repeated API calls.
- [ ] Write `tests/sources/test_ppd_ingest.py` against a saved PPD API fixture asserting field mapping and ≥N plans.
- [ ] Test a deliberate mapped-variable rename in the fixture path so the mapping test fails, then restore the correct mapping.

#### Acceptance criteria
- [ ] Running the client populates ≥200 plans across multiple years into the peer dataset with cached offline-reusable data.
- [ ] `allocation_peer_compare` and `funding_trend` produce peer mean, median, and delta for a chosen subject `ppd_id` without fixtures.
- [ ] Every ingested row includes provenance with source=PPD, as_of, and url.
- [ ] Re-running a refresh with the same source data is idempotent.
- [ ] `tests/sources/test_ppd_ingest.py` passes against a saved PPD API fixture and asserts field mapping plus ≥N plans.
- [ ] Renaming a mapped variable causes the mapping test to fail.

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why
To benchmark one plan we need a real peer universe. For US **public** plans the keystone is the **Public Plans Database (PPD)** — ~230 plans, FY2001-2023, ~95% of public-pension assets, 100+ variables, stable `ppd_id`, **free JSON/CSV/XML API (no key)**. The repo's `allocation_peer_compare`/`funding_trend` primitives already expect peer rows keyed by plan_id/plan_period/peer_group — they're just fed fixtures today. This issue feeds them real data. (Parent: #642.)

## Scope
A PPD ingestion client + a mapping into the existing analytics dataclasses/staging, with entity keying on `ppd_id`. Public track only (governmental plans don't file Form 5500).

## Non-Goals
No new analytics here (that's issue B) — this is data acquisition + mapping only. Do NOT build the private/corporate Form 5500 path in this issue (separate, only if needed). No scaffolding/placeholder modules; wire into existing `query/saved_views` inputs.

## Tasks
- [ ] Add a PPD API client in `sources/` or `ingest/` for `GET https://publicplansdata.org/api/?q=QVariables&variables=...&filterfystart=..&filterfyend=..&format=json` and pull the codebook once from `https://publicplansdata.org/api/?q=gettemplate&template=data-codebook&format=csv...`.
  - [ ] Create a PPD API client module in sources/ or ingest/ with base HTTP request handling (verify: confirm completion in repo)
  - [ ] Create a PPD API client module in sources/ or ingest/ with error management (verify: confirm completion in repo)
  - [ ] Implement the QVariables endpoint method to fetch plan data with configurable variables (verify: config validated)
  - [ ] Implement the QVariables endpoint method to fetch plan data with fiscal year filters (verify: confirm completion in repo)
  - [ ] Implement the codebook endpoint method to fetch (verify: confirm completion in repo)
  - [ ] parse the data dictionary CSV from the gettemplate API (verify: confirm completion in repo)
- [ ] Map PPD variables to existing `FundingTrendInput` and `AllocationPeerInput` fields for funded ratio AVA & MVA, contributions, benefit payments, allocation by class, and `peer_group`.
  - [ ] Create mapping functions from PPD variables to FundingTrendInput fields including funded ratio AVA (verify: confirm completion in repo)
  - [ ] Create mapping functions from PPD variables to FundingTrendInput fields including contributions (verify: confirm completion in repo)
  - [ ] Create mapping functions from PPD variables to FundingTrendInput fields including and benefit payments (verify: confirm completion in repo)
  - [ ] Create mapping functions from PPD variables to AllocationPeerInput fields for allocation by asset class percentages (verify: confirm completion in repo)
  - [ ] Implement peer_group field mapping logic that extracts or derives cohort classification from PPD data (verify: confirm completion in repo)
- [ ] Persist a peer-universe dataset keyed by `ppd_id` + fy and record provenance with source=PPD, as_of, and url using the existing provenance layer.
  - [ ] Implement persistence logic to store peer-universe records keyed by ppd_id (verify: confirm completion in repo)
  - [ ] fiscal year with appropriate indexing (verify: confirm completion in repo)
  - [ ] Integrate the existing provenance layer to attach source, as_of timestamp, (verify: confirm completion in repo)
  - [ ] API URL metadata to each persisted record (verify: confirm completion in repo)
- [ ] Implement `peer_group` derivation for plan type, size, state, and maturity so `allocation_peer_compare` has real cohorts.
  - [ ] Implement plan type classification logic to categorize plans into defined peer groups based on PPD plan_type field (verify: confirm completion in repo)
  - [ ] Implement plan size classification using asset thresholds to create small, medium, (verify: confirm completion in repo)
  - [ ] large peer cohorts (verify: confirm completion in repo)
  - [ ] Implement state-based peer grouping to enable geographic comparison cohorts (verify: confirm completion in repo)
  - [ ] Implement maturity classification using liability-to-asset or beneficiary ratios to identify mature versus growing plans (verify: confirm completion in repo)
- [ ] Add cached on-disk responses so the ingestion is offline-reusable and avoids repeated API calls.
- [ ] Write `tests/sources/test_ppd_ingest.py` against a saved PPD API fixture asserting field mapping and ≥N plans.
- [ ] Test a deliberate mapped-variable rename in the fixture path so the mapping test fails, then restore the correct mapping.

## Acceptance Criteria
- [ ] Running the client populates ≥200 plans across multiple years into the peer dataset with cached offline-reusable data.
- [ ] `allocation_peer_compare` and `funding_trend` produce peer mean, median, and delta for a chosen subject `ppd_id` without fixtures.
- [ ] Every ingested row includes provenance with source=PPD, as_of, and url.
- [ ] Re-running a refresh with the same source data is idempotent.
- [ ] `tests/sources/test_ppd_ingest.py` passes against a saved PPD API fixture and asserts field mapping plus ≥N plans.
- [ ] Renaming a mapped variable causes the mapping test to fail.

## Implementation Notes
Full source detail: `Code/Audits/Pension-Data/2026-06-28-R1-benchmarking-universe.md` §A.1; design `2026-06-28-ANALYTICS_DESIGN.md` §4-5. Codebook URL: `https://publicplansdata.org/api/?q=gettemplate&template=data-codebook&format=csv...`. Cache responses on disk (on-box, no repeated calls).

<details>
<summary>Original Issue</summary>

```text
## Why
To benchmark one plan we need a real peer universe. For US **public** plans the keystone is the **Public Plans Database (PPD)** — ~230 plans, FY2001-2023, ~95% of public-pension assets, 100+ variables, stable `ppd_id`, **free JSON/CSV/XML API (no key)**. The repo's `allocation_peer_compare`/`funding_trend` primitives already expect peer rows keyed by plan_id/plan_period/peer_group — they're just fed fixtures today. This issue feeds them real data. (Parent: #642.)

## Scope
A PPD ingestion client + a mapping into the existing analytics dataclasses/staging, with entity keying on `ppd_id`. Public track only (governmental plans don't file Form 5500).

## Non-Goals
- No new analytics here (that's issue B) — this is data acquisition + mapping only.
- Do NOT build the private/corporate Form 5500 path in this issue (separate, only if needed).
- No scaffolding/placeholder modules; wire into existing `query/saved_views` inputs.

## Tasks
- [ ] Add a PPD API client (`sources/` or `ingest/`): `GET https://publicplansdata.org/api/?q=QVariables&variables=...&filterfystart=..&filterfyend=..&format=json`; pull the codebook once for variable names.
- [ ] Map PPD variables → the existing `FundingTrendInput`/`AllocationPeerInput` fields (funded ratio AVA & MVA, contributions, benefit payments, allocation by class, peer_group) + the new metric fields from issue B.
- [ ] Persist as a peer-universe dataset keyed by `ppd_id`+fy; record provenance (source=PPD, as_of, url) using the existing provenance layer.
- [ ] A `peer_group` derivation (plan type/size/state/maturity) so `allocation_peer_compare` has real cohorts.

## Acceptance Criteria
- [ ] Running the client populates ≥200 plans × multiple years into the peer dataset, offline-reusable (cached).
- [ ] `allocation_peer_compare` and `funding_trend` produce real peer mean/median/delta for a chosen subject `ppd_id` (no fixtures).
- [ ] Every ingested row carries PPD provenance; a refresh is idempotent.

## Test gate
Gate: `tests/sources/test_ppd_ingest.py` against a saved PPD API fixture (recorded response) asserting field mapping + ≥N plans. Deliberate-break: rename a mapped variable → mapping test fails → revert.

## Implementation Notes
- Full source detail: `Code/Audits/Pension-Data/2026-06-28-R1-benchmarking-universe.md` §A.1; design `2026-06-28-ANALYTICS_DESIGN.md` §4-5.
- Codebook URL: `https://publicplansdata.org/api/?q=gettemplate&template=data-codebook&format=csv...`. Cache responses on disk (on-box, no repeated calls).
```
</details>

<!-- issue-pr-context:formatted-body:v1 {"sha256":"999a60ab1d298713fab685362df2d63c14720d10c3fa6d11ed8fef6c708f1f05","workflows":["agents-auto-pilot","agents-issue-optimizer","agents-63-issue-intake","issue_formatter","issue_optimizer"]} -->



</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
<!-- meta:issue:645 -->
> **Source:** Issue #645

Closes #645

<!-- pr-preamble:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added internal issue-tracking metadata for the PPD API client and data-ingestion workstream.
  * Added execution metadata for an automated worker run.

* **Documentation**
  * Recorded planned tasks and progress details for upcoming data integration, validation, and reporting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->