### PR TITLE
feat(quant): holdings analytics — drift/stress/overlap/concentration/fees (#648)

### DIFF
--- a/src/pension_data/quant/holdings_analytics.py
+++ b/src/pension_data/quant/holdings_analytics.py
@@ -1,0 +1,947 @@
+"""Holdings analytics layer (issue #648).
+
+Turns collected security-level holdings (#647) into decision-useful portfolio
+analysis for a single plan-period: allocation-vs-policy drift, funded-status
+stress, fee/cost-effectiveness, manager overlap / active share, look-through
+concentration & factor tilts, and (where data allows) liquidity & Brinson
+attribution.
+
+Design contract — the #1 rule (R3 guardrail)
+--------------------------------------------
+Every analytic output carries an explicit :data:`ScopeLabel`:
+
+* ``"total-plan"`` — CAFR/ACFR-anchored, covers the whole plan.
+* ``"equity-sleeve"`` — 13F-only public-equity slice (~25-46% of a typical plan).
+
+A 13F-equity-sleeve number is **never** presented as total-plan. Total-plan
+figures must be anchored to the CAFR/ACFR coverage report
+(:class:`~pension_data.db.models.investment_positions.HoldingsCoverageReport`
+from #647). Concentration, active share, and factor tilts are intrinsically
+equity-sleeve; drift, funded-status, and fees are total-plan only when their
+inputs are CAFR-anchored, and are otherwise downgraded to equity-sleeve.
+
+Reuse (do not reimplement)
+--------------------------
+* Funded-status stress routes through
+  :func:`pension_data.quant.scenarios.run_deterministic_scenario`.
+* The peer leg of allocation-vs-policy reuses
+  :func:`pension_data.query.saved_views.service.execute_allocation_peer_compare_view`.
+* Security-level overlap extends the ``holdings_overlap`` min-exposure seam.
+* Every numeric boundary is guarded by :mod:`pension_data.finite_guards`.
+* Provenance is normalized via
+  :func:`pension_data.quant.contracts.normalize_provenance_refs`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Literal
+
+from pension_data.db.models.investment_positions import (
+    HoldingsCoverageReport,
+    PlanSecurityPosition,
+)
+from pension_data.finite_guards import is_finite_number, require_finite
+from pension_data.quant.contracts import normalize_provenance_refs
+from pension_data.quant.scenarios import (
+    ScenarioInput,
+    ScenarioResult,
+    ScenarioRunConfig,
+    run_deterministic_scenario,
+)
+from pension_data.query.saved_views.models import AllocationPeerInput, AllocationPeerRow
+from pension_data.query.saved_views.service import execute_allocation_peer_compare_view
+
+__all__ = [
+    "ScopeLabel",
+    "CremersBand",
+    "AllocationDriftRow",
+    "AllocationDriftReport",
+    "FundedStatusStressResult",
+    "FeeEffectivenessReport",
+    "SecurityOverlapRow",
+    "ActiveShareReport",
+    "ConcentrationReport",
+    "FactorTiltReport",
+    "LiquidityReport",
+    "BrinsonAttributionReport",
+    "DEFAULT_ALTERNATIVES",
+    "DEFAULT_FEE_ANCHOR_BPS",
+    "coverage_scope_label",
+    "positions_to_weights",
+    "compute_allocation_drift",
+    "run_funded_status_equity_shock",
+    "run_funded_status_combined_shock",
+    "compute_fee_effectiveness",
+    "compute_security_overlap",
+    "compute_active_share",
+    "compute_concentration",
+    "compute_factor_tilts",
+    "compute_liquidity",
+    "compute_brinson_attribution",
+]
+
+ScopeLabel = Literal["total-plan", "equity-sleeve"]
+CremersBand = Literal[
+    "closet-indexer",
+    "moderately-active",
+    "highly-active",
+    "very-highly-active",
+]
+
+DEFAULT_FEE_ANCHOR_BPS = 40.0
+"""Cost-effectiveness anchor: a passive-ish ~40 bps all-in investment expense."""
+
+DEFAULT_ALTERNATIVES: frozenset[str] = frozenset(
+    {
+        "alternatives",
+        "commodities",
+        "hedge_funds",
+        "infrastructure",
+        "opportunistic",
+        "private_credit",
+        "private_debt",
+        "private_equity",
+        "real_assets",
+        "real_estate",
+    }
+)
+"""Asset-class names treated as alternatives for over/underweight rollup."""
+
+
+# ---------------------------------------------------------------------------
+# Scope / weight helpers (shared plumbing)
+# ---------------------------------------------------------------------------
+def coverage_scope_label(coverage: HoldingsCoverageReport) -> ScopeLabel:
+    """Return the CAFR-anchored scope label from a #647 coverage report.
+
+    Reuses the coverage report's own threshold decision so the analytics layer
+    and the ingestion layer agree byte-for-byte on what counts as total-plan.
+    """
+    return "total-plan" if coverage.scope_label == "total-plan" else "equity-sleeve"
+
+
+def _normalized_class(name: str) -> str:
+    return "_".join(name.strip().lower().split())
+
+
+def positions_to_weights(
+    positions: Iterable[PlanSecurityPosition],
+) -> dict[str, float]:
+    """Collapse disclosed security positions into ``security_id -> weight``.
+
+    Only ``disclosed`` positions with a finite, positive market value contribute.
+    Weights are normalized to sum to 1 over the disclosed, finite universe. An
+    empty or all-non-finite universe yields an empty mapping (no fabrication).
+    """
+    market_values: dict[str, float] = {}
+    for position in positions:
+        if not position.is_disclosed:
+            continue
+        value = position.market_value_usd
+        if not is_finite_number(value) or value is None or value <= 0.0:
+            continue
+        market_values[position.security_id] = market_values.get(position.security_id, 0.0) + float(
+            value
+        )
+    total = sum(market_values.values())
+    if total <= 0.0 or not is_finite_number(total):
+        return {}
+    return {security_id: value / total for security_id, value in market_values.items()}
+
+
+def _weighted_gross_abs(deltas: Iterable[float]) -> float:
+    return sum(abs(delta) for delta in deltas)
+
+
+# ---------------------------------------------------------------------------
+# Task 1 — Allocation vs policy & peers
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True, slots=True)
+class AllocationDriftRow:
+    """Per-asset-class active weight (actual minus policy target)."""
+
+    asset_class: str
+    actual_weight: float
+    target_weight: float
+    active_weight: float
+    is_alternative: bool
+
+
+@dataclass(frozen=True, slots=True)
+class AllocationDriftReport:
+    """Allocation-vs-policy drift with optional peer positioning."""
+
+    plan_id: str
+    plan_period: str
+    scope_label: ScopeLabel
+    drift: float
+    rows: tuple[AllocationDriftRow, ...]
+    alternatives_active_weight: float
+    peer_rows: tuple[AllocationPeerRow, ...]
+    provenance_refs: tuple[str, ...]
+
+
+def compute_allocation_drift(
+    *,
+    plan_id: str,
+    plan_period: str,
+    actual_weights: Mapping[str, float],
+    target_weights: Mapping[str, float],
+    scope_label: ScopeLabel,
+    provenance_refs: Sequence[str],
+    alternatives: Iterable[str] = DEFAULT_ALTERNATIVES,
+    peer_rows: Sequence[AllocationPeerInput] = (),
+    alternatives_normalizer: bool = True,
+) -> AllocationDriftReport:
+    """Compute allocation drift ``= ½·Σ|actualᵢ − targetᵢ|`` across asset classes.
+
+    ``actual_weights`` and ``target_weights`` are asset-class → weight fractions.
+    Missing classes on either side are treated as a zero weight, so a class held
+    but not targeted (or targeted but not held) still contributes to drift. The
+    peer leg reuses
+    :func:`~pension_data.query.saved_views.service.execute_allocation_peer_compare_view`.
+
+    ``scope_label`` is the caller's responsibility: pass ``"total-plan"`` only when
+    the weights are CAFR-anchored asset-allocation percentages.
+    """
+    alt_set = (
+        {_normalized_class(name) for name in alternatives}
+        if alternatives_normalizer
+        else set(alternatives)
+    )
+    classes = sorted(
+        {_normalized_class(name) for name in actual_weights}
+        | {_normalized_class(name) for name in target_weights}
+    )
+    actual_norm = {
+        _normalized_class(k): require_finite(v, field=f"actual_weights[{k!r}]")
+        for k, v in actual_weights.items()
+    }
+    target_norm = {
+        _normalized_class(k): require_finite(v, field=f"target_weights[{k!r}]")
+        for k, v in target_weights.items()
+    }
+
+    rows: list[AllocationDriftRow] = []
+    for asset_class in classes:
+        actual = actual_norm.get(asset_class, 0.0)
+        target = target_norm.get(asset_class, 0.0)
+        active = actual - target
+        rows.append(
+            AllocationDriftRow(
+                asset_class=asset_class,
+                actual_weight=round(actual, 6),
+                target_weight=round(target, 6),
+                active_weight=round(active, 6),
+                is_alternative=asset_class in alt_set,
+            )
+        )
+
+    drift = round(0.5 * _weighted_gross_abs(row.active_weight for row in rows), 6)
+    alternatives_active = round(sum(row.active_weight for row in rows if row.is_alternative), 6)
+
+    peer_out: tuple[AllocationPeerRow, ...] = ()
+    if peer_rows:
+        peer_out = tuple(
+            execute_allocation_peer_compare_view(
+                list(peer_rows), subject_plan_id=plan_id, plan_period=plan_period
+            )
+        )
+
+    return AllocationDriftReport(
+        plan_id=plan_id,
+        plan_period=plan_period,
+        scope_label=scope_label,
+        drift=drift,
+        rows=tuple(rows),
+        alternatives_active_weight=alternatives_active,
+        peer_rows=peer_out,
+        provenance_refs=normalize_provenance_refs(provenance_refs),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 2 — Funded-status stress (routed through quant/scenarios.py)
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True, slots=True)
+class FundedStatusStressResult:
+    """Funded-status impact of an equity (and optional discount-rate) shock.
+
+    ``scope_label`` is ``"total-plan"`` only when the equity market value used to
+    size the shock is itself CAFR total-plan equity. A 13F-equity-sleeve equity
+    basis under-sizes the shock, so the result is downgraded to ``"equity-sleeve"``
+    (a partial/floor impact), never presented as total-plan.
+    """
+
+    plan_id: str
+    plan_period: str
+    scope_label: ScopeLabel
+    equity_shock_pct: float
+    discount_rate_shock: float | None
+    baseline_funded_ratio: float
+    shocked_funded_ratio: float
+    funded_ratio_delta: float
+    asset_delta_usd: float
+    liability_delta_usd: float
+    baseline_uaal_usd: float
+    shocked_uaal_usd: float
+    equity_basis_scope: ScopeLabel
+    scenario: ScenarioResult
+    provenance_refs: tuple[str, ...]
+
+
+def _funded_status_stress(
+    *,
+    plan_id: str,
+    plan_period: str,
+    total_assets_usd: float,
+    liabilities_usd: float,
+    equity_market_value_usd: float,
+    equity_basis_scope: ScopeLabel,
+    equity_shock_pct: float,
+    discount_rate_shock: float | None,
+    liability_duration_years: float | None,
+    module_version: str,
+    source_snapshot_id: str,
+    provenance_refs: Sequence[str],
+    scenario_name: str,
+) -> FundedStatusStressResult:
+    total_assets_usd = require_finite(total_assets_usd, field="total_assets_usd")
+    liabilities_usd = require_finite(liabilities_usd, field="liabilities_usd")
+    equity_market_value_usd = require_finite(
+        equity_market_value_usd, field="equity_market_value_usd"
+    )
+    equity_shock_pct = require_finite(equity_shock_pct, field="equity_shock_pct")
+    if liabilities_usd <= 0.0:
+        raise ValueError("liabilities_usd must be positive to define a funded ratio")
+
+    asset_delta = equity_market_value_usd * equity_shock_pct
+
+    liability_delta = 0.0
+    if discount_rate_shock is not None:
+        discount_rate_shock = require_finite(discount_rate_shock, field="discount_rate_shock")
+        if liability_duration_years is None:
+            raise ValueError("liability_duration_years is required when discount_rate_shock is set")
+        liability_duration_years = require_finite(
+            liability_duration_years, field="liability_duration_years"
+        )
+        if liability_duration_years < 0.0:
+            raise ValueError("liability_duration_years must be non-negative")
+        # Duration approximation: a fall in the discount rate (negative shock)
+        # raises the present value of liabilities.
+        liability_delta = -liability_duration_years * discount_rate_shock * liabilities_usd
+
+    # Route the asset & liability shocks through the shared scenario engine so
+    # the funded-status stress reuses the same deterministic machinery, config
+    # hashing, and reproducibility metadata as every other quant scenario.
+    macro_shocks: dict[str, float] = {"total_assets_usd": asset_delta}
+    if discount_rate_shock is not None:
+        macro_shocks["liabilities_usd"] = liability_delta
+    scenario = run_deterministic_scenario(
+        plan_id=plan_id,
+        plan_period=plan_period,
+        baseline_metrics={
+            "total_assets_usd": total_assets_usd,
+            "liabilities_usd": liabilities_usd,
+        },
+        scenario=ScenarioInput(name=scenario_name, macro_shocks=macro_shocks),
+        config=ScenarioRunConfig(module_version=module_version),
+        source_snapshot_id=source_snapshot_id,
+    )
+    row_map = {row.metric_name: row for row in scenario.rows}
+    shocked_assets = row_map["total_assets_usd"].scenario_value
+    shocked_liabilities = row_map["liabilities_usd"].scenario_value
+    if shocked_liabilities <= 0.0:
+        raise ValueError("shocked liabilities collapsed to non-positive; shock is unphysical")
+
+    baseline_funded = total_assets_usd / liabilities_usd
+    shocked_funded = shocked_assets / shocked_liabilities
+
+    # A total-plan funded-status result requires a total-plan equity basis; a
+    # 13F sleeve under-sizes the asset shock, so downgrade the label.
+    scope_label: ScopeLabel = (
+        "total-plan" if equity_basis_scope == "total-plan" else "equity-sleeve"
+    )
+
+    return FundedStatusStressResult(
+        plan_id=plan_id,
+        plan_period=plan_period,
+        scope_label=scope_label,
+        equity_shock_pct=equity_shock_pct,
+        discount_rate_shock=discount_rate_shock,
+        baseline_funded_ratio=round(baseline_funded, 6),
+        shocked_funded_ratio=round(shocked_funded, 6),
+        funded_ratio_delta=round(shocked_funded - baseline_funded, 6),
+        asset_delta_usd=round(asset_delta, 6),
+        liability_delta_usd=round(liability_delta, 6),
+        baseline_uaal_usd=round(liabilities_usd - total_assets_usd, 6),
+        shocked_uaal_usd=round(shocked_liabilities - shocked_assets, 6),
+        equity_basis_scope=equity_basis_scope,
+        scenario=scenario,
+        provenance_refs=normalize_provenance_refs(provenance_refs),
+    )
+
+
+def run_funded_status_equity_shock(
+    *,
+    plan_id: str,
+    plan_period: str,
+    total_assets_usd: float,
+    liabilities_usd: float,
+    equity_market_value_usd: float,
+    equity_basis_scope: ScopeLabel,
+    equity_shock_pct: float = -0.20,
+    module_version: str,
+    source_snapshot_id: str,
+    provenance_refs: Sequence[str] = (),
+) -> FundedStatusStressResult:
+    """Funded-status impact of an equity-only shock (default −20%), via scenarios.py."""
+    return _funded_status_stress(
+        plan_id=plan_id,
+        plan_period=plan_period,
+        total_assets_usd=total_assets_usd,
+        liabilities_usd=liabilities_usd,
+        equity_market_value_usd=equity_market_value_usd,
+        equity_basis_scope=equity_basis_scope,
+        equity_shock_pct=equity_shock_pct,
+        discount_rate_shock=None,
+        liability_duration_years=None,
+        module_version=module_version,
+        source_snapshot_id=source_snapshot_id,
+        provenance_refs=provenance_refs,
+        scenario_name=f"equity-shock:{equity_shock_pct:+.2f}",
+    )
+
+
+def run_funded_status_combined_shock(
+    *,
+    plan_id: str,
+    plan_period: str,
+    total_assets_usd: float,
+    liabilities_usd: float,
+    equity_market_value_usd: float,
+    equity_basis_scope: ScopeLabel,
+    liability_duration_years: float,
+    equity_shock_pct: float = -0.20,
+    discount_rate_shock: float = -0.01,
+    module_version: str,
+    source_snapshot_id: str,
+    provenance_refs: Sequence[str] = (),
+) -> FundedStatusStressResult:
+    """Combined equity + discount-rate shock on funded status, via scenarios.py.
+
+    ``discount_rate_shock`` is the additive change in the discount rate (e.g.
+    ``-0.01`` for a 100 bps fall). Liability sensitivity uses the standard
+    duration approximation ``Δliab ≈ −duration × Δr × liab``.
+    """
+    return _funded_status_stress(
+        plan_id=plan_id,
+        plan_period=plan_period,
+        total_assets_usd=total_assets_usd,
+        liabilities_usd=liabilities_usd,
+        equity_market_value_usd=equity_market_value_usd,
+        equity_basis_scope=equity_basis_scope,
+        equity_shock_pct=equity_shock_pct,
+        discount_rate_shock=discount_rate_shock,
+        liability_duration_years=liability_duration_years,
+        module_version=module_version,
+        source_snapshot_id=source_snapshot_id,
+        provenance_refs=provenance_refs,
+        scenario_name=(f"combined-shock:eq{equity_shock_pct:+.2f}:dr{discount_rate_shock:+.4f}"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 3 — Fee / cost-effectiveness
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True, slots=True)
+class FeeEffectivenessReport:
+    """Investment-expense cost-effectiveness vs a passive anchor."""
+
+    plan_id: str
+    plan_period: str
+    scope_label: ScopeLabel
+    expense_bps: float
+    anchor_bps: float
+    excess_bps: float
+    investment_expense_usd: float
+    alts_management_fees_usd: float | None
+    alts_carried_interest_usd: float | None
+    net_value_added: float | None
+    provenance_refs: tuple[str, ...]
+
+
+def _sum_finite_optional(values: Iterable[float | None]) -> float | None:
+    present = [float(v) for v in values if is_finite_number(v)]
+    return round(sum(present), 6) if present else None
+
+
+def compute_fee_effectiveness(
+    *,
+    plan_id: str,
+    plan_period: str,
+    investment_expense_usd: float,
+    total_assets_usd: float,
+    scope_label: ScopeLabel,
+    anchor_bps: float = DEFAULT_FEE_ANCHOR_BPS,
+    alts_management_fees_usd: Iterable[float | None] = (),
+    alts_carried_interest_usd: Iterable[float | None] = (),
+    net_return: float | None = None,
+    policy_benchmark_return: float | None = None,
+    provenance_refs: Sequence[str] = (),
+) -> FeeEffectivenessReport:
+    """Investment expense (bps of assets) vs a ~40 bps anchor, plus alts fees.
+
+    ``alts_management_fees_usd`` / ``alts_carried_interest_usd`` are the per-fund
+    components from the #647 AB 2833 capture (finite components only; non-finite
+    dropped, never poisoning the total to NaN). ``net_value_added`` is
+    ``net_return − policy_benchmark_return`` when both are available.
+    """
+    investment_expense_usd = require_finite(investment_expense_usd, field="investment_expense_usd")
+    total_assets_usd = require_finite(total_assets_usd, field="total_assets_usd")
+    anchor_bps = require_finite(anchor_bps, field="anchor_bps")
+    if total_assets_usd <= 0.0:
+        raise ValueError("total_assets_usd must be positive to express a fee ratio")
+
+    expense_bps = round(investment_expense_usd / total_assets_usd * 10_000.0, 4)
+    net_value_added: float | None = None
+    if is_finite_number(net_return) and is_finite_number(policy_benchmark_return):
+        assert net_return is not None and policy_benchmark_return is not None
+        net_value_added = round(net_return - policy_benchmark_return, 6)
+
+    return FeeEffectivenessReport(
+        plan_id=plan_id,
+        plan_period=plan_period,
+        scope_label=scope_label,
+        expense_bps=expense_bps,
+        anchor_bps=round(anchor_bps, 4),
+        excess_bps=round(expense_bps - anchor_bps, 4),
+        investment_expense_usd=round(investment_expense_usd, 6),
+        alts_management_fees_usd=_sum_finite_optional(alts_management_fees_usd),
+        alts_carried_interest_usd=_sum_finite_optional(alts_carried_interest_usd),
+        net_value_added=net_value_added,
+        provenance_refs=normalize_provenance_refs(provenance_refs),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 4 — Manager overlap / active share (equity sleeve)
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True, slots=True)
+class SecurityOverlapRow:
+    """One security's overlap between subject and counterparty equity sleeves."""
+
+    security_id: str
+    subject_weight: float
+    counterparty_weight: float
+    overlap_weight: float
+
+
+@dataclass(frozen=True, slots=True)
+class ActiveShareReport:
+    """Active share vs a benchmark plus pairwise overlap, on the equity sleeve.
+
+    Active share and overlap are intrinsically 13F-equity-sleeve figures, so the
+    scope label is fixed to ``"equity-sleeve"``.
+    """
+
+    plan_id: str
+    plan_period: str
+    scope_label: ScopeLabel
+    active_share: float
+    active_share_pct: float
+    cremers_band: CremersBand
+    pairwise_overlap: float
+    fee_per_unit_active_risk: float | None
+    overlap_rows: tuple[SecurityOverlapRow, ...]
+    provenance_refs: tuple[str, ...]
+
+
+def _cremers_band(active_share_pct: float) -> CremersBand:
+    if active_share_pct < 20.0:
+        return "closet-indexer"
+    if active_share_pct <= 60.0:
+        return "moderately-active"
+    if active_share_pct <= 80.0:
+        return "highly-active"
+    return "very-highly-active"
+
+
+def compute_security_overlap(
+    *,
+    subject_weights: Mapping[str, float],
+    counterparty_weights: Mapping[str, float],
+) -> tuple[tuple[SecurityOverlapRow, ...], float]:
+    """Security-level overlap = ``Σ min(w_subject,i, w_counterparty,i)``.
+
+    Extends the ``holdings_overlap`` min-exposure seam from manager/fund level to
+    the security level. Returns per-security rows and the scalar pairwise overlap.
+    """
+    all_ids = sorted(set(subject_weights) | set(counterparty_weights))
+    rows: list[SecurityOverlapRow] = []
+    overlap_total = 0.0
+    for security_id in all_ids:
+        subject = require_finite(
+            subject_weights.get(security_id, 0.0), field=f"subject_weights[{security_id!r}]"
+        )
+        counterparty = require_finite(
+            counterparty_weights.get(security_id, 0.0),
+            field=f"counterparty_weights[{security_id!r}]",
+        )
+        overlap = min(subject, counterparty)
+        overlap_total += overlap
+        rows.append(
+            SecurityOverlapRow(
+                security_id=security_id,
+                subject_weight=round(subject, 6),
+                counterparty_weight=round(counterparty, 6),
+                overlap_weight=round(overlap, 6),
+            )
+        )
+    return tuple(rows), round(overlap_total, 6)
+
+
+def compute_active_share(
+    *,
+    plan_id: str,
+    plan_period: str,
+    portfolio_weights: Mapping[str, float],
+    benchmark_weights: Mapping[str, float],
+    fee_bps: float | None = None,
+    counterparty_weights: Mapping[str, float] | None = None,
+    provenance_refs: Sequence[str] = (),
+) -> ActiveShareReport:
+    """Active share ``= ½·Σ|w_portfolio,i − w_benchmark,i|`` with Cremers-Petajisto bands.
+
+    Active share is a fraction in ``[0, 1]``; ``active_share_pct`` is the 0-100
+    form used for the bands (<20 closet, 20-60 moderate, 60-80 high, >80 very
+    high). ``fee_per_unit_active_risk`` = ``fee_bps / active_share_pct`` (bps of
+    fee per point of active share), ``None`` when active share is zero.
+    ``counterparty_weights`` optionally drives the pairwise-overlap leg.
+    """
+    all_ids = sorted(set(portfolio_weights) | set(benchmark_weights))
+    gross = 0.0
+    for security_id in all_ids:
+        w_p = require_finite(
+            portfolio_weights.get(security_id, 0.0),
+            field=f"portfolio_weights[{security_id!r}]",
+        )
+        w_b = require_finite(
+            benchmark_weights.get(security_id, 0.0),
+            field=f"benchmark_weights[{security_id!r}]",
+        )
+        gross += abs(w_p - w_b)
+    active_share = round(0.5 * gross, 6)
+    active_share_pct = round(active_share * 100.0, 4)
+
+    overlap_rows: tuple[SecurityOverlapRow, ...] = ()
+    pairwise_overlap = 0.0
+    if counterparty_weights is not None:
+        overlap_rows, pairwise_overlap = compute_security_overlap(
+            subject_weights=portfolio_weights,
+            counterparty_weights=counterparty_weights,
+        )
+
+    fee_per_unit: float | None = None
+    if fee_bps is not None:
+        fee_bps = require_finite(fee_bps, field="fee_bps")
+        if active_share_pct > 0.0:
+            fee_per_unit = round(fee_bps / active_share_pct, 6)
+
+    return ActiveShareReport(
+        plan_id=plan_id,
+        plan_period=plan_period,
+        scope_label="equity-sleeve",
+        active_share=active_share,
+        active_share_pct=active_share_pct,
+        cremers_band=_cremers_band(active_share_pct),
+        pairwise_overlap=pairwise_overlap,
+        fee_per_unit_active_risk=fee_per_unit,
+        overlap_rows=overlap_rows,
+        provenance_refs=normalize_provenance_refs(provenance_refs),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 5 — Look-through concentration & factor tilts (equity sleeve)
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True, slots=True)
+class ConcentrationReport:
+    """Herfindahl-Hirschman concentration and top-N weight of the equity sleeve."""
+
+    plan_id: str
+    plan_period: str
+    scope_label: ScopeLabel
+    hhi: float
+    effective_n: float | None
+    top_n: int
+    top_n_weight: float
+    n_holdings: int
+    provenance_refs: tuple[str, ...]
+
+
+def compute_concentration(
+    *,
+    plan_id: str,
+    plan_period: str,
+    weights: Mapping[str, float],
+    top_n: int = 10,
+    provenance_refs: Sequence[str] = (),
+) -> ConcentrationReport:
+    """HHI ``= Σ wᵢ²``, effective holdings ``1/HHI``, and top-N weight.
+
+    Operates on the 13F equity sleeve, so the scope label is fixed to
+    ``"equity-sleeve"``. Weights are expected to be a normalized fraction vector.
+    """
+    if top_n <= 0:
+        raise ValueError("top_n must be positive")
+    finite_weights = {
+        security_id: require_finite(weight, field=f"weights[{security_id!r}]")
+        for security_id, weight in weights.items()
+    }
+    hhi = round(sum(weight * weight for weight in finite_weights.values()), 6)
+    effective_n = round(1.0 / hhi, 6) if hhi > 0.0 else None
+    ordered = sorted(finite_weights.values(), reverse=True)
+    top_n_weight = round(sum(ordered[:top_n]), 6)
+    return ConcentrationReport(
+        plan_id=plan_id,
+        plan_period=plan_period,
+        scope_label="equity-sleeve",
+        hhi=hhi,
+        effective_n=effective_n,
+        top_n=top_n,
+        top_n_weight=top_n_weight,
+        n_holdings=len(finite_weights),
+        provenance_refs=normalize_provenance_refs(provenance_refs),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class FactorTiltReport:
+    """Weighted factor z-scores over the equity sleeve (no fabrication).
+
+    ``factor_zscores`` maps each requested factor to the sleeve's weight-average
+    standardized exposure, or ``None`` when no held security carries that factor.
+    ``factor_coverage`` reports the weight fraction of the sleeve that carried an
+    exposure for each factor, so a thinly-covered tilt is never mistaken for a
+    fully-informed one.
+    """
+
+    plan_id: str
+    plan_period: str
+    scope_label: ScopeLabel
+    factor_zscores: dict[str, float | None]
+    factor_coverage: dict[str, float]
+    factors_missing: tuple[str, ...]
+    provenance_refs: tuple[str, ...]
+
+
+def compute_factor_tilts(
+    *,
+    plan_id: str,
+    plan_period: str,
+    weights: Mapping[str, float],
+    factor_exposures: Mapping[str, Mapping[str, float]],
+    factors: Sequence[str] = ("value", "quality", "size", "momentum"),
+    provenance_refs: Sequence[str] = (),
+) -> FactorTiltReport:
+    """Weight-average standardized factor exposures over the equity sleeve.
+
+    ``factor_exposures`` maps ``security_id -> {factor -> standardized z}``. For
+    each factor the report is the weight-average z over the *held securities that
+    carry that factor*, with weights renormalized over the covered subset. Where a
+    factor is absent for every held security the value is ``None`` and the factor
+    is listed in ``factors_missing`` — the hook is exposed but no data is
+    fabricated. Scope is fixed to ``"equity-sleeve"``.
+    """
+    finite_weights = {
+        security_id: require_finite(weight, field=f"weights[{security_id!r}]")
+        for security_id, weight in weights.items()
+    }
+    zscores: dict[str, float | None] = {}
+    coverage: dict[str, float] = {}
+    missing: list[str] = []
+    for factor in factors:
+        covered_weight = 0.0
+        weighted_sum = 0.0
+        for security_id, weight in finite_weights.items():
+            exposures = factor_exposures.get(security_id)
+            if not exposures:
+                continue
+            raw = exposures.get(factor)
+            if not is_finite_number(raw):
+                continue
+            covered_weight += weight
+            weighted_sum += weight * float(raw)
+        if covered_weight > 0.0:
+            zscores[factor] = round(weighted_sum / covered_weight, 6)
+            coverage[factor] = round(covered_weight, 6)
+        else:
+            zscores[factor] = None
+            coverage[factor] = 0.0
+            missing.append(factor)
+    return FactorTiltReport(
+        plan_id=plan_id,
+        plan_period=plan_period,
+        scope_label="equity-sleeve",
+        factor_zscores=zscores,
+        factor_coverage=coverage,
+        factors_missing=tuple(missing),
+        provenance_refs=normalize_provenance_refs(provenance_refs),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 6 — Liquidity & Brinson attribution (where data allows)
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True, slots=True)
+class LiquidityReport:
+    """Illiquid share vs a net cash outflow (liquidity-adequacy view)."""
+
+    plan_id: str
+    plan_period: str
+    scope_label: ScopeLabel
+    illiquid_market_value_usd: float
+    total_market_value_usd: float
+    illiquid_pct: float
+    net_cash_outflow_usd: float | None
+    liquid_market_value_usd: float
+    outflow_coverage_ratio: float | None
+    provenance_refs: tuple[str, ...]
+
+
+def compute_liquidity(
+    *,
+    plan_id: str,
+    plan_period: str,
+    illiquid_market_value_usd: float,
+    total_market_value_usd: float,
+    scope_label: ScopeLabel,
+    net_cash_outflow_usd: float | None = None,
+    provenance_refs: Sequence[str] = (),
+) -> LiquidityReport:
+    """Illiquid share of the portfolio and its coverage of a net cash outflow.
+
+    ``outflow_coverage_ratio`` = ``liquid_market_value / net_cash_outflow`` (how
+    many years of outflow the liquid book covers), ``None`` when outflow is not
+    supplied or non-positive.
+    """
+    illiquid_market_value_usd = require_finite(
+        illiquid_market_value_usd, field="illiquid_market_value_usd"
+    )
+    total_market_value_usd = require_finite(total_market_value_usd, field="total_market_value_usd")
+    if total_market_value_usd <= 0.0:
+        raise ValueError("total_market_value_usd must be positive")
+    if illiquid_market_value_usd < 0.0:
+        raise ValueError("illiquid_market_value_usd must be non-negative")
+    liquid = total_market_value_usd - illiquid_market_value_usd
+    outflow_coverage: float | None = None
+    outflow_clean: float | None = None
+    if net_cash_outflow_usd is not None:
+        outflow_clean = require_finite(net_cash_outflow_usd, field="net_cash_outflow_usd")
+        if outflow_clean > 0.0:
+            outflow_coverage = round(liquid / outflow_clean, 6)
+    return LiquidityReport(
+        plan_id=plan_id,
+        plan_period=plan_period,
+        scope_label=scope_label,
+        illiquid_market_value_usd=round(illiquid_market_value_usd, 6),
+        total_market_value_usd=round(total_market_value_usd, 6),
+        illiquid_pct=round(illiquid_market_value_usd / total_market_value_usd, 6),
+        net_cash_outflow_usd=None if outflow_clean is None else round(outflow_clean, 6),
+        liquid_market_value_usd=round(liquid, 6),
+        outflow_coverage_ratio=outflow_coverage,
+        provenance_refs=normalize_provenance_refs(provenance_refs),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class BrinsonAttributionReport:
+    """Brinson allocation/selection attribution vs a policy benchmark."""
+
+    plan_id: str
+    plan_period: str
+    scope_label: ScopeLabel
+    allocation_effect: float
+    selection_effect: float
+    interaction_effect: float
+    total_active_return: float
+    total_active_return_net_of_fee: float
+    fee_drag: float
+    per_bucket: dict[str, dict[str, float]] = field(default_factory=dict)
+    provenance_refs: tuple[str, ...] = ()
+
+
+def compute_brinson_attribution(
+    *,
+    plan_id: str,
+    plan_period: str,
+    portfolio_weights: Mapping[str, float],
+    portfolio_returns: Mapping[str, float],
+    policy_weights: Mapping[str, float],
+    policy_returns: Mapping[str, float],
+    scope_label: ScopeLabel,
+    fee_drag: float = 0.0,
+    provenance_refs: Sequence[str] = (),
+) -> BrinsonAttributionReport:
+    """Brinson-Fachler allocation/selection/interaction attribution vs policy.
+
+    Per bucket ``i`` with policy weight ``Wᵢ``/return ``Bᵢ`` and portfolio weight
+    ``wᵢ``/return ``Rᵢ`` against total benchmark return ``B̄``:
+
+    * allocation ``= (wᵢ − Wᵢ)·(Bᵢ − B̄)``
+    * selection  ``= Wᵢ·(Rᵢ − Bᵢ)``
+    * interaction ``= (wᵢ − Wᵢ)·(Rᵢ − Bᵢ)``
+
+    ``fee_drag`` (a positive return give-up) is subtracted to report a
+    net-of-fee active return. Every weight and return is finite-guarded.
+    """
+    buckets = sorted(set(portfolio_weights) | set(policy_weights))
+    fee_drag = require_finite(fee_drag, field="fee_drag")
+
+    def _get(mapping: Mapping[str, float], key: str, name: str) -> float:
+        return require_finite(mapping.get(key, 0.0), field=f"{name}[{key!r}]")
+
+    total_benchmark_return = sum(
+        _get(policy_weights, bucket, "policy_weights")
+        * _get(policy_returns, bucket, "policy_returns")
+        for bucket in buckets
+    )
+
+    allocation_total = 0.0
+    selection_total = 0.0
+    interaction_total = 0.0
+    per_bucket: dict[str, dict[str, float]] = {}
+    for bucket in buckets:
+        w_p = _get(portfolio_weights, bucket, "portfolio_weights")
+        w_b = _get(policy_weights, bucket, "policy_weights")
+        r_p = _get(portfolio_returns, bucket, "portfolio_returns")
+        r_b = _get(policy_returns, bucket, "policy_returns")
+        allocation = (w_p - w_b) * (r_b - total_benchmark_return)
+        selection = w_b * (r_p - r_b)
+        interaction = (w_p - w_b) * (r_p - r_b)
+        allocation_total += allocation
+        selection_total += selection
+        interaction_total += interaction
+        per_bucket[bucket] = {
+            "allocation": round(allocation, 6),
+            "selection": round(selection, 6),
+            "interaction": round(interaction, 6),
+        }
+
+    total_active = allocation_total + selection_total + interaction_total
+    return BrinsonAttributionReport(
+        plan_id=plan_id,
+        plan_period=plan_period,
+        scope_label=scope_label,
+        allocation_effect=round(allocation_total, 6),
+        selection_effect=round(selection_total, 6),
+        interaction_effect=round(interaction_total, 6),
+        total_active_return=round(total_active, 6),
+        total_active_return_net_of_fee=round(total_active - fee_drag, 6),
+        fee_drag=round(fee_drag, 6),
+        per_bucket=per_bucket,
+        provenance_refs=normalize_provenance_refs(provenance_refs),
+    )

--- a/tests/quant/test_holdings_analytics.py
+++ b/tests/quant/test_holdings_analytics.py
@@ -1,0 +1,429 @@
+"""Test gate for the holdings analytics layer (issue #648).
+
+Fixed synthetic portfolio; asserts allocation-vs-policy drift, HHI/top-N,
+active share, and the −20% equity funded-status stress — each with its scope
+label — plus the finite-guard rejection behavior at every numeric boundary.
+
+The stress assertion (:func:`test_equity_shock_reduces_funded_status`) is the
+deliberate-break target: flipping ``EQUITY_SHOCK`` from −0.20 to +0.20 turns the
+shock into a gain and makes the "funded status falls" assertion fail.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from pension_data.db.models.investment_positions import PlanSecurityPosition
+from pension_data.quant.holdings_analytics import (
+    compute_active_share,
+    compute_allocation_drift,
+    compute_brinson_attribution,
+    compute_concentration,
+    compute_factor_tilts,
+    compute_fee_effectiveness,
+    compute_liquidity,
+    compute_security_overlap,
+    positions_to_weights,
+    run_funded_status_combined_shock,
+    run_funded_status_equity_shock,
+)
+
+# Deliberate-break knob: flip to +0.20 to break test_equity_shock_reduces_funded_status.
+EQUITY_SHOCK = -0.20
+
+
+# ---------------------------------------------------------------------------
+# Fixed synthetic portfolio
+# ---------------------------------------------------------------------------
+def _equity_positions() -> list[PlanSecurityPosition]:
+    """A fixed 5-name equity sleeve; market values chosen for round weights."""
+    raw = [
+        ("cusip:AAA", "Alpha Corp", 400.0),
+        ("cusip:BBB", "Beta Corp", 300.0),
+        ("cusip:CCC", "Gamma Corp", 150.0),
+        ("cusip:DDD", "Delta Corp", 100.0),
+        ("cusip:EEE", "Epsilon Corp", 50.0),
+    ]
+    return [
+        PlanSecurityPosition(
+            plan_id="CA-TEST",
+            plan_period="FY2024",
+            security_id=security_id,
+            security_name=name,
+            cusip=security_id.split(":", 1)[1],
+            ticker=None,
+            shares=None,
+            market_value_usd=market_value,
+            asset_class="public_equity",
+            source="13f",
+            as_of="2024-06-30",
+            disclosure_state="disclosed",
+            provenance_ref=f"prov:{security_id}",
+            valid_from="2024-06-30",
+            asserted_at="2024-06-30",
+        )
+        for security_id, name, market_value in raw
+    ]
+
+
+def test_positions_to_weights_normalizes_disclosed_universe() -> None:
+    weights = positions_to_weights(_equity_positions())
+    assert weights["cusip:AAA"] == pytest.approx(0.4)
+    assert weights["cusip:BBB"] == pytest.approx(0.3)
+    assert sum(weights.values()) == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Task 1 — allocation-vs-policy drift (scope-labeled)
+# ---------------------------------------------------------------------------
+def test_allocation_drift_total_plan_scope() -> None:
+    report = compute_allocation_drift(
+        plan_id="CA-TEST",
+        plan_period="FY2024",
+        actual_weights={
+            "public_equity": 0.55,
+            "fixed_income": 0.20,
+            "private_equity": 0.15,
+            "real_estate": 0.10,
+        },
+        target_weights={
+            "public_equity": 0.50,
+            "fixed_income": 0.25,
+            "private_equity": 0.15,
+            "real_estate": 0.10,
+        },
+        scope_label="total-plan",
+        provenance_refs=["cafr:2024"],
+    )
+    # Only two classes move: +0.05 equity, -0.05 fixed income.
+    # drift = 0.5 * (|0.05| + |0.05|) = 0.05
+    assert report.drift == pytest.approx(0.05)
+    assert report.scope_label == "total-plan"
+    assert report.provenance_refs == ("cafr:2024",)
+    # Alternatives (private_equity, real_estate) are on-target here.
+    assert report.alternatives_active_weight == pytest.approx(0.0)
+    equity_row = next(r for r in report.rows if r.asset_class == "public_equity")
+    assert equity_row.active_weight == pytest.approx(0.05)
+
+
+def test_allocation_drift_flags_alternatives_overweight() -> None:
+    report = compute_allocation_drift(
+        plan_id="CA-TEST",
+        plan_period="FY2024",
+        actual_weights={"public_equity": 0.55, "private_equity": 0.45},
+        target_weights={"public_equity": 0.65, "private_equity": 0.35},
+        scope_label="total-plan",
+        provenance_refs=["cafr:2024"],
+    )
+    assert report.alternatives_active_weight == pytest.approx(0.10)
+    pe_row = next(r for r in report.rows if r.asset_class == "private_equity")
+    assert pe_row.is_alternative is True
+
+
+# ---------------------------------------------------------------------------
+# Task 5 — concentration HHI / top-N (equity-sleeve scope)
+# ---------------------------------------------------------------------------
+def test_concentration_hhi_and_top_n_equity_sleeve() -> None:
+    weights = positions_to_weights(_equity_positions())
+    report = compute_concentration(
+        plan_id="CA-TEST",
+        plan_period="FY2024",
+        weights=weights,
+        top_n=2,
+        provenance_refs=["13f:2024q2"],
+    )
+    # HHI = 0.4^2 + 0.3^2 + 0.15^2 + 0.1^2 + 0.05^2
+    #     = 0.16 + 0.09 + 0.0225 + 0.01 + 0.0025 = 0.285
+    assert report.hhi == pytest.approx(0.285)
+    assert report.effective_n == pytest.approx(1.0 / 0.285, rel=1e-5)
+    # top-2 weight = 0.4 + 0.3 = 0.7
+    assert report.top_n_weight == pytest.approx(0.7)
+    assert report.n_holdings == 5
+    assert report.scope_label == "equity-sleeve"
+
+
+# ---------------------------------------------------------------------------
+# Task 4 — active share (Cremers-Petajisto bands) + overlap (equity-sleeve)
+# ---------------------------------------------------------------------------
+def test_active_share_bands_and_fee_per_unit() -> None:
+    # Portfolio holds two names the benchmark does not; benchmark holds two the
+    # portfolio does not. Active share = 0.5 * sum|dw|.
+    portfolio = {"AAA": 0.5, "BBB": 0.5}
+    benchmark = {"AAA": 0.25, "BBB": 0.25, "CCC": 0.25, "DDD": 0.25}
+    report = compute_active_share(
+        plan_id="CA-TEST",
+        plan_period="FY2024",
+        portfolio_weights=portfolio,
+        benchmark_weights=benchmark,
+        fee_bps=60.0,
+        counterparty_weights={"AAA": 0.5, "CCC": 0.5},
+        provenance_refs=["13f:2024q2"],
+    )
+    # |0.5-0.25|*2 + |0-0.25|*2 = 0.25*4 = 1.0 -> active share = 0.5
+    assert report.active_share == pytest.approx(0.5)
+    assert report.active_share_pct == pytest.approx(50.0)
+    assert report.cremers_band == "moderately-active"
+    # fee per unit of active risk = 60 bps / 50 pts = 1.2
+    assert report.fee_per_unit_active_risk == pytest.approx(1.2)
+    # pairwise overlap vs counterparty {AAA:0.5, CCC:0.5} = min(0.5,0.5)+min(0.5,0)+... = 0.5
+    assert report.pairwise_overlap == pytest.approx(0.5)
+    assert report.scope_label == "equity-sleeve"
+
+
+def test_active_share_closet_and_high_bands() -> None:
+    closet = compute_active_share(
+        plan_id="p",
+        plan_period="FY2024",
+        portfolio_weights={"AAA": 0.5, "BBB": 0.5},
+        benchmark_weights={"AAA": 0.55, "BBB": 0.45},
+        provenance_refs=[],
+    )
+    assert closet.cremers_band == "closet-indexer"  # AS = 5%
+    high = compute_active_share(
+        plan_id="p",
+        plan_period="FY2024",
+        portfolio_weights={"AAA": 1.0},
+        benchmark_weights={"BBB": 1.0},
+        provenance_refs=[],
+    )
+    assert high.active_share_pct == pytest.approx(100.0)
+    assert high.cremers_band == "very-highly-active"
+
+
+def test_security_overlap_min_exposure_seam() -> None:
+    rows, overlap = compute_security_overlap(
+        subject_weights={"AAA": 0.6, "BBB": 0.4},
+        counterparty_weights={"AAA": 0.3, "CCC": 0.7},
+    )
+    # min(0.6,0.3) + min(0.4,0) + min(0,0.7) = 0.3
+    assert overlap == pytest.approx(0.3)
+    aaa = next(r for r in rows if r.security_id == "AAA")
+    assert aaa.overlap_weight == pytest.approx(0.3)
+
+
+# ---------------------------------------------------------------------------
+# Task 2 — funded-status stress (via scenarios.py) — DELIBERATE-BREAK TARGET
+# ---------------------------------------------------------------------------
+def test_equity_shock_reduces_funded_status() -> None:
+    result = run_funded_status_equity_shock(
+        plan_id="CA-TEST",
+        plan_period="FY2024",
+        total_assets_usd=100_000_000.0,
+        liabilities_usd=125_000_000.0,
+        equity_market_value_usd=40_000_000.0,
+        equity_basis_scope="total-plan",
+        equity_shock_pct=EQUITY_SHOCK,
+        module_version="v0.1.0",
+        source_snapshot_id="snapshot:2024-06-30",
+        provenance_refs=["cafr:2024"],
+    )
+    # baseline funded ratio = 100M / 125M = 0.8
+    assert result.baseline_funded_ratio == pytest.approx(0.8)
+    # -20% on 40M equity = -8M assets -> 92M / 125M = 0.736
+    assert result.asset_delta_usd == pytest.approx(-8_000_000.0)
+    assert result.shocked_funded_ratio == pytest.approx(0.736)
+    # THE stress assertion: a -20% equity shock must REDUCE funded status.
+    # Deliberate-break: EQUITY_SHOCK = +0.20 makes this fail.
+    assert result.shocked_funded_ratio < result.baseline_funded_ratio
+    assert result.funded_ratio_delta < 0.0
+    assert result.scope_label == "total-plan"
+    # Routed through the shared scenario engine (reproducibility metadata present).
+    assert result.scenario.mode == "deterministic"
+    assert result.scenario.reproducibility.config_hash
+
+
+def test_equity_sleeve_basis_downgrades_scope_label() -> None:
+    """A 13F-sleeve equity basis must NOT yield a total-plan funded-status label."""
+    result = run_funded_status_equity_shock(
+        plan_id="CA-TEST",
+        plan_period="FY2024",
+        total_assets_usd=100_000_000.0,
+        liabilities_usd=125_000_000.0,
+        equity_market_value_usd=30_000_000.0,
+        equity_basis_scope="equity-sleeve",
+        module_version="v0.1.0",
+        source_snapshot_id="snapshot:2024-06-30",
+    )
+    assert result.scope_label == "equity-sleeve"
+
+
+def test_combined_shock_adds_discount_rate_leg() -> None:
+    result = run_funded_status_combined_shock(
+        plan_id="CA-TEST",
+        plan_period="FY2024",
+        total_assets_usd=100_000_000.0,
+        liabilities_usd=125_000_000.0,
+        equity_market_value_usd=40_000_000.0,
+        equity_basis_scope="total-plan",
+        liability_duration_years=12.0,
+        equity_shock_pct=EQUITY_SHOCK,
+        discount_rate_shock=-0.01,
+        module_version="v0.1.0",
+        source_snapshot_id="snapshot:2024-06-30",
+    )
+    # Δliab = -12 * (-0.01) * 125M = +15M -> liabilities rise, funded status
+    # falls harder than the equity-only shock.
+    assert result.liability_delta_usd == pytest.approx(15_000_000.0)
+    assert result.shocked_funded_ratio < 0.736
+    assert result.scope_label == "total-plan"
+
+
+# ---------------------------------------------------------------------------
+# Task 3 — fee / cost-effectiveness
+# ---------------------------------------------------------------------------
+def test_fee_effectiveness_vs_anchor_and_alts() -> None:
+    report = compute_fee_effectiveness(
+        plan_id="CA-TEST",
+        plan_period="FY2024",
+        investment_expense_usd=650_000.0,
+        total_assets_usd=100_000_000.0,
+        scope_label="total-plan",
+        alts_management_fees_usd=[200_000.0, 100_000.0, float("nan")],
+        alts_carried_interest_usd=[300_000.0],
+        net_return=0.072,
+        policy_benchmark_return=0.065,
+        provenance_refs=["cafr:2024", "ab2833:2024"],
+    )
+    # 650k / 100M = 65 bps vs 40 bps anchor -> +25 bps excess
+    assert report.expense_bps == pytest.approx(65.0)
+    assert report.excess_bps == pytest.approx(25.0)
+    # NaN component dropped, not poisoned to NaN.
+    assert report.alts_management_fees_usd == pytest.approx(300_000.0)
+    assert report.alts_carried_interest_usd == pytest.approx(300_000.0)
+    assert report.net_value_added == pytest.approx(0.007)
+
+
+# ---------------------------------------------------------------------------
+# Task 5 — factor tilts (no fabrication where absent)
+# ---------------------------------------------------------------------------
+def test_factor_tilts_weight_average_and_missing_hook() -> None:
+    weights = {"AAA": 0.5, "BBB": 0.5}
+    report = compute_factor_tilts(
+        plan_id="CA-TEST",
+        plan_period="FY2024",
+        weights=weights,
+        factor_exposures={
+            "AAA": {"value": 1.0, "momentum": -0.5},
+            "BBB": {"value": -1.0},
+        },
+        provenance_refs=["factor:2024"],
+    )
+    # value present on both: 0.5*1.0 + 0.5*(-1.0) = 0.0
+    assert report.factor_zscores["value"] == pytest.approx(0.0)
+    assert report.factor_coverage["value"] == pytest.approx(1.0)
+    # momentum only on AAA (covered weight 0.5) -> weighted avg over covered = -0.5
+    assert report.factor_zscores["momentum"] == pytest.approx(-0.5)
+    assert report.factor_coverage["momentum"] == pytest.approx(0.5)
+    # quality/size absent everywhere -> None, listed missing (no fabrication).
+    assert report.factor_zscores["quality"] is None
+    assert report.factor_zscores["size"] is None
+    assert "quality" in report.factors_missing
+    assert report.scope_label == "equity-sleeve"
+
+
+# ---------------------------------------------------------------------------
+# Task 6 — liquidity & Brinson attribution
+# ---------------------------------------------------------------------------
+def test_liquidity_illiquid_pct_and_outflow_coverage() -> None:
+    report = compute_liquidity(
+        plan_id="CA-TEST",
+        plan_period="FY2024",
+        illiquid_market_value_usd=30_000_000.0,
+        total_market_value_usd=100_000_000.0,
+        scope_label="total-plan",
+        net_cash_outflow_usd=5_000_000.0,
+        provenance_refs=["cafr:2024"],
+    )
+    assert report.illiquid_pct == pytest.approx(0.3)
+    # liquid 70M / 5M outflow = 14 years of coverage
+    assert report.outflow_coverage_ratio == pytest.approx(14.0)
+
+
+def test_brinson_attribution_decomposes_active_return() -> None:
+    report = compute_brinson_attribution(
+        plan_id="CA-TEST",
+        plan_period="FY2024",
+        portfolio_weights={"equity": 0.6, "bonds": 0.4},
+        portfolio_returns={"equity": 0.10, "bonds": 0.03},
+        policy_weights={"equity": 0.5, "bonds": 0.5},
+        policy_returns={"equity": 0.08, "bonds": 0.04},
+        scope_label="total-plan",
+        fee_drag=0.002,
+        provenance_refs=["cafr:2024"],
+    )
+    # Effects should sum to total active return; net-of-fee subtracts the drag.
+    assert report.total_active_return == pytest.approx(
+        report.allocation_effect + report.selection_effect + report.interaction_effect
+    )
+    assert report.total_active_return_net_of_fee == pytest.approx(
+        report.total_active_return - 0.002
+    )
+
+
+# ---------------------------------------------------------------------------
+# Finite-guard discipline (#636) — NaN/inf rejected, not silently passed
+# ---------------------------------------------------------------------------
+def test_finite_guards_reject_non_finite_inputs() -> None:
+    with pytest.raises(ValueError, match="must be a finite number"):
+        compute_allocation_drift(
+            plan_id="p",
+            plan_period="FY2024",
+            actual_weights={"public_equity": float("nan")},
+            target_weights={"public_equity": 0.5},
+            scope_label="total-plan",
+            provenance_refs=[],
+        )
+    with pytest.raises(ValueError, match="must be a finite number"):
+        compute_concentration(
+            plan_id="p",
+            plan_period="FY2024",
+            weights={"AAA": float("inf")},
+        )
+    with pytest.raises(ValueError, match="must be a finite number"):
+        compute_active_share(
+            plan_id="p",
+            plan_period="FY2024",
+            portfolio_weights={"AAA": float("nan")},
+            benchmark_weights={"AAA": 0.5},
+        )
+    with pytest.raises(ValueError, match="must be a finite number"):
+        run_funded_status_equity_shock(
+            plan_id="p",
+            plan_period="FY2024",
+            total_assets_usd=float("inf"),
+            liabilities_usd=125_000_000.0,
+            equity_market_value_usd=40_000_000.0,
+            equity_basis_scope="total-plan",
+            module_version="v0.1.0",
+            source_snapshot_id="snapshot",
+        )
+
+
+def test_positions_to_weights_drops_non_finite_market_values() -> None:
+    positions = _equity_positions()
+    poisoned = [
+        PlanSecurityPosition(
+            plan_id="CA-TEST",
+            plan_period="FY2024",
+            security_id="cusip:NAN",
+            security_name="Bad",
+            cusip="NAN",
+            ticker=None,
+            shares=None,
+            market_value_usd=float("nan"),
+            asset_class="public_equity",
+            source="13f",
+            as_of="2024-06-30",
+            disclosure_state="disclosed",
+            provenance_ref="prov:nan",
+            valid_from="2024-06-30",
+            asserted_at="2024-06-30",
+        )
+    ]
+    weights = positions_to_weights(positions + poisoned)
+    # The NaN-valued position is dropped; the finite universe still sums to 1.
+    assert "cusip:NAN" not in weights
+    assert sum(weights.values()) == pytest.approx(1.0)
+    assert all(math.isfinite(w) for w in weights.values())


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:648 -->
> **Source:** Issue #648

Closes #648

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Turn collected holdings (#C) into decision-useful analysis of one plan's portfolio. Reuses the existing `holdings_overlap` primitive and `quant/scenarios.py`. (Parent: #642; depends on #C; #B for peer/policy context.)

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#642](https://github.com/stranske/Pension-Data/issues/642)
- [#1](https://github.com/stranske/Pension-Data/issues/1)
- [#636](https://github.com/stranske/Pension-Data/issues/636)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] **Allocation vs policy & peers** — drift = ½Σ|actualᵢ−targetᵢ|; alternatives over/underweight; reuse `allocation_peer_compare` for the peer leg.
- [ ] **Funded-status stress** — −20% equity (and combined asset+discount-rate) shock → funded-status impact, via `quant/scenarios.py`.
- [ ] **Fee / cost-effectiveness** — investment expense vs ~40bps anchor; alternatives mgmt + **carried interest** (AB 2833 data); net value added where returns available.
- [ ] **Manager overlap / active share** — extend `holdings_overlap` to security level; aggregate active share (Cremers-Petajisto bands), pairwise overlap, fee-per-unit-of-active-risk.
- [ ] **Look-through concentration & factor** — HHI, top-N, value/quality/size/momentum z-scores (equity sleeve).
- [ ] **Liquidity & attribution** (where data allows) — % illiquid vs net cash outflow; Brinson allocation/selection net-of-fee vs policy + assumed return.
- [ ] Every output carries a scope label + provenance + the finite/bounds discipline (#636).

#### Acceptance criteria
- [ ] For the target plan: allocation-vs-policy drift, a −20%-equity funded-status stress result, an overlap/active-share figure, and a concentration (HHI/top-N) report — each scope-labeled.
- [ ] Total-plan numbers are CAFR-anchored; equity-sleeve-only analyses are explicitly marked.
- [ ] Tests cover drift, HHI, active-share, and the stress calc on synthetic holdings.

**Head SHA:** 752eea361fb21e095d7ae437ee2e5d7cf199b081
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ❔ in progress | [View run](https://github.com/stranske/Pension-Data/actions/runs/30180584014) |
| Backplane Conformance | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30180492093) |
| Cross-Repo Smoke | ⏭️ skipped | [View run](https://github.com/stranske/Pension-Data/actions/runs/30180492073) |
| Entity Regression Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30180491830) |
| Extraction Golden Regression | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30180491829) |
| Foundation Fixture E2E | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30180491863) |
| Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30180492083) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30180491837) |
| NL-SQL Golden | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30180491844) |
| One-PDF Pilot Golden | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30180491882) |
| PostgreSQL Integration | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30180491828) |
| Quality Replay Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30180491853) |
| Quality SLA Gate | ✅ success | [View run](https://github.com/stranske/Pension-Data/actions/runs/30180491865) |
<!-- auto-status-summary:end -->