### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.16.2
+RUFF_VERSION=0.16.3
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ source_collection = [
 dev = [
     "pytest==9.1.1",
     "pytest-cov==7.1.0",
-    "ruff==0.16.2",
+    "ruff==0.16.3",
     "mypy==2.3.0",
     "black==26.5.1",
     # app behavior baseline kit (tests/baseline/) -- shared core + golden-master glue.

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -85,7 +85,7 @@ pyyaml==6.0.3
     # via
     #   app-baseline-kit
     #   pytest-regressions
-ruff==0.16.2
+ruff==0.16.3
     # via pension-data (pyproject.toml)
 six==1.17.0
     # via python-dateutil

--- a/requirements.lock
+++ b/requirements.lock
@@ -219,7 +219,7 @@ rpds-py==2026.6.3
     # via
     #   jsonschema
     #   referencing
-ruff==0.16.2
+ruff==0.16.3
     # via pension-data (pyproject.toml)
 six==1.17.0
     # via python-dateutil


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` and related generated dependency files to match the central version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 3 version updates:
  - ruff: ==0.16.2 -> ==0.16.3
  - requirements.lock:ruff: 0.16.2 -> ==0.16.3
  - requirements-dev.lock:ruff: 0.16.2 -> ==0.16.3

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`
**Settled source commit:** `770c226a9eeb22be1dc8e1e33511f8aacd5434a8`

<!-- sync-pr-delivery-record:v1 {"schema":"sync-pr-delivery-record/v1","durable_issue_url":"https://github.com/stranske/Workflows/issues/1836","plan_id":"dev-tool-02c0c6e3cd5f","generation":"02c0c6e3cd5f","repository":"stranske/Pension-Data","desired_tree_hash":"7dbe9e084eb96abb635c31dc54118f63988a4252","source_commit":"770c226a9eeb22be1dc8e1e33511f8aacd5434a8","lease_expires_at":"2026-08-16T19:28:24Z","predecessor_prs":[],"successor_prs":[]} -->