### PR TITLE
feat(ingest): security-level holdings collection — 13F + own-file + CAFR reconcile (#647)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,13 @@ disallow_untyped_defs = false
 module = ["baseline_kit", "baseline_kit.*", "stranske_pdf_extract", "stranske_pdf_extract.*"]
 ignore_missing_imports = true
 
+# openpyxl is an optional dep (the 'source_collection' extra) and ships no stubs;
+# the own-holdings XLS loader imports it lazily. Don't fail strict mypy when it's
+# absent (base install / CI test gate) or untyped (when the extra is installed).
+[[tool.mypy.overrides]]
+module = ["openpyxl", "openpyxl.*"]
+ignore_missing_imports = true
+
 [tool.black]
 line-length = 100
 target-version = ["py312"]

--- a/src/pension_data/extract/investment/__init__.py
+++ b/src/pension_data/extract/investment/__init__.py
@@ -22,15 +22,22 @@ from pension_data.extract.investment.risk_disclosures import (
     extract_risk_exposure_observations,
 )
 from pension_data.extract.investment.security_positions import (
+    Ab2833AltDisclosure,
+    Ab2833AltDisclosureInput,
     AcfrAllocationInput,
     SecurityPositionInput,
+    ab2833_to_security_positions,
     build_security_positions,
+    capture_ab2833_alt_disclosures,
     load_own_holdings_csv,
+    load_own_holdings_xls,
     parse_13f_information_table_xml,
     reconcile_holdings_to_acfr,
 )
 
 __all__ = [
+    "Ab2833AltDisclosure",
+    "Ab2833AltDisclosureInput",
     "AllocationDisclosureInput",
     "AcfrAllocationInput",
     "DerivativesDisclosureInput",
@@ -41,13 +48,16 @@ __all__ = [
     "RiskExtractionDiagnostic",
     "SecuritiesLendingDisclosureInput",
     "SecurityPositionInput",
+    "ab2833_to_security_positions",
     "build_manager_fund_positions",
     "build_security_positions",
+    "capture_ab2833_alt_disclosures",
     "extract_asset_allocations",
     "extract_fee_observations",
     "extract_risk_exposure_observations",
     "infer_lifecycle_events",
     "load_own_holdings_csv",
+    "load_own_holdings_xls",
     "parse_13f_information_table_xml",
     "reconcile_holdings_to_acfr",
 ]

--- a/src/pension_data/extract/investment/security_positions.py
+++ b/src/pension_data/extract/investment/security_positions.py
@@ -6,7 +6,9 @@ import csv
 import math
 from collections import defaultdict
 from dataclasses import dataclass
-from io import StringIO
+from io import BytesIO, StringIO
+from pathlib import Path
+from typing import Any
 
 from defusedxml import ElementTree  # type: ignore[import-untyped]
 
@@ -16,6 +18,7 @@ from pension_data.db.models.investment_positions import (
     SecurityDisclosureState,
     SecurityPositionSource,
 )
+from pension_data.finite_guards import finite_or_none
 
 _TOTAL_PLAN_COVERAGE_THRESHOLD = 0.95
 
@@ -133,6 +136,31 @@ def parse_13f_information_table_xml(
     return rows
 
 
+def _own_holdings_input_from_row(
+    row: dict[str, str | None],
+    *,
+    as_of: str,
+    provenance_ref: str,
+    default_asset_class: str,
+) -> SecurityPositionInput:
+    """Build one own-holdings input from a header-keyed row (CSV or spreadsheet)."""
+    security_name = row.get("security_name") or row.get("name")
+    ticker = row.get("ticker")
+    return SecurityPositionInput(
+        security_name=security_name.strip() if security_name else None,
+        cusip=_normalize_cusip(row.get("cusip")),
+        ticker=ticker.strip().upper() if ticker and ticker.strip() else None,
+        shares=_float_or_none(row.get("shares")),
+        market_value_usd=_float_or_none(row.get("market_value_usd")),
+        asset_class=(row.get("asset_class") or default_asset_class).strip().lower(),
+        source="own_holdings_file",
+        as_of=as_of,
+        provenance_ref=provenance_ref,
+        manager_name=(row.get("manager_name") or None),
+        fund_name=(row.get("fund_name") or None),
+    )
+
+
 def load_own_holdings_csv(
     csv_text: str,
     *,
@@ -142,27 +170,73 @@ def load_own_holdings_csv(
 ) -> list[SecurityPositionInput]:
     """Load a public own-holdings CSV export into normalized inputs."""
     reader = csv.DictReader(StringIO(csv_text))
-    rows: list[SecurityPositionInput] = []
-    for row in reader:
-        security_name = row.get("security_name") or row.get("name")
-        cusip = _normalize_cusip(row.get("cusip"))
-        ticker = row.get("ticker")
-        rows.append(
-            SecurityPositionInput(
-                security_name=security_name.strip() if security_name else None,
-                cusip=cusip,
-                ticker=ticker.strip().upper() if ticker and ticker.strip() else None,
-                shares=_float_or_none(row.get("shares")),
-                market_value_usd=_float_or_none(row.get("market_value_usd")),
-                asset_class=(row.get("asset_class") or default_asset_class).strip().lower(),
-                source="own_holdings_file",
-                as_of=as_of,
-                provenance_ref=provenance_ref,
-                manager_name=(row.get("manager_name") or None),
-                fund_name=(row.get("fund_name") or None),
-            )
+    return [
+        _own_holdings_input_from_row(
+            dict(row),
+            as_of=as_of,
+            provenance_ref=provenance_ref,
+            default_asset_class=default_asset_class,
         )
-    return rows
+        for row in reader
+    ]
+
+
+def load_own_holdings_xls(
+    source: str | Path | bytes,
+    *,
+    as_of: str,
+    provenance_ref: str,
+    default_asset_class: str = "unknown",
+    sheet_name: str | None = None,
+) -> list[SecurityPositionInput]:
+    """Load a public own-holdings ``.xlsx``/``.xls`` export into normalized inputs.
+
+    ``source`` may be a filesystem path or the raw workbook bytes. The first row
+    is treated as the header; header cells are matched case-insensitively against
+    the same column names as :func:`load_own_holdings_csv`
+    (``security_name``/``name``, ``cusip``, ``ticker``, ``shares``,
+    ``market_value_usd``, ``asset_class``, ``manager_name``, ``fund_name``).
+
+    ``openpyxl`` is an optional dependency (the ``source_collection`` extra); it is
+    imported lazily so the base install and CI test gate stay dependency-light.
+    """
+    try:
+        from openpyxl import load_workbook
+    except ModuleNotFoundError as exc:  # pragma: no cover - exercised via importorskip in tests
+        raise ModuleNotFoundError(
+            "load_own_holdings_xls requires openpyxl; install the 'source_collection' extra"
+        ) from exc
+
+    workbook_source: Any = BytesIO(source) if isinstance(source, bytes) else source
+    workbook = load_workbook(filename=workbook_source, read_only=True, data_only=True)
+    try:
+        worksheet = workbook[sheet_name] if sheet_name is not None else workbook.active
+        row_iter = worksheet.iter_rows(values_only=True)
+        try:
+            header_cells = next(row_iter)
+        except StopIteration:
+            return []
+        headers = [str(cell).strip().lower() if cell is not None else "" for cell in header_cells]
+        inputs: list[SecurityPositionInput] = []
+        for raw_row in row_iter:
+            if all(cell is None for cell in raw_row):
+                continue
+            row: dict[str, str | None] = {}
+            for header, cell in zip(headers, raw_row, strict=False):
+                if not header:
+                    continue
+                row[header] = None if cell is None else str(cell)
+            inputs.append(
+                _own_holdings_input_from_row(
+                    row,
+                    as_of=as_of,
+                    provenance_ref=provenance_ref,
+                    default_asset_class=default_asset_class,
+                )
+            )
+        return inputs
+    finally:
+        workbook.close()
 
 
 def build_security_positions(
@@ -275,3 +349,106 @@ def reconcile_holdings_to_acfr(
         },
         provenance_refs=provenance_refs,
     )
+
+
+@dataclass(frozen=True, slots=True)
+class Ab2833AltDisclosureInput:
+    """Raw AB 2833 alternative-investment fee/valuation disclosure row.
+
+    California AB 2833 (Gov. Code §7514.7) requires public pension plans to
+    publish, per alternative-investment vehicle, the plan's fair value plus the
+    management fees and carried interest borne. This captures that disclosure so
+    alts (which 13F never covers) can contribute to total-plan coverage.
+    """
+
+    fund_name: str
+    asset_class: str
+    reported_fair_value_usd: float | None
+    management_fees_usd: float | None
+    carried_interest_usd: float | None
+    as_of: str
+    provenance_ref: str
+    manager_name: str | None = None
+    explicit_not_disclosed: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class Ab2833AltDisclosure:
+    """Captured AB 2833 alts disclosure with summed fees and a disclosure state."""
+
+    fund_name: str
+    manager_name: str | None
+    asset_class: str
+    reported_fair_value_usd: float | None
+    management_fees_usd: float | None
+    carried_interest_usd: float | None
+    total_fees_usd: float | None
+    disclosure_state: SecurityDisclosureState
+    as_of: str
+    provenance_ref: str
+
+
+def capture_ab2833_alt_disclosures(
+    rows: list[Ab2833AltDisclosureInput],
+) -> list[Ab2833AltDisclosure]:
+    """Normalize AB 2833 alts disclosures, summing fees under finite guards.
+
+    Fees are summed only over finite components; a non-finite fee is dropped from
+    the total rather than poisoning it to NaN. A row with an explicit
+    non-disclosure flag or no fair value is marked ``not_disclosed``.
+    """
+    captured: list[Ab2833AltDisclosure] = []
+    for row in rows:
+        fair_value = finite_or_none(row.reported_fair_value_usd)
+        management_fees = finite_or_none(row.management_fees_usd)
+        carried_interest = finite_or_none(row.carried_interest_usd)
+        fee_components = [fee for fee in (management_fees, carried_interest) if fee is not None]
+        total_fees = round(sum(fee_components), 6) if fee_components else None
+        disclosure_state: SecurityDisclosureState = (
+            "not_disclosed" if row.explicit_not_disclosed or fair_value is None else "disclosed"
+        )
+        captured.append(
+            Ab2833AltDisclosure(
+                fund_name=row.fund_name.strip(),
+                manager_name=row.manager_name.strip() if row.manager_name else None,
+                asset_class=row.asset_class.strip().lower(),
+                reported_fair_value_usd=fair_value,
+                management_fees_usd=management_fees,
+                carried_interest_usd=carried_interest,
+                total_fees_usd=total_fees,
+                disclosure_state=disclosure_state,
+                as_of=row.as_of,
+                provenance_ref=row.provenance_ref,
+            )
+        )
+    return sorted(
+        captured,
+        key=lambda item: (item.asset_class, item.fund_name, item.provenance_ref),
+    )
+
+
+def ab2833_to_security_positions(
+    disclosures: list[Ab2833AltDisclosure],
+) -> list[SecurityPositionInput]:
+    """Convert captured AB 2833 alts disclosures into security-position inputs.
+
+    The vehicle's reported fair value becomes the position ``market_value_usd`` so
+    alts feed the same reconciliation and coverage math as 13F/own-file holdings.
+    """
+    return [
+        SecurityPositionInput(
+            security_name=disclosure.fund_name,
+            cusip=None,
+            ticker=None,
+            shares=None,
+            market_value_usd=disclosure.reported_fair_value_usd,
+            asset_class=disclosure.asset_class,
+            source="ab2833",
+            as_of=disclosure.as_of,
+            provenance_ref=disclosure.provenance_ref,
+            disclosure_state=disclosure.disclosure_state,
+            manager_name=disclosure.manager_name,
+            fund_name=disclosure.fund_name,
+        )
+        for disclosure in disclosures
+    ]

--- a/src/pension_data/query/saved_views/holdings_ingest.py
+++ b/src/pension_data/query/saved_views/holdings_ingest.py
@@ -1,0 +1,48 @@
+"""Adapt ingested security-level holdings into saved-view inputs (issue #647).
+
+This is the seam that lets the *real* ``execute_holdings_overlap_view`` run over
+collected 13F / own-file / AB 2833 positions instead of hand-built view fixtures.
+Two plans "overlap" on an instrument when both disclose a holding keyed by the
+same deterministic ``security_id`` (cusip -> ticker -> normalized name), so the
+overlap view's tri-state disclosure logic carries straight through from the
+ingested positions.
+"""
+
+from __future__ import annotations
+
+from pension_data.db.models.investment_positions import PlanSecurityPosition
+from pension_data.query.saved_views.models import DisclosureState, HoldingsOverlapInput
+
+_VALID_DISCLOSURE_STATES: frozenset[str] = frozenset(
+    {"disclosed", "not_disclosed", "known_not_invested"}
+)
+
+
+def to_holdings_overlap_inputs(
+    positions: list[PlanSecurityPosition],
+) -> list[HoldingsOverlapInput]:
+    """Map security-level positions onto holdings-overlap view inputs.
+
+    The instrument is projected onto the view's ``(manager_name, fund_name)`` key
+    as ``(issuer name, security_id)``: ``security_id`` is the deterministic
+    cusip/ticker/name identity produced by ``build_security_positions``, so the
+    same instrument held by two plans lands on the same overlap key.
+    """
+    rows: list[HoldingsOverlapInput] = []
+    for position in positions:
+        disclosure_state: DisclosureState = (
+            position.disclosure_state
+            if position.disclosure_state in _VALID_DISCLOSURE_STATES
+            else "not_disclosed"
+        )
+        rows.append(
+            HoldingsOverlapInput(
+                plan_id=position.plan_id,
+                plan_period=position.plan_period,
+                manager_name=position.security_name or position.security_id,
+                fund_name=position.security_id,
+                exposure_usd=position.market_value_usd,
+                disclosure_state=disclosure_state,
+            )
+        )
+    return rows

--- a/src/pension_data/sources/edgar/__init__.py
+++ b/src/pension_data/sources/edgar/__init__.py
@@ -1,0 +1,31 @@
+"""EDGAR 13F-HR ingestion source (public, on-box)."""
+
+from pension_data.sources.edgar.client import (
+    ARCHIVES_BASE_URL,
+    FORM_13F_HR,
+    FORM_13F_HR_AMENDMENT,
+    SUBMISSIONS_BASE_URL,
+    EdgarApiError,
+    EdgarClient,
+    Filing13F,
+    build_information_table_url,
+    build_submissions_url,
+    format_cik,
+    parse_13f_hr_filings,
+    select_latest_13f_hr,
+)
+
+__all__ = [
+    "ARCHIVES_BASE_URL",
+    "FORM_13F_HR",
+    "FORM_13F_HR_AMENDMENT",
+    "SUBMISSIONS_BASE_URL",
+    "EdgarApiError",
+    "EdgarClient",
+    "Filing13F",
+    "build_information_table_url",
+    "build_submissions_url",
+    "format_cik",
+    "parse_13f_hr_filings",
+    "select_latest_13f_hr",
+]

--- a/src/pension_data/sources/edgar/client.py
+++ b/src/pension_data/sources/edgar/client.py
@@ -1,0 +1,256 @@
+"""EDGAR 13F-HR fetch flow for security-level holdings collection (issue #647).
+
+The SEC's public EDGAR system exposes an institutional manager's filing history
+at ``https://data.sec.gov/submissions/CIK{10-digit}.json``. From that document we
+select the most recent ``13F-HR`` filing and construct the URL of its INFORMATION
+TABLE XML (the security-level holdings), which is parsed by
+:func:`pension_data.extract.investment.security_positions.parse_13f_information_table_xml`.
+
+The SEC **requires a descriptive ``User-Agent``** on every request (they return
+HTTP 403 without one). This client enforces that at construction.
+
+Network egress is sandboxed in CI and in this workspace, so no live call is made
+in tests: the URL builders and the submissions-JSON selector are the tested units,
+and the end-to-end flow is driven from **recorded-shape fixtures**
+(``tests/ingest/fixtures/``). The live ``_get`` path exists for the documented
+acceptance criterion on an unrestricted host and is excluded from coverage.
+
+Public EDGAR shapes referenced (documented at www.sec.gov/os/webmaster-faq#developers):
+
+    GET https://data.sec.gov/submissions/CIK{cik:010d}.json
+        -> {"filings": {"recent": {"form": [...], "accessionNumber": [...],
+                                    "reportDate": [...], "filingDate": [...],
+                                    "primaryDocument": [...]}}}
+    GET https://www.sec.gov/Archives/edgar/data/{cik}/{accession_no_dashes}/{document}
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+SUBMISSIONS_BASE_URL = "https://data.sec.gov/submissions/"
+ARCHIVES_BASE_URL = "https://www.sec.gov/Archives/edgar/data/"
+DEFAULT_TIMEOUT_SECONDS = 30.0
+FORM_13F_HR = "13F-HR"
+FORM_13F_HR_AMENDMENT = "13F-HR/A"
+
+
+class EdgarApiError(RuntimeError):
+    """Raised when an EDGAR request cannot be completed or a payload cannot be parsed."""
+
+
+@dataclass(frozen=True, slots=True)
+class Filing13F:
+    """A single 13F filing selected from an EDGAR submissions document."""
+
+    accession_number: str
+    form: str
+    filing_date: str
+    report_date: str
+    primary_document: str
+
+    @property
+    def is_amendment(self) -> bool:
+        """Whether this filing is a 13F-HR/A amendment (restatement) rather than an original."""
+        return self.form == FORM_13F_HR_AMENDMENT
+
+    @property
+    def accession_no_dashes(self) -> str:
+        """Accession number with dashes stripped, as used in the Archives path."""
+        return self.accession_number.replace("-", "")
+
+
+def format_cik(cik: str | int) -> str:
+    """Zero-pad a CIK to the 10-digit form EDGAR's submissions endpoint requires.
+
+    Accepts an int, a bare numeric string, or an already ``CIK``-prefixed string.
+    """
+    text = str(cik).strip().upper()
+    if text.startswith("CIK"):
+        text = text[3:]
+    digits = text.lstrip("0") or "0"
+    if not digits.isdigit():
+        raise EdgarApiError(f"CIK must be numeric, got {cik!r}")
+    if len(digits) > 10:
+        raise EdgarApiError(f"CIK {cik!r} exceeds 10 digits")
+    return digits.zfill(10)
+
+
+def build_submissions_url(cik: str | int, *, base_url: str = SUBMISSIONS_BASE_URL) -> str:
+    """Construct the submissions JSON URL for a CIK: ``.../CIK{10-digit}.json``."""
+    return f"{base_url}CIK{format_cik(cik)}.json"
+
+
+def build_information_table_url(
+    cik: str | int,
+    *,
+    accession_number: str,
+    document: str,
+    base_url: str = ARCHIVES_BASE_URL,
+) -> str:
+    """Construct the Archives URL of a filing's INFORMATION TABLE document.
+
+    EDGAR archives paths use the *unpadded* integer CIK and the accession number
+    with dashes stripped.
+    """
+    cik_int = int(format_cik(cik))
+    accession_no_dashes = accession_number.replace("-", "")
+    document = document.strip().lstrip("/")
+    if not document:
+        raise EdgarApiError("information table document name is required")
+    return f"{base_url}{cik_int}/{accession_no_dashes}/{document}"
+
+
+def _recent_filings_block(submissions_json: str) -> dict[str, list[object]]:
+    try:
+        payload = json.loads(submissions_json)
+    except json.JSONDecodeError as exc:
+        raise EdgarApiError(f"EDGAR submissions response was not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise EdgarApiError("EDGAR submissions response was not a JSON object")
+    filings = payload.get("filings")
+    if not isinstance(filings, dict):
+        raise EdgarApiError("EDGAR submissions payload has no 'filings' object")
+    recent = filings.get("recent")
+    if not isinstance(recent, dict):
+        raise EdgarApiError("EDGAR submissions payload has no 'filings.recent' object")
+    forms = recent.get("form")
+    if not isinstance(forms, list):
+        raise EdgarApiError("EDGAR submissions 'filings.recent.form' was not an array")
+    return {key: value for key, value in recent.items() if isinstance(value, list)}
+
+
+def parse_13f_hr_filings(
+    submissions_json: str, *, include_amendments: bool = True
+) -> list[Filing13F]:
+    """Extract all 13F-HR (and optionally 13F-HR/A) filings from a submissions payload.
+
+    Filings are returned newest-first, ordered by ``filingDate`` descending (ties
+    broken by accession number) so the first element is the latest filing.
+    """
+    recent = _recent_filings_block(submissions_json)
+    forms = recent["form"]
+    accessions = recent.get("accessionNumber", [])
+    filing_dates = recent.get("filingDate", [])
+    report_dates = recent.get("reportDate", [])
+    primary_docs = recent.get("primaryDocument", [])
+
+    wanted = {FORM_13F_HR, FORM_13F_HR_AMENDMENT} if include_amendments else {FORM_13F_HR}
+    filings: list[Filing13F] = []
+    for index, form in enumerate(forms):
+        if not isinstance(form, str) or form not in wanted:
+            continue
+
+        def _at(seq: Sequence[object], position: int = index) -> str:
+            if position < len(seq) and isinstance(seq[position], str):
+                return str(seq[position])
+            return ""
+
+        accession = _at(accessions)
+        if not accession:
+            raise EdgarApiError(
+                f"EDGAR 13F filing at index {index} is missing its accession number"
+            )
+        filings.append(
+            Filing13F(
+                accession_number=accession,
+                form=form,
+                filing_date=_at(filing_dates),
+                report_date=_at(report_dates),
+                primary_document=_at(primary_docs),
+            )
+        )
+    return sorted(
+        filings,
+        key=lambda filing: (filing.filing_date, filing.accession_number),
+        reverse=True,
+    )
+
+
+def select_latest_13f_hr(submissions_json: str, *, include_amendments: bool = True) -> Filing13F:
+    """Return the single most recent 13F-HR filing, or raise if the plan files none.
+
+    Some plans outsource all public-equity management and barely file 13F, so a
+    ``None`` here is a real "no equity sleeve on EDGAR" answer, not a bug -- callers
+    should surface it as ``known_not_invested``/``not_disclosed`` rather than an error.
+    """
+    filings = parse_13f_hr_filings(submissions_json, include_amendments=include_amendments)
+    if not filings:
+        raise EdgarApiError("EDGAR submissions payload contains no 13F-HR filings")
+    return filings[0]
+
+
+class EdgarClient:
+    """Thin EDGAR client over ``urllib`` that enforces the required ``User-Agent``.
+
+    Parameters
+    ----------
+    user_agent:
+        Descriptive contact string (SEC policy: "Sample Company Name
+        admin@example.com"). Required; EDGAR returns HTTP 403 without it.
+    timeout:
+        Per-request timeout in seconds. A finite timeout is mandatory so a hung
+        socket never stalls an ingest run.
+    """
+
+    def __init__(
+        self,
+        *,
+        user_agent: str,
+        submissions_base_url: str = SUBMISSIONS_BASE_URL,
+        archives_base_url: str = ARCHIVES_BASE_URL,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+        opener: urllib.request.OpenerDirector | None = None,
+    ) -> None:
+        if not user_agent or not user_agent.strip():
+            raise EdgarApiError("a descriptive User-Agent is required for EDGAR requests")
+        self.user_agent = user_agent.strip()
+        self.submissions_base_url = submissions_base_url
+        self.archives_base_url = archives_base_url
+        self.timeout = timeout
+        self._opener = opener or urllib.request.build_opener()
+
+    def _get(self, url: str) -> str:  # pragma: no cover - network path (egress sandboxed)
+        headers = {"User-Agent": self.user_agent, "Accept-Encoding": "gzip, deflate"}
+        request = urllib.request.Request(url, method="GET", headers=headers)
+        try:
+            with self._opener.open(request, timeout=self.timeout) as response:
+                status = getattr(response, "status", 200)
+                if status is not None and int(status) >= 400:
+                    raise EdgarApiError(f"EDGAR returned HTTP {status} for {url}")
+                charset = response.headers.get_content_charset() or "utf-8"
+                body: bytes = response.read()
+                return body.decode(charset)
+        except urllib.error.HTTPError as exc:
+            raise EdgarApiError(f"EDGAR HTTP error {exc.code} for {url}") from exc
+        except urllib.error.URLError as exc:
+            raise EdgarApiError(f"EDGAR request failed for {url}: {exc.reason}") from exc
+
+    def submissions_url(self, cik: str | int) -> str:
+        """Public URL builder mirroring :func:`build_submissions_url` with this base."""
+        return build_submissions_url(cik, base_url=self.submissions_base_url)
+
+    def information_table_url(self, cik: str | int, *, accession_number: str, document: str) -> str:
+        """Public URL builder mirroring :func:`build_information_table_url` with this base."""
+        return build_information_table_url(
+            cik,
+            accession_number=accession_number,
+            document=document,
+            base_url=self.archives_base_url,
+        )
+
+    def fetch_submissions_raw(self, cik: str | int) -> str:  # pragma: no cover - network path
+        """Fetch the raw submissions JSON body for a CIK."""
+        return self._get(self.submissions_url(cik))
+
+    def fetch_information_table_xml(
+        self, cik: str | int, *, accession_number: str, document: str
+    ) -> str:  # pragma: no cover - network path
+        """Fetch the raw INFORMATION TABLE XML body for a specific 13F filing document."""
+        return self._get(
+            self.information_table_url(cik, accession_number=accession_number, document=document)
+        )

--- a/tests/ingest/fixtures/edgar_13f_information_table.xml
+++ b/tests/ingest/fixtures/edgar_13f_information_table.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<informationTable xmlns="http://www.sec.gov/edgar/document/thirteenf/informationtable"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.sec.gov/edgar/document/thirteenf/informationtable">
+  <infoTable>
+    <nameOfIssuer>APPLE INC</nameOfIssuer>
+    <titleOfClass>COM</titleOfClass>
+    <cusip>037833100</cusip>
+    <value>1250</value>
+    <shrsOrPrnAmt>
+      <sshPrnamt>2500</sshPrnamt>
+      <sshPrnamtType>SH</sshPrnamtType>
+    </shrsOrPrnAmt>
+    <investmentDiscretion>SOLE</investmentDiscretion>
+    <votingAuthority>
+      <Sole>2500</Sole>
+      <Shared>0</Shared>
+      <None>0</None>
+    </votingAuthority>
+  </infoTable>
+  <infoTable>
+    <nameOfIssuer>MICROSOFT CORP</nameOfIssuer>
+    <titleOfClass>COM</titleOfClass>
+    <cusip>594918104</cusip>
+    <value>2750</value>
+    <shrsOrPrnAmt>
+      <sshPrnamt>3000</sshPrnamt>
+      <sshPrnamtType>SH</sshPrnamtType>
+    </shrsOrPrnAmt>
+    <investmentDiscretion>SOLE</investmentDiscretion>
+    <votingAuthority>
+      <Sole>3000</Sole>
+      <Shared>0</Shared>
+      <None>0</None>
+    </votingAuthority>
+  </infoTable>
+  <infoTable>
+    <nameOfIssuer>AMAZON COM INC</nameOfIssuer>
+    <titleOfClass>COM</titleOfClass>
+    <cusip>023135106</cusip>
+    <value>1500</value>
+    <shrsOrPrnAmt>
+      <sshPrnamt>800</sshPrnamt>
+      <sshPrnamtType>SH</sshPrnamtType>
+    </shrsOrPrnAmt>
+    <investmentDiscretion>SOLE</investmentDiscretion>
+    <votingAuthority>
+      <Sole>800</Sole>
+      <Shared>0</Shared>
+      <None>0</None>
+    </votingAuthority>
+  </infoTable>
+  <infoTable>
+    <nameOfIssuer>NVIDIA CORP</nameOfIssuer>
+    <titleOfClass>COM</titleOfClass>
+    <cusip>67066G104</cusip>
+    <value>4500</value>
+    <shrsOrPrnAmt>
+      <sshPrnamt>1200</sshPrnamt>
+      <sshPrnamtType>SH</sshPrnamtType>
+    </shrsOrPrnAmt>
+    <investmentDiscretion>SOLE</investmentDiscretion>
+    <votingAuthority>
+      <Sole>1200</Sole>
+      <Shared>0</Shared>
+      <None>0</None>
+    </votingAuthority>
+  </infoTable>
+</informationTable>

--- a/tests/ingest/fixtures/edgar_submissions_CIK0000919079.json
+++ b/tests/ingest/fixtures/edgar_submissions_CIK0000919079.json
@@ -1,0 +1,45 @@
+{
+  "cik": "919079",
+  "name": "CALIFORNIA PUBLIC EMPLOYEES RETIREMENT SYSTEM",
+  "tickers": [],
+  "filings": {
+    "recent": {
+      "accessionNumber": [
+        "0000919079-25-000042",
+        "0000919079-25-000019",
+        "0000919079-24-000088",
+        "0000919079-25-000007"
+      ],
+      "filingDate": [
+        "2025-05-15",
+        "2025-02-14",
+        "2024-11-14",
+        "2025-01-31"
+      ],
+      "reportDate": [
+        "2025-03-31",
+        "2024-12-31",
+        "2024-09-30",
+        "2024-12-31"
+      ],
+      "form": [
+        "13F-HR",
+        "13F-HR",
+        "13F-HR",
+        "NPORT-P"
+      ],
+      "primaryDocument": [
+        "primary_doc.xml",
+        "primary_doc.xml",
+        "primary_doc.xml",
+        "primary_doc.xml"
+      ],
+      "primaryDocDescription": [
+        "13F-HR",
+        "13F-HR",
+        "13F-HR",
+        "NPORT-P"
+      ]
+    }
+  }
+}

--- a/tests/ingest/test_13f_parse.py
+++ b/tests/ingest/test_13f_parse.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from pension_data.extract.investment.security_positions import (
@@ -11,6 +13,41 @@ from pension_data.extract.investment.security_positions import (
     parse_13f_information_table_xml,
     reconcile_holdings_to_acfr,
 )
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+INFO_TABLE_FIXTURE = FIXTURE_DIR / "edgar_13f_information_table.xml"
+
+# Recorded-shape EDGAR INFORMATION TABLE (egress sandboxed -> no live SEC call).
+# Four holdings, values reported in thousands: 1250 + 2750 + 1500 + 4500 = 10000
+# thousand USD -> 10,000,000 USD once scaled by the 13F thousands convention.
+EXPECTED_POSITION_COUNT = 4
+EXPECTED_MARKET_VALUE_SUM_USD = 10_000_000.0
+
+
+def test_saved_13f_information_table_fixture_count_and_market_value_sum() -> None:
+    inputs = parse_13f_information_table_xml(
+        INFO_TABLE_FIXTURE.read_text(encoding="utf-8"),
+        as_of="2025-03-31",
+        provenance_ref="edgar:calpers:0000919079:2025q1",
+    )
+    positions = build_security_positions(
+        plan_id="CA-PERS",
+        plan_period="FY2025",
+        rows=inputs,
+    )
+
+    assert len(positions) == EXPECTED_POSITION_COUNT
+    assert (
+        sum(position.market_value_usd or 0.0 for position in positions)
+        == EXPECTED_MARKET_VALUE_SUM_USD
+    )
+    assert {position.source for position in positions} == {"13f"}
+    assert {position.asset_class for position in positions} == {"public_equity"}
+    assert all(position.as_of == "2025-03-31" for position in positions)
+    assert all(
+        position.provenance_ref == "edgar:calpers:0000919079:2025q1" for position in positions
+    )
+
 
 NAMESPACED_13F_XML = """<?xml version="1.0" encoding="UTF-8"?>
 <informationTable xmlns="http://www.sec.gov/edgar/document/thirteenf/informationtable">

--- a/tests/ingest/test_edgar_flow.py
+++ b/tests/ingest/test_edgar_flow.py
@@ -1,0 +1,126 @@
+"""Tests for the EDGAR 13F-HR fetch flow (issue #647).
+
+Egress is sandboxed, so the network ``_get`` path is never exercised; the URL
+builders and the submissions-JSON selector are the tested units, and the
+end-to-end flow is driven from recorded-shape fixtures under ``fixtures/``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pension_data.extract.investment.security_positions import (
+    build_security_positions,
+    parse_13f_information_table_xml,
+)
+from pension_data.sources.edgar import (
+    EdgarApiError,
+    EdgarClient,
+    build_information_table_url,
+    build_submissions_url,
+    format_cik,
+    parse_13f_hr_filings,
+    select_latest_13f_hr,
+)
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+SUBMISSIONS_FIXTURE = FIXTURE_DIR / "edgar_submissions_CIK0000919079.json"
+INFO_TABLE_FIXTURE = FIXTURE_DIR / "edgar_13f_information_table.xml"
+
+CALPERS_CIK = "0000919079"
+
+
+def test_format_cik_zero_pads_to_ten_digits() -> None:
+    assert format_cik(919079) == "0000919079"
+    assert format_cik("919079") == "0000919079"
+    assert format_cik("0000919079") == "0000919079"
+    assert format_cik("CIK0000810265") == "0000810265"
+
+
+def test_format_cik_rejects_non_numeric_and_overlong() -> None:
+    with pytest.raises(EdgarApiError, match="numeric"):
+        format_cik("not-a-cik")
+    with pytest.raises(EdgarApiError, match="exceeds 10 digits"):
+        format_cik("123456789012")
+
+
+def test_build_submissions_url_uses_ten_digit_cik() -> None:
+    assert build_submissions_url(919079) == "https://data.sec.gov/submissions/CIK0000919079.json"
+
+
+def test_build_information_table_url_uses_unpadded_cik_and_stripped_accession() -> None:
+    url = build_information_table_url(
+        919079,
+        accession_number="0000919079-25-000042",
+        document="form13fInfoTable.xml",
+    )
+    assert url == (
+        "https://www.sec.gov/Archives/edgar/data/919079/" "000091907925000042/form13fInfoTable.xml"
+    )
+
+
+def test_information_table_url_requires_a_document() -> None:
+    with pytest.raises(EdgarApiError, match="document name is required"):
+        build_information_table_url(919079, accession_number="0000919079-25-000042", document="  ")
+
+
+def test_select_latest_13f_hr_from_saved_submissions() -> None:
+    submissions_json = SUBMISSIONS_FIXTURE.read_text(encoding="utf-8")
+    latest = select_latest_13f_hr(submissions_json)
+    # The NPORT-P filing must be ignored, and the newest 13F-HR wins by filingDate.
+    assert latest.form == "13F-HR"
+    assert latest.accession_number == "0000919079-25-000042"
+    assert latest.filing_date == "2025-05-15"
+    assert latest.report_date == "2025-03-31"
+
+    all_13f = parse_13f_hr_filings(submissions_json)
+    assert [filing.accession_number for filing in all_13f] == [
+        "0000919079-25-000042",
+        "0000919079-25-000019",
+        "0000919079-24-000088",
+    ]
+
+
+def test_select_latest_13f_hr_raises_when_plan_files_none() -> None:
+    # A plan that outsources equity management and files no 13F-HR.
+    with pytest.raises(EdgarApiError, match="no 13F-HR filings"):
+        select_latest_13f_hr('{"filings": {"recent": {"form": ["NPORT-P"]}}}')
+
+
+def test_edgar_client_requires_user_agent() -> None:
+    with pytest.raises(EdgarApiError, match="User-Agent is required"):
+        EdgarClient(user_agent="   ")
+
+
+def test_edgar_client_builds_flow_urls() -> None:
+    client = EdgarClient(user_agent="Pension-Data research tim@stranskemo.com")
+    assert (
+        client.submissions_url(CALPERS_CIK) == "https://data.sec.gov/submissions/CIK0000919079.json"
+    )
+    latest = select_latest_13f_hr(SUBMISSIONS_FIXTURE.read_text(encoding="utf-8"))
+    url = client.information_table_url(
+        CALPERS_CIK,
+        accession_number=latest.accession_number,
+        document="form13fInfoTable.xml",
+    )
+    assert url.endswith("/919079/000091907925000042/form13fInfoTable.xml")
+
+
+def test_end_to_end_fixture_flow_produces_security_positions() -> None:
+    # 1. submissions JSON -> latest 13F-HR selection
+    latest = select_latest_13f_hr(SUBMISSIONS_FIXTURE.read_text(encoding="utf-8"))
+    # 2. information table XML (would be fetched from the built URL on a live host)
+    provenance_ref = f"edgar:{CALPERS_CIK}:{latest.accession_number}"
+    inputs = parse_13f_information_table_xml(
+        INFO_TABLE_FIXTURE.read_text(encoding="utf-8"),
+        as_of=latest.report_date,
+        provenance_ref=provenance_ref,
+    )
+    positions = build_security_positions(plan_id="CA-PERS", plan_period="FY2025", rows=inputs)
+
+    assert len(positions) == 4
+    assert sum(position.market_value_usd or 0.0 for position in positions) == 10_000_000.0
+    assert all(position.as_of == "2025-03-31" for position in positions)
+    assert all(position.provenance_ref == provenance_ref for position in positions)

--- a/tests/ingest/test_holdings_pipeline.py
+++ b/tests/ingest/test_holdings_pipeline.py
@@ -1,0 +1,214 @@
+"""End-to-end holdings pipeline: own-file XLS, AB 2833 alts, and overlap view (#647).
+
+Covers the pieces that surround 13F parsing:
+- the own-holdings XLS loader (openpyxl optional dep -> importorskip);
+- AB 2833 alts capture feeding total-plan coverage beyond the equity sleeve;
+- the *real* ``execute_holdings_overlap_view`` run over ingested security-level
+  positions (not hand-built view fixtures).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pension_data.extract.investment.security_positions import (
+    Ab2833AltDisclosureInput,
+    AcfrAllocationInput,
+    SecurityPositionInput,
+    ab2833_to_security_positions,
+    build_security_positions,
+    capture_ab2833_alt_disclosures,
+    load_own_holdings_xls,
+    reconcile_holdings_to_acfr,
+)
+from pension_data.query.saved_views.holdings_ingest import to_holdings_overlap_inputs
+from pension_data.query.saved_views.service import execute_holdings_overlap_view
+
+
+def _write_workbook(path: Path) -> None:
+    openpyxl = pytest.importorskip("openpyxl")
+    workbook = openpyxl.Workbook()
+    worksheet = workbook.active
+    worksheet.append(
+        ["security_name", "cusip", "ticker", "shares", "market_value_usd", "asset_class"]
+    )
+    worksheet.append(["Apple Inc", "037833100", "AAPL", 100, 2_500_000, "public_equity"])
+    worksheet.append(["US Treasury 10Y", "91282CJL6", None, 50, 1_500_000, "fixed_income"])
+    worksheet.append([None, None, None, None, None, None])  # trailing blank row
+    workbook.save(path)
+
+
+def test_load_own_holdings_xls_from_path(tmp_path: Path) -> None:
+    pytest.importorskip("openpyxl")
+    workbook_path = tmp_path / "calpers_holdings.xlsx"
+    _write_workbook(workbook_path)
+
+    inputs = load_own_holdings_xls(
+        workbook_path,
+        as_of="2025-06-30",
+        provenance_ref="calpers:own-holdings:fy2025",
+    )
+
+    assert len(inputs) == 2
+    assert [row.cusip for row in inputs] == ["037833100", "91282CJL6"]
+    assert inputs[0].ticker == "AAPL"
+    assert inputs[0].market_value_usd == 2_500_000.0
+    assert inputs[1].asset_class == "fixed_income"
+    assert {row.source for row in inputs} == {"own_holdings_file"}
+
+
+def test_load_own_holdings_xls_from_bytes(tmp_path: Path) -> None:
+    pytest.importorskip("openpyxl")
+    workbook_path = tmp_path / "calpers_holdings.xlsx"
+    _write_workbook(workbook_path)
+
+    inputs = load_own_holdings_xls(
+        workbook_path.read_bytes(),
+        as_of="2025-06-30",
+        provenance_ref="calpers:own-holdings:fy2025",
+    )
+    assert len(inputs) == 2
+    assert inputs[0].security_name == "Apple Inc"
+
+
+def test_ab2833_alts_capture_feeds_total_plan_coverage() -> None:
+    disclosures = capture_ab2833_alt_disclosures(
+        [
+            Ab2833AltDisclosureInput(
+                fund_name="Blackstone Capital Partners VIII",
+                asset_class="private_equity",
+                reported_fair_value_usd=3_000_000.0,
+                management_fees_usd=45_000.0,
+                carried_interest_usd=120_000.0,
+                as_of="2025-06-30",
+                provenance_ref="ab2833:calpers:fy2025:pe",
+                manager_name="Blackstone",
+            ),
+            Ab2833AltDisclosureInput(
+                fund_name="Brookfield Infrastructure IV",
+                asset_class="real_assets",
+                reported_fair_value_usd=2_000_000.0,
+                management_fees_usd=30_000.0,
+                carried_interest_usd=None,
+                as_of="2025-06-30",
+                provenance_ref="ab2833:calpers:fy2025:ra",
+                manager_name="Brookfield",
+            ),
+        ]
+    )
+
+    # Fees are summed under finite guards; the PE fund carries mgmt + carry.
+    pe_disclosure = next(d for d in disclosures if d.asset_class == "private_equity")
+    assert pe_disclosure.total_fees_usd == 165_000.0
+    assert pe_disclosure.disclosure_state == "disclosed"
+
+    alt_inputs = ab2833_to_security_positions(disclosures)
+    equity_input = SecurityPositionInput(
+        security_name="APPLE INC",
+        cusip="037833100",
+        ticker=None,
+        shares=1000.0,
+        market_value_usd=5_000_000.0,
+        asset_class="public_equity",
+        source="13f",
+        as_of="2025-03-31",
+        provenance_ref="edgar:calpers:2025q1",
+    )
+    positions = build_security_positions(
+        plan_id="CA-PERS",
+        plan_period="FY2025",
+        rows=[equity_input, *alt_inputs],
+    )
+
+    report = reconcile_holdings_to_acfr(
+        plan_id="CA-PERS",
+        plan_period="FY2025",
+        positions=positions,
+        total_plan_assets_usd=40_000_000.0,
+        acfr_allocations=[
+            AcfrAllocationInput("public_equity", 20_000_000.0, "acfr:eq"),
+            AcfrAllocationInput("private_equity", 6_000_000.0, "acfr:pe"),
+            AcfrAllocationInput("real_assets", 4_000_000.0, "acfr:ra"),
+            AcfrAllocationInput("fixed_income", 10_000_000.0, "acfr:fi"),
+        ],
+    )
+
+    # Collected = 5M equity + 3M PE + 2M real assets = 10M of a 40M plan.
+    assert report.collected_market_value_usd == 10_000_000.0
+    assert report.coverage_ratio == 0.25
+    assert report.scope_label == "equity-sleeve"
+    # AB 2833 lets alts (which 13F never covers) contribute to coverage.
+    assert report.by_asset_class["private_equity"] == 0.5
+    assert report.by_asset_class["real_assets"] == 0.5
+    assert report.by_asset_class["fixed_income"] == 0.0
+
+
+def test_holdings_overlap_view_runs_over_ingested_security_positions() -> None:
+    # Two plans both disclose the same CUSIP -> the real overlap view must pair them.
+    subject = build_security_positions(
+        plan_id="CA-PERS",
+        plan_period="FY2025",
+        rows=[
+            SecurityPositionInput(
+                security_name="APPLE INC",
+                cusip="037833100",
+                ticker=None,
+                shares=2500.0,
+                market_value_usd=1_250_000.0,
+                asset_class="public_equity",
+                source="13f",
+                as_of="2025-03-31",
+                provenance_ref="edgar:ca",
+            ),
+            SecurityPositionInput(
+                security_name="NVIDIA CORP",
+                cusip="67066G104",
+                ticker=None,
+                shares=1200.0,
+                market_value_usd=4_500_000.0,
+                asset_class="public_equity",
+                source="13f",
+                as_of="2025-03-31",
+                provenance_ref="edgar:ca",
+            ),
+        ],
+    )
+    counterparty = build_security_positions(
+        plan_id="NY-CRF",
+        plan_period="FY2025",
+        rows=[
+            SecurityPositionInput(
+                security_name="APPLE INC",
+                cusip="037833100",
+                ticker=None,
+                shares=1000.0,
+                market_value_usd=900_000.0,
+                asset_class="public_equity",
+                source="13f",
+                as_of="2025-03-31",
+                provenance_ref="edgar:ny",
+            )
+        ],
+    )
+
+    overlap_inputs = to_holdings_overlap_inputs([*subject, *counterparty])
+    rows = execute_holdings_overlap_view(
+        overlap_inputs,
+        subject_plan_id="CA-PERS",
+        plan_period="FY2025",
+    )
+
+    apple_rows = [row for row in rows if row.fund_name == "cusip:037833100"]
+    assert len(apple_rows) == 1
+    apple = apple_rows[0]
+    assert apple.subject_plan_id == "CA-PERS"
+    assert apple.counterparty_plan_id == "NY-CRF"
+    assert apple.overlap_status == "overlap"
+    assert apple.overlap_usd == 900_000.0  # min(1,250,000, 900,000)
+
+    # NVIDIA is held only by the subject -> counterparty non-disclosure, no overlap.
+    nvidia_rows = [row for row in rows if row.fund_name == "cusip:67066G104"]
+    assert len(nvidia_rows) == 1
+    assert nvidia_rows[0].overlap_status == "unknown_due_to_non_disclosure"


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:647 -->
> **Source:** Issue #647

Closes #647

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
To analyze a specific plan's actual portfolio we need real holdings. No single SEC filing is complete — 13F is an **equity-only sleeve (~25-46% of a plan)**, so total-plan figures must be **CAFR-anchored**. The richest source is usually the plan's **own published holdings file** (CalSTRS gold standard). The repo's `manager_fund_positions` already models positions with a `disclosed/not_disclosed/known_not_invested` tri-state — extend it down to security level. (Parent: #642; pairs with #D.)

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#642](https://github.com/stranske/Pension-Data/issues/642)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add a security-level positions table/dataclass beneath `manager_fund_positions`: cusip/ticker, name, shares, market_value, asset_class, source, as_of, `disclosure_state`, provenance ref.
- [ ] **13F ingestion** via EDGAR `https://data.sec.gov/submissions/CIK{10-digit}.json` → latest `13F-HR` → parse the INFORMATION TABLE XML (User-Agent header required). Verify the target plan's CIK (e.g. CalPERS 0000919079, NY Common 0000810265, Texas TRS 0000796848) — confirm per plan, some outsource and barely file.
- [ ] **Own-holdings-file** loader (CSV/XLS) when the plan publishes one (primary source, highest coverage).
- [ ] **ACFR allocation** capture (authoritative total-plan asset-class weights) as the anchor; **AB 2833**-style fee/alts disclosure capture where available.
- [ ] **Reconciliation**: compute and store the coverage gap (Σ holdings market_value vs CAFR total assets) and label each analysis's scope (equity-sleeve vs total-plan).

#### Acceptance criteria
- [ ] For one target plan, the pipeline produces security-level equity positions (13F) + asset-class totals (CAFR), with provenance and as_of on every row.
- [ ] A coverage report states what % of total plan assets the collected holdings represent, by asset class.
- [ ] `holdings_overlap` runs against the real security-level data.

**Head SHA:** 7019a426e34835852c7e867031d103eaee7a9669
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Pension-Data/actions/runs/30180201955) |
| Backplane Conformance | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30180166099) |
| Cross-Repo Smoke | ⏭️ skipped | [View run](https://github.com/stranske/Pension-Data/actions/runs/30180166096) |
| Entity Regression Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30180166042) |
| Extraction Golden Regression | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30180166040) |
| Foundation Fixture E2E | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30180166037) |
| Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30180166110) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30180166064) |
| NL-SQL Golden | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30180166038) |
| One-PDF Pilot Golden | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30180166065) |
| PostgreSQL Integration | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30180166036) |
| Quality Replay Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30180166124) |
| Quality SLA Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30180166044) |
<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added EDGAR 13F-HR filing retrieval and parsing.
  * Added Excel holdings import from files or raw workbook data.
  * Added AB 2833 alternative-investment disclosure capture and reconciliation.
  * Added holdings-overlap view support for ingested positions.

* **Bug Fixes**
  * Improved handling of missing, invalid, and non-finite disclosure and valuation data.

* **Tests**
  * Added end-to-end coverage for EDGAR ingestion, Excel imports, alternative investments, and holdings overlap reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->