### PR TITLE
fix(ingest): harden EDGAR request headers and AB 2833 disclosure tests

### DIFF
--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-26T02:44:30.044457Z",
+  "emitted_at": "2026-07-26T02:50:35.660469Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-26T02:50:35.660469Z",
+  "emitted_at": "2026-07-26T02:54:05.923663Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-26T02:54:05.923663Z",
+  "emitted_at": "2026-07-26T03:01:07.208768Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-26T03:01:07.208768Z",
+  "emitted_at": "2026-07-26T03:04:15.185113Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,7 +1,7 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-26T02:31:54.742540Z",
+  "emitted_at": "2026-07-26T02:44:30.044457Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.125.0",
-  "emitted_at": "2026-07-25T16:02:28.412746Z",
+  "emitted_at": "2026-07-26T02:31:54.742540Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.4"
   ],
   "operation_role": "worker",
-  "pr_number": "777",
+  "pr_number": "782",
   "requested_model": "gpt-5.5",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/src/pension_data/sources/edgar/client.py
+++ b/src/pension_data/sources/edgar/client.py
@@ -215,7 +215,10 @@ class EdgarClient:
         self._opener = opener or urllib.request.build_opener()
 
     def _get(self, url: str) -> str:  # pragma: no cover - network path (egress sandboxed)
-        headers = {"User-Agent": self.user_agent, "Accept-Encoding": "gzip, deflate"}
+        # Do not advertise compressed transfer encodings: this deliberately small
+        # client decodes the response bytes directly, and opting into gzip/deflate
+        # without a matching decompression path can corrupt live EDGAR payloads.
+        headers = {"User-Agent": self.user_agent}
         request = urllib.request.Request(url, method="GET", headers=headers)
         try:
             with self._opener.open(request, timeout=self.timeout) as response:

--- a/tests/ingest/test_edgar_flow.py
+++ b/tests/ingest/test_edgar_flow.py
@@ -7,6 +7,7 @@ end-to-end flow is driven from recorded-shape fixtures under ``fixtures/``.
 
 from __future__ import annotations
 
+from email.message import Message
 from pathlib import Path
 
 import pytest
@@ -30,6 +31,34 @@ SUBMISSIONS_FIXTURE = FIXTURE_DIR / "edgar_submissions_CIK0000919079.json"
 INFO_TABLE_FIXTURE = FIXTURE_DIR / "edgar_13f_information_table.xml"
 
 CALPERS_CIK = "0000919079"
+
+
+class _RecordedResponse:
+    status = 200
+
+    def __init__(self, body: bytes) -> None:
+        self.headers = Message()
+        self.headers.set_charset("utf-8")
+        self._body = body
+
+    def __enter__(self) -> _RecordedResponse:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._body
+
+
+class _RecordedOpener:
+    def __init__(self) -> None:
+        self.request = None
+
+    def open(self, request: object, *, timeout: float) -> _RecordedResponse:
+        self.request = request
+        assert timeout == 30.0
+        return _RecordedResponse(b'{"filings": {}}')
 
 
 def test_format_cik_zero_pads_to_ten_digits() -> None:
@@ -106,6 +135,15 @@ def test_edgar_client_builds_flow_urls() -> None:
         document="form13fInfoTable.xml",
     )
     assert url.endswith("/919079/000091907925000042/form13fInfoTable.xml")
+
+
+def test_edgar_client_does_not_request_compressed_transfer_encoding() -> None:
+    opener = _RecordedOpener()
+    client = EdgarClient(user_agent="Pension-Data research tim@stranskemo.com", opener=opener)
+
+    assert client._get("https://data.sec.gov/submissions/CIK0000919079.json") == '{"filings": {}}'
+    assert opener.request is not None
+    assert all(key.lower() != "accept-encoding" for key, _ in opener.request.header_items())
 
 
 def test_end_to_end_fixture_flow_produces_security_positions() -> None:

--- a/tests/ingest/test_edgar_flow.py
+++ b/tests/ingest/test_edgar_flow.py
@@ -143,7 +143,8 @@ def test_edgar_client_does_not_request_compressed_transfer_encoding() -> None:
 
     assert client._get("https://data.sec.gov/submissions/CIK0000919079.json") == '{"filings": {}}'
     assert opener.request is not None
-    assert all(key.lower() != "accept-encoding" for key, _ in opener.request.header_items())
+    headers = {key.lower(): value for key, value in opener.request.header_items()}
+    assert headers == {"user-agent": "Pension-Data research tim@stranskemo.com"}
 
 
 def test_end_to_end_fixture_flow_produces_security_positions() -> None:

--- a/tests/ingest/test_holdings_pipeline.py
+++ b/tests/ingest/test_holdings_pipeline.py
@@ -170,7 +170,16 @@ def test_ab2833_alts_marks_explicit_and_missing_fair_value_as_not_disclosed() ->
         ]
     )
 
-    explicit, missing_value = disclosures
+    explicit = next(
+        disclosure
+        for disclosure in disclosures
+        if disclosure.provenance_ref == "ab2833:explicit-withheld"
+    )
+    missing_value = next(
+        disclosure
+        for disclosure in disclosures
+        if disclosure.provenance_ref == "ab2833:value-omitted"
+    )
     assert explicit.disclosure_state == "not_disclosed"
     assert explicit.reported_fair_value_usd == 500_000.0
     assert explicit.total_fees_usd == 10_000.0

--- a/tests/ingest/test_holdings_pipeline.py
+++ b/tests/ingest/test_holdings_pipeline.py
@@ -145,6 +145,40 @@ def test_ab2833_alts_capture_feeds_total_plan_coverage() -> None:
     assert report.by_asset_class["fixed_income"] == 0.0
 
 
+def test_ab2833_alts_marks_explicit_and_missing_fair_value_as_not_disclosed() -> None:
+    disclosures = capture_ab2833_alt_disclosures(
+        [
+            Ab2833AltDisclosureInput(
+                fund_name="Explicitly withheld fund",
+                asset_class="private_equity",
+                reported_fair_value_usd=500_000.0,
+                management_fees_usd=4_000.0,
+                carried_interest_usd=6_000.0,
+                as_of="2025-06-30",
+                provenance_ref="ab2833:explicit-withheld",
+                explicit_not_disclosed=True,
+            ),
+            Ab2833AltDisclosureInput(
+                fund_name="Value omitted fund",
+                asset_class="real_assets",
+                reported_fair_value_usd=None,
+                management_fees_usd=7_000.0,
+                carried_interest_usd=None,
+                as_of="2025-06-30",
+                provenance_ref="ab2833:value-omitted",
+            ),
+        ]
+    )
+
+    explicit, missing_value = disclosures
+    assert explicit.disclosure_state == "not_disclosed"
+    assert explicit.reported_fair_value_usd == 500_000.0
+    assert explicit.total_fees_usd == 10_000.0
+    assert missing_value.disclosure_state == "not_disclosed"
+    assert missing_value.reported_fair_value_usd is None
+    assert missing_value.total_fees_usd == 7_000.0
+
+
 def test_holdings_overlap_view_runs_over_ingested_security_positions() -> None:
     # Two plans both disclose the same CUSIP -> the real overlap view must pair them.
     subject = build_security_positions(


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:647 -->
> **Source:** Issue #647

Closes #647

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
To analyze a specific plan's actual portfolio we need real holdings. No single SEC filing is complete — 13F is an **equity-only sleeve (~25-46% of a plan)**, so total-plan figures must be **CAFR-anchored**. The richest source is usually the plan's **own published holdings file** (CalSTRS gold standard). The repo's `manager_fund_positions` already models positions with a `disclosed/not_disclosed/known_not_invested` tri-state — extend it down to security level. (Parent: #642; pairs with #D.)

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#642](https://github.com/stranske/Pension-Data/issues/642)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add a security-level positions table/dataclass beneath `manager_fund_positions`: cusip/ticker, name, shares, market_value, asset_class, source, as_of, `disclosure_state`, provenance ref.
- [ ] **13F ingestion** via EDGAR `https://data.sec.gov/submissions/CIK{10-digit}.json` → latest `13F-HR` → parse the INFORMATION TABLE XML (User-Agent header required). Verify the target plan's CIK (e.g. CalPERS 0000919079, NY Common 0000810265, Texas TRS 0000796848) — confirm per plan, some outsource and barely file.
- [ ] **Own-holdings-file** loader (CSV/XLS) when the plan publishes one (primary source, highest coverage).
- [ ] **ACFR allocation** capture (authoritative total-plan asset-class weights) as the anchor; **AB 2833**-style fee/alts disclosure capture where available.
- [ ] **Reconciliation**: compute and store the coverage gap (Σ holdings market_value vs CAFR total assets) and label each analysis's scope (equity-sleeve vs total-plan).

#### Acceptance criteria
- [ ] For one target plan, the pipeline produces security-level equity positions (13F) + asset-class totals (CAFR), with provenance and as_of on every row.
- [ ] A coverage report states what % of total plan assets the collected holdings represent, by asset class.
- [ ] `holdings_overlap` runs against the real security-level data.

<!-- auto-status-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EDGAR data retrieval reliability by no longer requesting compressed transfer encodings, reducing unexpected compressed payloads.
  * Correctly marks AB 2833 alternative disclosures as “not disclosed” when explicitly undisclosed or when fair value is missing, while preserving provided fair value and continuing total-fee calculations.
* **Tests**
  * Added coverage to confirm EDGAR requests omit `Accept-Encoding`.
  * Added end-to-end validation for AB 2833 disclosure state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->